### PR TITLE
Fix Switch components not getting set with the default value the first time they render CORWEB-104

### DIFF
--- a/src/components/Switch/Switch.js
+++ b/src/components/Switch/Switch.js
@@ -37,6 +37,10 @@ class Switch extends Component {
     }
   }
 
+  componentWillReceiveProps(newProps) {
+    this.setState({ checked: newProps.checked })
+  }
+
   handleChange(e) {
     if (this.props.onChange) {
       this.props.onChange(e)

--- a/src/components/WizardOptions/WizardOptions.js
+++ b/src/components/WizardOptions/WizardOptions.js
@@ -203,7 +203,8 @@ class WizardOptions extends Reflux.Component {
               <InfoIcon text={Helper.getCloudFieldDescription(field.name)} />
             </div>
             <Switch
-              checked={this.state.destination_environment[field.name] === true}
+              checked={this.state.destination_environment[field.name] === true ||
+                this.state.destination_environment[field.name] === 'true'}
               onChange={(e) => this.handleOptionsFieldChange(e, field)}
               checkedLabel="Yes"
               uncheckedLabel="No"


### PR DESCRIPTION
Add support for 'string' boolean values in case the server sends the default boolean values as string.