### PR TITLE
Simplify webpack progress logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "url-loader": "^0.6.2",
     "webpack": "^3.6.0",
     "webpack-blocks-happypack": "^0.1.3",
-    "webpack-blocks-split-vendor": "^0.2.1",
-    "webpack-logging-plugin": "^0.1.2"
+    "webpack-blocks-split-vendor": "^0.2.1"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,7 @@ const path = require('path')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const splitVendor = require('webpack-blocks-split-vendor')
 const happypack = require('webpack-blocks-happypack')
-const WebpackLoggingPlugin = require('webpack-logging-plugin')
+const ProgressPlugin = require('webpack/lib/ProgressPlugin')
 
 const {
   addPlugins, createConfig, entryPoint, env, setOutput,
@@ -83,7 +83,7 @@ const config = createConfig([
       filename: 'index.html',
       template: path.join(process.cwd(), 'public/index.html'),
     }),
-    new WebpackLoggingPlugin(),
+    new ProgressPlugin(),
   ]),
   happypack([
     babel(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2656,10 +2656,6 @@ electron-to-chromium@^1.3.27:
   version "1.3.27"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz#78ecb8a399066187bb374eede35d9c70565a803d"
 
-elegant-spinner@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
-
 elliptic@^6.0.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.0.tgz#cac9af8762c85836187003c8dfe193e5e2eae5df"
@@ -7580,14 +7576,6 @@ webpack-hot-middleware@^2.20.0:
     html-entities "^1.2.0"
     querystring "^0.2.0"
     strip-ansi "^3.0.0"
-
-webpack-logging-plugin@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/webpack-logging-plugin/-/webpack-logging-plugin-0.1.2.tgz#6f7bcb93d3a01fac070d9e98b12ead30f2d46237"
-  dependencies:
-    chalk "^1.1.3"
-    elegant-spinner "^1.0.1"
-    lodash "^4.17.4"
 
 webpack-md5-hash@^0.0.5:
   version "0.0.5"


### PR DESCRIPTION
By using webpack's built-in progress plugin and removing the dependency
of external one.