### PR TITLE
Fix ignoring daylight saving time

### DIFF
--- a/src/components/molecules/DatetimePicker/index.jsx
+++ b/src/components/molecules/DatetimePicker/index.jsx
@@ -58,7 +58,7 @@ type Props = {
 }
 type State = {
   showPicker: boolean,
-  date: ?Date,
+  date: ?moment$Moment,
 }
 class DatetimePicker extends React.Component<Props, State> {
   itemMouseDown: boolean
@@ -76,7 +76,9 @@ class DatetimePicker extends React.Component<Props, State> {
   }
 
   componentWillMount() {
-    this.setState({ date: this.props.value })
+    if (this.props.value) {
+      this.setState({ date: moment(this.props.value) })
+    }
   }
 
   componentDidMount() {
@@ -100,7 +102,7 @@ class DatetimePicker extends React.Component<Props, State> {
 
     if (!this.itemMouseDown && !path.find(n => n.className === 'rdtPicker')) {
       if (this.state.date && this.state.showPicker) {
-        this.props.onChange(this.state.date)
+        this.props.onChange(this.state.date.toDate())
       }
       this.setState({ showPicker: false })
     }
@@ -108,15 +110,16 @@ class DatetimePicker extends React.Component<Props, State> {
 
   handleDropdownClick() {
     if (this.state.showPicker && this.state.date) {
-      this.props.onChange(this.state.date)
+      this.props.onChange(this.state.date.toDate())
     }
 
     this.setState({ showPicker: !this.state.showPicker })
   }
 
-  handleChange(date: Date) {
+  handleChange(newDate: Date) {
+    let date = moment(newDate)
     if (this.props.timezone === 'utc') {
-      date = DateUtils.getLocalTime(date)
+      date = DateUtils.getLocalTime(newDate)
     }
 
     this.setState({ date })

--- a/src/components/molecules/ScheduleItem/index.jsx
+++ b/src/components/molecules/ScheduleItem/index.jsx
@@ -118,10 +118,8 @@ class ScheduleItem extends React.Component<Props> {
     if (zeroBasedIndex) {
       let value = this.props.item.schedule[fieldName]
 
-      if (fieldName === 'hour') {
-        if (this.props.timezone === 'local') {
-          value = DateUtils.getLocalHour(value)
-        }
+      if (fieldName === 'hour' && this.props.timezone === 'local') {
+        value = DateUtils.getLocalHour(value)
       }
 
       return items[value + 1]
@@ -304,12 +302,12 @@ class ScheduleItem extends React.Component<Props> {
 
   renderExpirationValue() {
     let date = this.props.item.expiration_date && moment(this.props.item.expiration_date)
-    let labelDate = date
-    if (this.props.timezone === 'utc' && date) {
-      labelDate = DateUtils.getUtcTime(date)
-    }
 
     if (this.props.item.enabled) {
+      let labelDate = date
+      if (this.props.timezone === 'utc' && date) {
+        labelDate = DateUtils.getUtcTime(date)
+      }
       return this.renderLabel({ label: (labelDate && labelDate.format('DD/MM/YYYY hh:mm A')) || '-' })
     }
 

--- a/src/types/Execution.js
+++ b/src/types/Execution.js
@@ -21,5 +21,6 @@ export type Execution = {
   number: number,
   status: string,
   created_at: Date,
+  updated_at: Date,
   tasks: Task[],
 }

--- a/src/types/MainItem.js
+++ b/src/types/MainItem.js
@@ -45,6 +45,7 @@ export type MainItem = {
   status: string,
   tasks: Task[],
   created_at: Date,
+  updated_at: Date,
   origin_endpoint_id: string,
   destination_endpoint_id: string,
   instances: string[],

--- a/src/types/Task.js
+++ b/src/types/Task.js
@@ -23,6 +23,7 @@ export type Task = {
   id: string,
   status: string,
   created_at: Date,
+  updated_at: Date,
   progress_updates: ProgressUpdate[],
   task_type: string,
   instance: string,

--- a/src/utils/DateUtils.js
+++ b/src/utils/DateUtils.js
@@ -12,31 +12,28 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+// @flow
+
 import moment from 'moment'
 
 class DateUtils {
-  static getLocalTime(rawDate) {
-    let offset = (new Date().getTimezoneOffset() / 60) * -1
-
-    return moment(rawDate).add(offset, 'hours')
+  static getLocalTime(rawDate: ?Date | ?moment$Moment): moment$Moment {
+    return moment(rawDate).add(-new Date().getTimezoneOffset(), 'minutes')
   }
 
-  static getUtcTime(rawDate) {
-    let offset = (new Date().getTimezoneOffset() / 60)
-    return moment(rawDate).add(offset, 'hours')
+  static getUtcTime(rawDate: ?Date | ?moment$Moment): moment$Moment {
+    return moment(rawDate).add(new Date().getTimezoneOffset(), 'minutes')
   }
 
-  static getLocalHour(hour) {
-    let hourDate = new Date(2017, 0, 1, hour)
-    return moment(hourDate).add(-hourDate.getTimezoneOffset(), 'minutes').get('hours')
+  static getLocalHour(hour: number): number {
+    return moment('00', 'HH').add(-new Date().getTimezoneOffset(), 'minutes').add(hour, 'hours').get('hours')
   }
 
-  static getUtcHour(hour) {
-    let hourDate = new Date(2017, 0, 1, hour)
-    return moment(hourDate).add(hourDate.getTimezoneOffset(), 'minutes').get('hours')
+  static getUtcHour(hour: number): number {
+    return moment('00', 'HH').add(new Date().getTimezoneOffset(), 'minutes').add(hour, 'hours').get('hours')
   }
 
-  static getOrdinalDay(number) {
+  static getOrdinalDay(number: number) {
     switch (number) {
       case 1:
       case 21:


### PR DESCRIPTION
Fixes an issue where daylight saving time may be ignored in some cases
when converting from UTC to local time due to not using the current year
when retrieving the timezone offset.