### PR TITLE
Restore window scroll after modal redirects

### DIFF
--- a/src/components/pages/EndpointDetailsPage/EndpointDetailsPage.jsx
+++ b/src/components/pages/EndpointDetailsPage/EndpointDetailsPage.jsx
@@ -133,6 +133,7 @@ class EndpointDetailsPage extends React.Component {
   }
 
   handleDeleteEndpointConfirmation() {
+    this.setState({ showDeleteEndpointConfirmation: false })
     window.location.href = '/#/endpoints'
     EndpointActions.delete(this.getEndpoint())
   }

--- a/src/components/pages/MigrationDetailsPage/MigrationDetailsPage.jsx
+++ b/src/components/pages/MigrationDetailsPage/MigrationDetailsPage.jsx
@@ -102,6 +102,7 @@ class MigrationDetailsPage extends React.Component {
   }
 
   handleDeleteMigrationConfirmation() {
+    this.setState({ showDeleteMigrationConfirmation: false })
     window.location.href = '/#/migrations'
     MigrationActions.delete(this.props.migrationStore.migrationDetails.id)
   }

--- a/src/components/pages/ReplicaDetailsPage/ReplicaDetailsPage.jsx
+++ b/src/components/pages/ReplicaDetailsPage/ReplicaDetailsPage.jsx
@@ -152,6 +152,7 @@ class ReplicaDetailsPage extends React.Component {
   }
 
   handleDeleteReplicaConfirmation() {
+    this.setState({ showDeleteReplicaConfirmation: false })
     window.location.href = '/#/replicas'
     ReplicaActions.delete(this.props.replicaStore.replicaDetails.id)
   }


### PR DESCRIPTION
If a modal redirects to a new page, its 'unmount' function is not
called and so window scroll is not restored.