### PR TITLE
Add OPC storage auth and api endpoints

### DIFF
--- a/src/constants/CloudLabels.js
+++ b/src/constants/CloudLabels.js
@@ -25,6 +25,8 @@ export const defaultLabels = {
   identity_api_version: "Identity Version",
   identity_domain: "Identity Domain",
   auth_url: "Auth URL",
+  storage_api_endpoint: "Storage Api Endpoint",
+  storage_auth_endpoint: "Storage Authentication Endpoint",
   user_domain_name: "User Domain Name",
   project_name: "Project Name",
   project_domain_name: "Project Domain Name",


### PR DESCRIPTION
Adds labels for storage API and storage authe ednpoints. These are needed for all OPC accounts created after April 2017.