### PR TITLE
Fix issue with dropdown list position

### DIFF
--- a/src/components/molecules/Dropdown/Dropdown.jsx
+++ b/src/components/molecules/Dropdown/Dropdown.jsx
@@ -119,6 +119,10 @@ class Dropdown extends React.Component {
     this.buttonRect = this.buttonRef.getBoundingClientRect()
   }
 
+  componentWillUpdate() {
+    this.buttonRect = this.buttonRef.getBoundingClientRect()
+  }
+
   componentDidUpdate() {
     this.updateListPosition()
   }


### PR DESCRIPTION
This fixes the case where a dropdown is opened while its button is
scrolled out of its original position.