### PR TITLE
Show 'Yes/No' as default values instead of 'true/false' for boolean fields CORWEB-68

### DIFF
--- a/src/components/LoginPage/LoginPage.js
+++ b/src/components/LoginPage/LoginPage.js
@@ -25,7 +25,7 @@ import UserStore from '../../stores/UserStore';
 import NotificationActions from '../../actions/NotificationActions';
 import LoadingIcon from '../LoadingIcon';
 import withViewport from '../withViewport.js';
-import {loginButtons} from '../../config.js';
+import { loginButtons } from '../../config.js';
 
 const title = 'Log In';
 const coriolisTextSvg = `
@@ -74,7 +74,6 @@ const footerLogoSvg = `
         </g>
     </g>
 </svg>`
-const origin = ""
 
 export class LoginPage extends Reflux.Component {
 

--- a/src/components/ReplicaList/ReplicaList.js
+++ b/src/components/ReplicaList/ReplicaList.js
@@ -111,7 +111,7 @@ class ReplicaList extends Reflux.Component {
     if (count == 0) {
       tasksRemaining = "-"
     }
-    
+
     return (
       <div className={"item " + (item.selected ? "selected" : "")} key={"replica_" + item.id}>
         <span className="cell cell-icon" onClick={(e) => this.replicaDetail(e, item)}>
@@ -129,7 +129,10 @@ class ReplicaList extends Reflux.Component {
         <span className={"cell " + s.composite} onClick={(e) => this.replicaDetail(e, item)}>
           <span className={s.label}>Last execution</span>
           <span className={s.value}>
-            {item.lastExecution ? <Moment format="MMM Do YYYY HH:mm" date={Helper.getTimeObject(item.lastExecution)} /> : "-"}
+            {
+              item.lastExecution ?
+                <Moment format="MMM Do YYYY HH:mm" date={Helper.getTimeObject(item.lastExecution)} /> : "-"
+            }
           </span>
         </span>
         <span className={"cell " + s.composite} onClick={(e) => this.replicaDetail(e, item)}>

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -63,12 +63,12 @@ class Table extends Component {
   }
 
   rowMouseDown(e) {
-    this.dragStartPosition = {x: e.screenX, y: e.screenY};
+    this.dragStartPosition = { x: e.screenX, y: e.screenY };
   }
 
   rowMouseUp(e, index) {
-    this.dragStartPosition = this.dragStartPosition || {x: e.screenX, y: e.screenY};
-   
+    this.dragStartPosition = this.dragStartPosition || { x: e.screenX, y: e.screenY };
+
     // If a drag operation has been initiated (i.e. text selection), don't call toggleDrawer
     if (Math.abs(this.dragStartPosition.x - e.screenX) < 3 && Math.abs(this.dragStartPosition.y - e.screenY) < 3) {
       this.toggleDrawer(index);

--- a/src/components/WizardNetworks/WizardNetworks.js
+++ b/src/components/WizardNetworks/WizardNetworks.js
@@ -105,7 +105,7 @@ class WizardNetworks extends Component {
     }
     if (props.data.targetNetworks && props.data.targetNetworks.length) {
       this.networkOptions = []
-      
+
       let targetNetworks = props.data.targetNetworks
       targetNetworks.sort((a, b) => a.name > b.name)
 

--- a/src/components/WizardOptions/WizardOptions.js
+++ b/src/components/WizardOptions/WizardOptions.js
@@ -124,7 +124,7 @@ class WizardOptions extends Reflux.Component {
   handleOptionsFieldChange(e, field) {
     let destinationEnvironment = this.state.destination_environment
     if (field.type == 'dropdown') {
-      destinationEnvironment[field.name] = e
+      destinationEnvironment[field.name] = e.value
     } else {
       destinationEnvironment[field.name] = e.target.value
     }
@@ -177,6 +177,12 @@ class WizardOptions extends Reflux.Component {
         )
         break;
       case "dropdown":
+        let value = this.state.destination_environment[field.name]
+
+        if (value) {
+          value = field.options && field.options.length && field.options.find(o => o.value === value).label
+        }
+
         returnValue = (
           <div
             className={"form-group " + extraClasses}
@@ -187,7 +193,7 @@ class WizardOptions extends Reflux.Component {
               options={field.options}
               onChange={(e) => this.handleOptionsFieldChange(e, field)}
               placeholder={field.label + (field.required ? " *" : "")}
-              value={this.state.destination_environment[field.name]}
+              value={value}
             />
           </div>
         )

--- a/src/stores/ConnectionsStore/ConnectionsStore.js
+++ b/src/stores/ConnectionsStore/ConnectionsStore.js
@@ -323,12 +323,14 @@ class ConnectionsStore extends Reflux.Store
         switch (cloudData.properties[propName].type) {
           case "boolean":
             field.type = "dropdown"
+
+            // Values need to be strings, due to a limitation in react-dropdown
             field.options = [
-              // Values need to be strings, due to a limitation in react-dropdown
-              {label: "Yes", value: "true"},
-              {label: "No", value: "false"}
+              {label: 'Yes', value: 'true'}, 
+              {label: 'No', value: 'false'}
             ]
-            field.default = field.default && "true"
+
+            field.default = (field.default === 'true' || field.default === true) ? 'true' : 'false'
             break
 
           case "string":

--- a/src/stores/MigrationStore/MigrationStore.js
+++ b/src/stores/MigrationStore/MigrationStore.js
@@ -96,7 +96,9 @@ class MigrationStore extends Reflux.Store
     })
 
     replicas.sort((a, b) => {
-      return moment(b.lastExecution || b.created_at).isAfter(moment(a.lastExecution || a.created_at))
+      let aTime = a.lastExecution || a.updated_at || a.created_at
+      let bTime = b.lastExecution || b.updated_at || b.created_at
+      return moment(bTime).diff(moment(aTime))
     })
 
     this.setState({


### PR DESCRIPTION
Also fixes an issue where changing a boolean field sends 'Yes/No' to the server instead of 'true/false'.

This uses the fact that the Dropdown's value is the label of the currently selected option. Ideally, the Dropdown should have a property called labelField (or something like that) that pulls the label from the 'options' property automatically. 