### PR TITLE
Stop Cypress if a test failed

### DIFF
--- a/private/cypress/support/index.js
+++ b/private/cypress/support/index.js
@@ -1,2 +1,6 @@
 // @flow
+
 import './commands'
+
+/* eslint func-names: off */
+afterEach(function () { if (this.currentTest.state === 'failed') { Cypress.runner.stop() } })


### PR DESCRIPTION
Some tests depend on previous tests (i.e. creating a replica / migration
depends on creating the 2 endpoints), so it is safer to stop all the
tests after the failed one.