### PR TITLE
Fix list pos. if window is horizontally scrolled

### DIFF
--- a/src/components/molecules/DatetimePicker/index.jsx
+++ b/src/components/molecules/DatetimePicker/index.jsx
@@ -114,7 +114,7 @@ class DatetimePicker extends React.Component<Props, State> {
     }
 
     this.portalRef.style.top = `${topOffset + window.pageYOffset}px`
-    this.portalRef.style.left = `${leftOffset}px`
+    this.portalRef.style.left = `${leftOffset + window.pageXOffset}px`
   }
 
   isValidDate(currentDate: Date, selectedDate: Date): boolean {

--- a/src/components/molecules/Dropdown/index.jsx
+++ b/src/components/molecules/Dropdown/index.jsx
@@ -233,7 +233,7 @@ class Dropdown extends React.Component<Props, State> {
     }
 
     this.listRef.style.top = `${listTop + (window.pageYOffset || scrollOffset)}px`
-    this.listRef.style.left = `${this.buttonRect.left}px`
+    this.listRef.style.left = `${this.buttonRect.left + window.pageXOffset}px`
   }
 
   renderList() {


### PR DESCRIPTION
Fixes the `Dropdown` and `DateTimePicker` list positioning if window is
horizontally scrolled.