### PR TITLE
[WiP] Fixed boolean dropdown option elements with default of `true` not getting rendered properly.

### DIFF
--- a/src/components/WizardOptions/WizardOptions.js
+++ b/src/components/WizardOptions/WizardOptions.js
@@ -186,7 +186,6 @@ class WizardOptions extends Reflux.Component {
             <Dropdown
               options={field.options}
               onChange={(e) => this.handleOptionsFieldChange(e, field)}
-              placeholder={field.label + (field.required ? " *" : "")}
               value={this.state.destination_environment[field.name]}
             />
           </div>

--- a/src/stores/ConnectionsStore/ConnectionsStore.js
+++ b/src/stores/ConnectionsStore/ConnectionsStore.js
@@ -320,6 +320,7 @@ class ConnectionsStore extends Reflux.Store
         if (cloudData.properties[propName].default) {
           field.default = cloudData.properties[propName].default
         }
+        field.defaultValue = cloudData.properties[propName].default;
         switch (cloudData.properties[propName].type) {
           case "boolean":
             field.type = "dropdown"
@@ -328,7 +329,14 @@ class ConnectionsStore extends Reflux.Store
               {label: "Yes", value: "true"},
               {label: "No", value: "false"}
             ]
-            field.default = field.default && "true"
+            // NOTE: for the dropdown we want our defaults to be "Yes"/"No":
+            if (typeof field.default === "boolean" && field.default) {
+              field.default = {label: "Yes", value: "true"}
+              field.defaultValue = true
+            } else {
+              field.default = {label: "No", value: "false"}
+              field.defaultValue = false
+            }
             break
 
           case "string":
@@ -353,7 +361,6 @@ class ConnectionsStore extends Reflux.Store
             break
         }
 
-        field.defaultValue = cloudData.properties[propName].default;
         field.dataType = cloudData.properties[propName].type;
 
         if (field.name == 'username') {


### PR DESCRIPTION
The `field.default` field's value is the one which gets rendered as the initial text (so before the user gets the chance to make a selection) on a "Yes/No" dropdown, and it overrides any `placeholder` declared in the field's `render()` method.

For some reason, if `field.default` is `true`, the field text does not get rendered, as can be seen in this [screenshot of the current version](http://imgur.com/a/Y2wy5) vs [the new version](http://imgur.com/a/jYltI)  

Currently, when processing the fields we define a `default` field as well as the `defaultValue` (both being an alias to the actual default in the schema, as can be seen [here](https://github.com/cloudbase/coriolis-web/blob/master/src/stores/ConnectionsStore/ConnectionsStore.js#L321) and [here](https://github.com/cloudbase/coriolis-web/blob/master/src/stores/ConnectionsStore/ConnectionsStore.js#L356))

As mentioned, for dropdown elements, we have to set the `default` to what we want it to be.
Ideally, we should refactor the code to ONLY use `default` or `defaultValue`, as one is redundant in the current implementation.