### PR TITLE
Fix replicas page polling issue in rare situation

### DIFF
--- a/src/components/pages/ReplicasPage/index.jsx
+++ b/src/components/pages/ReplicasPage/index.jsx
@@ -53,6 +53,7 @@ type State = {
 @observer
 class ReplicasPage extends React.Component<{}, State> {
   pollTimeout: TimeoutID
+  stopPolling: boolean
 
   constructor() {
     super()
@@ -70,11 +71,13 @@ class ReplicasPage extends React.Component<{}, State> {
     ProjectStore.getProjects()
     EndpointStore.getEndpoints()
 
+    this.stopPolling = false
     this.pollData()
   }
 
   componentWillUnmount() {
     clearTimeout(this.pollTimeout)
+    this.stopPolling = true
   }
 
   getEndpoint(endpointId: string) {
@@ -169,7 +172,7 @@ class ReplicasPage extends React.Component<{}, State> {
   }
 
   pollData() {
-    if (this.state.modalIsOpen) {
+    if (this.state.modalIsOpen || this.stopPolling) {
       return
     }
     ReplicaStore.getReplicas().then(() => {


### PR DESCRIPTION
Rarely, when the browser is redirected from replicas page (ie due to
token expiration), the replicas polling would continue in the
background.

This PR also contains a commit which adds polling to migrations list
page, which didn't have any polling at all being done in the 
background.