### PR TITLE
Fix `yarn build` fail

### DIFF
--- a/src/components/atoms/CopyMultilineValue/index.jsx
+++ b/src/components/atoms/CopyMultilineValue/index.jsx
@@ -54,7 +54,7 @@ class CopyMultineValue extends React.Component<Props> {
     return (
       <Wrapper
         onClick={() => { this.handleCopy() }}
-        data-test-id={this.props['data-test-id'] || 'copyMultilineValue'}
+        data-test-id={(this.props && this.props['data-test-id']) || 'copyMultilineValue'}
       >
         {this.props.value}
         <CopyButton />

--- a/src/components/organisms/MainDetails/index.jsx
+++ b/src/components/organisms/MainDetails/index.jsx
@@ -44,7 +44,6 @@ const ColumnsLayout = styled.div`
 `
 const Column = styled.div`
   ${props => StyleProps.exactWidth(props.width)}
-  /* width: ${props => props.width}; */
 `
 const Arrow = styled.div`
   width: 34px;


### PR DESCRIPTION
Most likely caused by the `styled-components` module trying to set the
style using `data-test-id` prop. If `data-test-id` is null,
`styled-components` fails to set the component up.