### PR TITLE
Fix `DateTimePicker` event if date not changed

### DIFF
--- a/src/components/molecules/DatetimePicker/index.jsx
+++ b/src/components/molecules/DatetimePicker/index.jsx
@@ -129,18 +129,13 @@ class DatetimePicker extends React.Component<Props, State> {
     let path = DomUtils.getEventPath(e)
 
     if (!this.itemMouseDown && !path.find(n => n.className === 'rdtPicker')) {
-      if (this.state.date && this.state.showPicker) {
-        this.props.onChange(this.state.date.toDate())
-      }
+      this.dispatchChange()
       this.setState({ showPicker: false })
     }
   }
 
   handleDropdownClick() {
-    if (this.state.showPicker && this.state.date) {
-      this.props.onChange(this.state.date.toDate())
-    }
-
+    this.dispatchChange()
     this.setState({ showPicker: !this.state.showPicker })
   }
 
@@ -151,6 +146,16 @@ class DatetimePicker extends React.Component<Props, State> {
     }
 
     this.setState({ date })
+  }
+
+  dispatchChange() {
+    if (
+      this.state.date
+      && this.state.showPicker
+      && this.state.date.toDate().getTime() !== (this.props.value && this.props.value.getTime())
+    ) {
+      this.props.onChange(this.state.date.toDate())
+    }
   }
 
   renderDateTimePicker(timezoneDate: ?moment$Moment) {


### PR DESCRIPTION
Fixes an issue where the `DateTimePicker` component dispatches the
`change` event even if it is not actually changed.
For example, opening and closing the `DateTimePicker` in the scheduler
causes the 'Expiration Date' field to be bold.