### PR TITLE
Fix list loading animation if list is empty

### DIFF
--- a/src/stores/MigrationStore.js
+++ b/src/stores/MigrationStore.js
@@ -28,8 +28,10 @@ class MigrationStore {
   @observable canceling: boolean | { failed: boolean } = true
   @observable detailsLoading: boolean = true
 
+  migrationsLoaded: boolean = false
+
   @action getMigrations(options?: { showLoading: boolean }) {
-    if ((options && options.showLoading) || this.migrations.length === 0) {
+    if ((options && options.showLoading) || !this.migrationsLoaded) {
       this.loading = true
     }
 
@@ -43,6 +45,7 @@ class MigrationStore {
         return migration
       })
       this.loading = false
+      this.migrationsLoaded = true
     }).catch(() => {
       this.loading = false
     })

--- a/src/stores/ReplicaStore.js
+++ b/src/stores/ReplicaStore.js
@@ -45,10 +45,12 @@ class ReplicaStore {
   @observable backgroundLoading: boolean = false
   @observable detailsLoading: boolean = true
 
+  replicasLoaded: boolean = false
+
   @action getReplicas(options?: { showLoading: boolean }): Promise<void> {
     this.backgroundLoading = true
 
-    if ((options && options.showLoading) || this.replicas.length === 0) {
+    if ((options && options.showLoading) || !this.replicasLoaded) {
       this.loading = true
     }
 
@@ -56,6 +58,7 @@ class ReplicaStore {
       this.replicas = replicas
       this.loading = false
       this.backgroundLoading = false
+      this.replicasLoaded = true
     }).catch(() => {
       this.loading = false
       this.backgroundLoading = false


### PR DESCRIPTION
Fixes an issue where the replicas/migrations list loading animation is
displayed each time data is polled from the server. This issue is
reproducible only if the replicas/migrations list is empty.