### PR TITLE
Fix execution selection after deletion CORWEB-66

### DIFF
--- a/src/components/ReplicaExecutions/ReplicaExecutions.js
+++ b/src/components/ReplicaExecutions/ReplicaExecutions.js
@@ -123,10 +123,12 @@ class ReplicaExecutions extends Component {
           let index = this.props.replica.executions.indexOf(this.state.executionRef)
 
           MigrationActions.deleteReplicaExecution(this.props.replica, this.state.executionRef.id, () => {
-            if (this.props.replica.executions[index - 1]) {
-              this.changeExecution(this.props.replica.executions[index - 1])
-            } else if (this.props.replica.executions[index + 1]) {
-              this.changeExecution(this.props.replica.executions[index + 1])
+            let executions = this.props.replica.executions
+
+            if (executions[index]) {
+              this.changeExecution(executions[index])
+            } else if (executions[index - 1]) {
+              this.changeExecution(executions[index - 1])
             } else {
               this.changeExecution(null)
             }


### PR DESCRIPTION
Select the next execution in line after an execution is deleted.
If it's the last execution that's deleted, select previous execution.