### PR TITLE
Preload wizard instances after choosing source

### DIFF
--- a/src/actions/InstanceActions.js
+++ b/src/actions/InstanceActions.js
@@ -21,18 +21,18 @@ import { wizardConfig } from '../config'
 class InstanceActions {
   loadInstances(endpointId) {
     InstanceSource.loadInstances(endpointId).then(
-      instances => { this.loadInstancesSuccess(instances) },
-      response => { this.loadInstancesFailed(response) },
+      instances => { this.loadInstancesSuccess(endpointId, instances) },
+      response => { this.loadInstancesFailed(endpointId, response) },
     )
-    return true
+    return endpointId
   }
 
-  loadInstancesSuccess(instances) {
-    return instances
+  loadInstancesSuccess(endpointId, instances) {
+    return { endpointId, instances }
   }
 
-  loadInstancesFailed(response) {
-    return response || true
+  loadInstancesFailed(endpointId, response) {
+    return { endpointId, response: response || true }
   }
 
   searchInstances(endpointId, searchText) {

--- a/src/components/pages/WizardPage/WizardPage.jsx
+++ b/src/components/pages/WizardPage/WizardPage.jsx
@@ -103,9 +103,6 @@ class WizardPage extends React.Component {
         ProviderActions.loadProviders()
         EndpointActions.getEndpoints()
         break
-      case 'vms':
-        InstanceActions.loadInstances(this.props.wizardStore.data.source.id)
-        break
       case 'options':
         ProviderActions.loadOptionsSchema(this.props.wizardStore.data.target.type, this.state.type)
         break
@@ -274,6 +271,8 @@ class WizardPage extends React.Component {
 
   handleSourceEndpointChange(source) {
     WizardActions.updateData({ source, selectedInstances: null, networks: null })
+    // Preload instances for 'vms' page
+    InstanceActions.loadInstances(source.id)
   }
 
   handleTargetEndpointChange(target) {

--- a/src/stores/InstanceStore.js
+++ b/src/stores/InstanceStore.js
@@ -76,12 +76,17 @@ class InstanceStore {
     })
   }
 
-  handleLoadInstances() {
+  handleLoadInstances(endpointId) {
+    this.endpointId = endpointId
     this.instancesLoading = true
     this.searchNotFound = false
   }
 
-  handleLoadInstancesSuccess(instances) {
+  handleLoadInstancesSuccess({ endpointId, instances }) {
+    if (endpointId !== this.endpointId) {
+      return
+    }
+
     this.currentPage = 1
     this.hasNextPage = InstanceStoreUtils.hasNextPage(instances)
     this.instances = instances
@@ -89,7 +94,11 @@ class InstanceStore {
     this.instancesLoading = false
   }
 
-  handleLoadInstancesFailed() {
+  handleLoadInstancesFailed({ endpointId }) {
+    if (endpointId !== this.endpointId) {
+      return
+    }
+
     this.instancesLoading = false
   }
 


### PR DESCRIPTION
Instead of loading the instances when the user reaches 'Select VMs'
page, load them after user chooses the 'Source' endpoint.

Advantage: The instances may already be loaded when reaching the 'Select
 VMs' page, thus decreasing the waiting time on the 'Loading' animation.
Disadvantage: The instances are requested from the server each time the
user changes the 'Source' endpoint.