### PR TITLE
Remove an invalid CSS property

### DIFF
--- a/src/components/molecules/Modal/Modal.jsx
+++ b/src/components/molecules/Modal/Modal.jsx
@@ -25,7 +25,6 @@ const Title = styled.div`
   font-size: 24px;
   font-weight: ${StyleProps.fontWeights.light};
   background: ${Palette.grayscale[1]};
-  border-top-radius: ${StyleProps.borderRadius};
   text-align: center;
   line-height: 48px;
 `


### PR DESCRIPTION
VS Code now comes with styled components CSS 'linting', as a result it identified an invalid CSS property.