### PR TITLE
Fix clearing endpoint fields while validating

### DIFF
--- a/src/components/organisms/Endpoint/index.jsx
+++ b/src/components/organisms/Endpoint/index.jsx
@@ -129,8 +129,8 @@ class Endpoint extends React.Component<Props, State> {
   closeTimeout: TimeoutID
   contentPluginRef: DefaultContentPlugin
   isValidateButtonEnabled: boolean
-  providerStoreObserver: any
-  endpointStoreObserver: any
+  providerStoreObserver: () => void
+  endpointValidationObserver: () => void
 
   constructor() {
     super()
@@ -149,7 +149,7 @@ class Endpoint extends React.Component<Props, State> {
     this.providerStoreObserver = observe(ProviderStore, 'connectionInfoSchema', () => {
       this.props.onResizeUpdate(this.scrollableRef)
     })
-    this.endpointStoreObserver = observe(EndpointStore, 'validation', () => {
+    this.endpointValidationObserver = observe(EndpointStore, 'validation', () => {
       this.componentWillReceiveProps(this.props)
     })
   }
@@ -192,7 +192,7 @@ class Endpoint extends React.Component<Props, State> {
     clearTimeout(this.closeTimeout)
     KeyboardManager.removeKeyDown('endpoint')
     this.providerStoreObserver()
-    this.endpointStoreObserver()
+    this.endpointValidationObserver()
   }
 
   getEndpointType() {
@@ -295,7 +295,7 @@ class Endpoint extends React.Component<Props, State> {
 
     EndpointStore.add(this.state.endpoint).then(() => {
       let endpoint = EndpointStore.endpoints[0]
-      this.setState({ isNew: false, endpoint })
+      this.setState({ isNew: false, endpoint: ObjectUtils.flatten(endpoint) })
       NotificationStore.notify('Validating endpoint ...')
       EndpointStore.validate(endpoint)
     })

--- a/src/utils/ObjectUtils.js
+++ b/src/utils/ObjectUtils.js
@@ -12,8 +12,10 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+// @flow
+
 class ObjectUtils {
-  static flatten(object) {
+  static flatten(object: any): any {
     let result = {}
 
     Object.keys(object).forEach(k => {
@@ -33,7 +35,7 @@ class ObjectUtils {
     return result
   }
 
-  static skipField(object, fieldName) {
+  static skipField(object: any, fieldName: string) {
     let result = {}
 
     if (Object.keys(object).length === 0) {


### PR DESCRIPTION
When creating a new endpoint, the input fields would be temporarily
cleared while the endpoint was validating.