### PR TITLE
Increase authorization token cookie expiration CORWEB-167

### DIFF
--- a/src/actions/UserActions.js
+++ b/src/actions/UserActions.js
@@ -21,6 +21,14 @@ import ProjectActions from './ProjectActions'
 import ProjectStore from '../stores/ProjectStore'
 import NotificationActions from './NotificationActions'
 
+/**
+ * This is the authentication / authorization flow:
+ * 1. Post username and password unscoped login. Set unscoped token in cookies.
+ * 2. Post unscoped token with project id. Set scoped token and project id in cookies.
+ * 3. Get token login on subsequent app reloads to retrieve the user info.
+ * 
+ * After token expiration, the app is redirected to login page.
+ */
 class UserActions {
   login(data) {
     UserSource.login(data).then(this.loginSuccess, this.loginFailed)

--- a/src/sources/UserSource.js
+++ b/src/sources/UserSource.js
@@ -58,7 +58,7 @@ class UserSource {
       }).then((response) => {
         let token = response.headers['X-Subject-Token'] || response.headers['x-subject-token']
         Api.setDefaultHeader('X-Auth-Token', token)
-        cookie.set('unscopedToken', token, { expires: 1 / 24 })
+        cookie.set('unscopedToken', token, { expires: 30 })
         resolve(response)
       }, reject).catch(reject)
     })
@@ -95,8 +95,8 @@ class UserSource {
         let token = response.headers['X-Subject-Token'] || response.headers['x-subject-token']
         let data = UserModel.parseUserData(response)
         data = { ...data, token }
-        cookie.set('token', data.token, { expires: 1 / 24 })
-        cookie.set('projectId', data.project.id, { expires: 1 * 30 })
+        cookie.set('token', data.token, { expires: 30 })
+        cookie.set('projectId', data.project.id, { expires: 30 })
         Api.setDefaultHeader('X-Auth-Token', data.token)
 
         resolve(data)


### PR DESCRIPTION
This, actually, doesn't do anything currently. It just means that if the
Keystone authorization token expiration time is increased, the UI client
will also stay authorized in that time.
Currently the Keystone token expires in 1 hour. The UI client can stay
authorized up to 30 days if the Keystone token expiration time is
increased.

This also includes a small code documentation of the UI authorization
process.