### PR TITLE
Infinite spinner for invalid server response

### DIFF
--- a/src/utils/ApiCaller.js
+++ b/src/utils/ApiCaller.js
@@ -66,7 +66,11 @@ class ApiCaller {
         let data = null
 
         if (options.json !== false && request.responseText) {
-          data = JSON.parse(request.responseText)
+          try {
+            data = JSON.parse(request.responseText)
+          } catch (err) {
+            reject({ message: 'Invalid server response!' })
+          }
         } else if (request.responseText) {
           data = request.responseText
         }


### PR DESCRIPTION
To reproduce this issue remove CORIOLIS_URL env. variable or set it to
an invalid URL and try to login. The application would show an infinite
spinner instead of the error being handled.