### PR TITLE
Switch to executions page if replica is currently executing CORWEB-19

### DIFF
--- a/src/components/MigrationList/MigrationList.js
+++ b/src/components/MigrationList/MigrationList.js
@@ -91,7 +91,11 @@ class MigrationList extends Reflux.Component {
   }
 
   migrationDetail(e, item) {
-    Location.push('/migration/' + item.id + "/")
+    if (item.status === 'RUNNING') {
+      Location.push('/migration/tasks/' + item.id + "/")
+    } else {
+      Location.push('/migration/' + item.id + "/")
+    }
   }
 
   renderItem(item) {

--- a/src/components/ReplicaList/ReplicaList.js
+++ b/src/components/ReplicaList/ReplicaList.js
@@ -90,7 +90,11 @@ class ReplicaList extends Reflux.Component {
   }
 
   replicaDetail(e, item) {
-    Location.push('/replica/' + item.id + "/")
+    if (item.status === 'RUNNING') {
+      Location.push('/replica/executions/' + item.id + "/")
+    } else {
+      Location.push('/replica/' + item.id + "/")
+    }
   }
 
   renderItem(item) {


### PR DESCRIPTION
Switch to tasks page if migration is currently executing. This happens when selecting a replica / migration from replicas / migrations list.
This happens when selecting a replica / migration from replicas / migrations list.