### PR TITLE
Fix failing tests caused by a previous feature CORWEB-153

### DIFF
--- a/src/components/atoms/EndpointLogos/test.jsx
+++ b/src/components/atoms/EndpointLogos/test.jsx
@@ -21,5 +21,7 @@ const wrap = props => shallow(<EndpointLogos {...props} />).dive()
 it('passes down props', () => {
   let wrapper = wrap({ height: 32, endpoint: 'aws' })
   expect(wrapper.prop('height')).toBe(32)
-  expect(wrapper.children().prop('endpoint')).toBe('aws')
+  let imageInfo = wrapper.findWhere(w => w.name() === 'styled.div' && w.prop('imageInfo')).prop('imageInfo')
+  expect(imageInfo.h).toBe(32)
+  expect(imageInfo.image).toBe('file')
 })

--- a/src/components/organisms/WizardEndpointList/test.jsx
+++ b/src/components/organisms/WizardEndpointList/test.jsx
@@ -52,8 +52,7 @@ it('has providers with correct enpoints available', () => {
 
 it('renders add new', () => {
   let wrapper = wrap({ endpoints, providers })
-  expect(wrapper.find('Dropdown').at(2).prop('items').length).toBe(1)
-  expect(wrapper.find('Dropdown').at(2).prop('items')[0].id).toBe('addNew')
+  expect(wrapper.findWhere(w => w.name() === 'Button' && w.html().indexOf('Add') > -1).length).toBe(4)
 })
 
 it('renders loading', () => {
@@ -65,7 +64,6 @@ it('renders dropdown as primary if endpoint is selected', () => {
   let wrapper = wrap({ endpoints, providers, selectedEndpoint: { ...endpoints[1] } })
   expect(wrapper.find('Dropdown').at(1).prop('primary')).toBe(true)
   expect(wrapper.find('Dropdown').at(0).prop('primary')).toBe(false)
-  expect(wrapper.find('Dropdown').at(2).prop('primary')).toBe(false)
 })
 
 it('doesn\'t render endpoint if another endpoint is supplied', () => {


### PR DESCRIPTION
Tests previously checked whether Providers in the Wizard which had no
Endpoints, had `Add New...` dropdown item.
The tests should check whether Providers with no Endpoints have `Add`
button.