### PR TITLE
Fix not using bold for `any` in schedule dropdowns

### DIFF
--- a/src/components/molecules/ScheduleItem/index.jsx
+++ b/src/components/molecules/ScheduleItem/index.jsx
@@ -164,7 +164,7 @@ class ScheduleItem extends React.Component<Props> {
       return false
     }
     let data = isRootField ? unsavedSchedule : unsavedSchedule.schedule
-    if (data && data[fieldName] !== undefined && data[fieldName] !== null) {
+    if (data && data[fieldName] !== undefined) {
       return true
     }
     return false

--- a/src/components/organisms/Schedule/index.jsx
+++ b/src/components/organisms/Schedule/index.jsx
@@ -133,10 +133,6 @@ class Schedule extends React.Component<Props, State> {
     unsavedSchedules: [],
   }
 
-  static defaultProps = {
-    unsavedSchedules: [],
-  }
-
   constructor() {
     super()
 


### PR DESCRIPTION
If a dropdown's value is changed to `any` it should have it's value
rendered in bold, just like all the other values, to indicate it is
changed.