### PR TITLE
Use `network_name` to uniquely identify a NIC

### DIFF
--- a/src/components/organisms/WizardNetworks/WizardNetworks.jsx
+++ b/src/components/organisms/WizardNetworks/WizardNetworks.jsx
@@ -170,7 +170,7 @@ class WizardNetworks extends React.Component {
             }
             return false
           }).map(i => i.instance_name)
-          let selectedNetworkName = this.props.selectedNetworks && this.props.selectedNetworks.find(n => n.sourceNic.id === nic.id)
+          let selectedNetworkName = this.props.selectedNetworks && this.props.selectedNetworks.find(n => n.sourceNic.network_name === nic.network_name)
           if (selectedNetworkName) {
             selectedNetworkName = selectedNetworkName.targetNetwork.name
           }

--- a/src/components/organisms/WizardSummary/WizardSummary.jsx
+++ b/src/components/organisms/WizardSummary/WizardSummary.jsx
@@ -260,7 +260,7 @@ class WizardSummary extends React.Component {
         <Table>
           {data.networks.map(mapping => {
             return (
-              <Row key={mapping.sourceNic.id} direction="row">
+              <Row key={mapping.sourceNic.network_name} direction="row">
                 <SourceNetwork>{mapping.sourceNic.network_name}</SourceNetwork>
                 <NetworkArrow />
                 <TargetNetwork>{mapping.targetNetwork.name}</TargetNetwork>

--- a/src/stores/WizardStore.js
+++ b/src/stores/WizardStore.js
@@ -87,7 +87,7 @@ class WizardStore {
       this.data.networks = []
     }
 
-    this.data.networks = this.data.networks.filter(n => n.sourceNic.id !== sourceNic.id)
+    this.data.networks = this.data.networks.filter(n => n.sourceNic.network_name !== sourceNic.network_name)
     this.data.networks.push({ sourceNic, targetNetwork })
   }
 


### PR DESCRIPTION
Using NIC `id` may cause bugs since NIC ids are not unique.