### PR TITLE
Fix 'Invalid date' label in notifications dropdown

### DIFF
--- a/src/components/molecules/NotificationDropdown/index.jsx
+++ b/src/components/molecules/NotificationDropdown/index.jsx
@@ -226,7 +226,7 @@ class NotificationDropdown extends React.Component<Props, State> {
               <Title>
                 <TypeIcon level={item.level} />
                 <TitleLabel>{title}</TitleLabel>
-                <Time>{moment(item.id).format('HH:mm')}</Time>
+                <Time>{moment(Number(item.id)).format('HH:mm')}</Time>
               </Title>
               <Description>{message}</Description>
             </ListItem>


### PR DESCRIPTION
Shown after creating a replica / migration.