### PR TITLE
Refresh new endpoints in replicas/migrations page

### DIFF
--- a/src/components/pages/MigrationsPage/index.jsx
+++ b/src/components/pages/MigrationsPage/index.jsx
@@ -205,7 +205,8 @@ class MigrationsPage extends React.Component<{}, State> {
     if (this.state.modalIsOpen || this.stopPolling) {
       return
     }
-    MigrationStore.getMigrations().then(() => {
+
+    Promise.all([MigrationStore.getMigrations(), EndpointStore.getEndpoints()]).then(() => {
       this.pollTimeout = setTimeout(() => { this.pollData() }, requestPollTimeout)
     })
   }

--- a/src/components/pages/ReplicasPage/index.jsx
+++ b/src/components/pages/ReplicasPage/index.jsx
@@ -166,7 +166,8 @@ class ReplicasPage extends React.Component<{}, State> {
     if (this.state.modalIsOpen || this.stopPolling) {
       return
     }
-    ReplicaStore.getReplicas().then(() => {
+
+    Promise.all([ReplicaStore.getReplicas(), EndpointStore.getEndpoints()]).then(() => {
       this.pollTimeout = setTimeout(() => { this.pollData() }, requestPollTimeout)
     })
   }


### PR DESCRIPTION
If, while having replicas / migrations page opened, a new replica /
migration is created somewhere with new endpoints, the opened page would
display the created replica / migration, but it wouldn't display the new
endpoints' logo.
To solve this, the endpoints are also polled when polling replicas /
migrations.