### PR TITLE
Don't repeat the same error notifications

### DIFF
--- a/src/stores/NotificationStore.js
+++ b/src/stores/NotificationStore.js
@@ -23,8 +23,17 @@ class NotificationStore {
   @observable notifications: NotificationItem[] = []
   @observable persistedNotifications: NotificationItem[] = []
 
+  visibleErrors: string[] = []
+
   @action notify(message: string, level?: $PropertyType<NotificationItem, 'level'>, options?: $PropertyType<NotificationItem, 'options'>): Promise<void> {
-    this.notifications.push({ message, level, options })
+    if (!this.visibleErrors.find(e => e === message)) {
+      this.notifications.push({ message, level, options })
+
+      if (level === 'error') {
+        this.visibleErrors.push(message)
+        setTimeout(() => { this.visibleErrors = this.visibleErrors.filter(e => e !== message) }, 10000)
+      }
+    }
 
     if (options && options.persist) {
       return NotificationSource.notify(message, level, options).then((notification: NotificationItem) => {


### PR DESCRIPTION
Fixes an issue where if the same error is triggered multiple times, for
each error a notification is shown. Only new errors should be visible.
If the repeated error notification fades away, it can reappear again as
soon as it is triggered.