### PR TITLE
Fix `Dropdown` list appearing behind modal CORWEB-161

### DIFF
--- a/src/components/molecules/Dropdown/Dropdown.jsx
+++ b/src/components/molecules/Dropdown/Dropdown.jsx
@@ -44,7 +44,7 @@ const List = styled.div`
   width: ${props => getWidth(props)}px;
   border: 1px solid ${Palette.grayscale[3]};
   border-radius: ${StyleProps.borderRadius};
-  z-index: 10;
+  z-index: 1000;
 `
 const ListItems = styled.div`
   max-height: 400px;


### PR DESCRIPTION
This makes the `Dropdown` unusable if there's a modal with a greater
z-index than the Dropdown's CORWEB-161