### PR TITLE
Fix execution sorting if there's only one replica

### DIFF
--- a/src/sources/ReplicaSource.js
+++ b/src/sources/ReplicaSource.js
@@ -36,6 +36,11 @@ class ReplicaSourceUtils {
   }
 
   static sortReplicas(replicas) {
+    if (replicas.length === 1) {
+      ReplicaSourceUtils.sortExecutions(replicas[0].executions)
+      return
+    }
+
     replicas.sort((a, b) => {
       ReplicaSourceUtils.sortExecutions(a.executions)
       ReplicaSourceUtils.sortExecutions(b.executions)


### PR DESCRIPTION
If there's only one replica in the replica list, execution sorting
would not trigger, thus replica may appear with `COMPLETED` status even
though the last execution was not successful.