### PR TITLE
Fix showing execution's status instead of ID

### DIFF
--- a/src/components/organisms/Executions/index.jsx
+++ b/src/components/organisms/Executions/index.jsx
@@ -236,10 +236,7 @@ class Executions extends React.Component<Props, State> {
         <ExecutionInfoId>
           ID:&nbsp;<CopyValue
             width="107px"
-            value={
-              // $FlowIssue
-              this.state.selectedExecution.status
-            }
+            value={this.state.selectedExecution ? this.state.selectedExecution.id : ''}
           />
         </ExecutionInfoId>
         {this.renderExecutionInfoButton()}


### PR DESCRIPTION
Fix an issue where execution's status is shown instead of execution's
ID.