### PR TITLE
Wait for details page API response

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -9,5 +9,6 @@
   "viewportWidth": 1280,
   "viewportHeight": 900,
   "defaultCommandTimeout": 7000,
-  "execTimeout": 90000
+  "execTimeout": 90000,
+  "requestTimeout": 20000
 }

--- a/private/cypress/integration/migration/3 - Create VmWare Openstack Migration.js
+++ b/private/cypress/integration/migration/3 - Create VmWare Openstack Migration.js
@@ -47,8 +47,7 @@ describe('Create VmWare to Openstack Migration', () => {
   it('Fills Openstack migration info', () => {
     cy.get('button').contains('Next').click()
     cy.get('div').contains('Advanced').click()
-    // cy.get('input[placeholder="Floating IP Pool"]').type(config.wizard.openstack.floatingIpPool)
-    // cy.get('input[placeholder="Migration Floating IP Pool"]').type(config.wizard.openstack.migrationFloatingIpPool)
+    cy.get('input[placeholder="Description"]').type('VmWare Openstack Migration')
   })
 
   it('Selects first available network mapping', () => {
@@ -61,7 +60,6 @@ describe('Create VmWare to Openstack Migration', () => {
     cy.get('button').contains('Next').should('be.disabled')
     cy.get('div[data-test-id="networkItem"]').its('length').should('be.gt', 0)
     cy.get('div[value="Select ..."]').first().click()
-    // cy.get('div[data-test-id="dropdownListItem"]').first().click()
     cy.get('div[data-test-id="dropdownListItem"]').contains(config.wizard.openstack.network).click()
     cy.get('button').contains('Next').should('not.be.disabled')
   })
@@ -73,8 +71,7 @@ describe('Create VmWare to Openstack Migration', () => {
     cy.get('#app').should('contain', 'e2e-openstack-test')
     cy.get('#app').should('contain', 'Coriolis Migration')
     cy.get('#app').should('contain', 'Migration Options')
-    // cy.get('#app').should('contain', config.wizard.openstack.migrationFloatingIpPool)
-    // cy.get('#app').should('contain', config.wizard.openstack.floatingIpPool)
+    cy.get('#app').should('contain', 'VmWare Openstack Migration')
     cy.get('#app').should('contain', 'Networks')
     cy.get('#app').should('contain', 'Instances')
   })

--- a/private/cypress/integration/replica/4 - Cancel first running replica.js
+++ b/private/cypress/integration/replica/4 - Cancel first running replica.js
@@ -11,9 +11,11 @@ describe('Cancel a running replica', () => {
   })
 
   it('Cancels replica execution', () => {
-    cy.get('div[data-test-id="statusPill-RUNNING"]').eq(0).click()
-    cy.get('a').contains('Executions').click()
     cy.server()
+    cy.route({ url: '**/executions/detail', method: 'GET' }).as('execution')
+    cy.get('div[data-test-id="statusPill-RUNNING"]').eq(0).click()
+    cy.wait('@execution')
+    cy.get('a').contains('Executions').click()
     cy.get('button').contains('Cancel Execution').click()
     cy.route({ url: '**/actions', method: 'POST' }).as('cancel')
     cy.get('button').contains('Yes').click()

--- a/private/cypress/integration/scheduler/Scheduler Operations.js
+++ b/private/cypress/integration/scheduler/Scheduler Operations.js
@@ -11,7 +11,10 @@ describe('Scheduler Operations', () => {
   })
 
   it('Goes to scheduler\'s page', () => {
+    cy.server()
+    cy.route('GET', '**/executions/detail').as('execution')
     cy.get('div[data-test-id="mainListItem"]').first().click()
+    cy.wait('@execution')
     cy.get('a').contains('Schedule').click()
     cy.get('button').should('contain', 'Add Schedule')
   })


### PR DESCRIPTION
Wait for details page API response before clicking the Executions list
so that the executions page is not in 'Loading' state.

Also increased the timeout for an API call to be made, from 5 sec to 20
sec. The timeout for an API call response remains 30 sec.