### PR TITLE
Fix an infinite loop when having expired token

### DIFF
--- a/src/sources/UserSource.js
+++ b/src/sources/UserSource.js
@@ -134,7 +134,6 @@ class UserSource {
         resolve(data)
       }).catch(() => {
         cookie.remove('token')
-        cookie.remove('projectId')
         Api.setDefaultHeader('X-Auth-Token', null)
         reject()
       })

--- a/src/utils/ApiCaller.js
+++ b/src/utils/ApiCaller.js
@@ -94,7 +94,7 @@ class ApiCaller {
           }
 
           if (error.response.status === 401 && window.location.hash !== loginUrl) {
-            window.location.href = `/${loginUrl}`
+            window.location.href = '/'
           }
 
           console.log(`%cError Response: ${axiosOptions.url}`, 'color: #D0021B', error.response)


### PR DESCRIPTION
Occasionally, after an authorisation token expires, the app would keep
looping between the login page and the previous page spamming the user
with 'Unauthorised' notifications.
This commit also fixes the project being reset after an unauthorised API
call.