### PR TITLE
Use network id instead of network name

### DIFF
--- a/src/sources/WizardSource.js
+++ b/src/sources/WizardSource.js
@@ -36,7 +36,7 @@ class WizardSourceUtils {
     env.network_map = {}
     if (data.networks && data.networks.length) {
       data.networks.forEach(mapping => {
-        env.network_map[mapping.sourceNic.network_name] = mapping.targetNetwork.name
+        env.network_map[mapping.sourceNic.network_name] = mapping.targetNetwork.id
       })
     }
 


### PR DESCRIPTION
Used when creating the network map for a replica / migration in the
wizard.

This is based on a discussion with @gabriel-samfira and @aznashwan 