### PR TITLE
Reverse progress updates sorting

### DIFF
--- a/src/components/molecules/TaskItem/index.jsx
+++ b/src/components/molecules/TaskItem/index.jsx
@@ -144,7 +144,7 @@ class TaskItem extends React.Component<Props> {
   getLastMessage() {
     let message
     if (this.props.item.progress_updates.length) {
-      message = this.props.item.progress_updates[0].message
+      message = this.props.item.progress_updates[this.props.item.progress_updates.length - 1].message
     } else {
       message = '-'
     }

--- a/src/sources/MigrationSource.js
+++ b/src/sources/MigrationSource.js
@@ -33,7 +33,7 @@ class MigrationSourceUtils {
             if (sortNull !== false) {
               return sortNull
             }
-            return moment(a.created_at).isBefore(moment(b.created_at))
+            return moment(b.created_at).isBefore(moment(a.created_at))
           })
         }
       })

--- a/src/sources/ReplicaSource.js
+++ b/src/sources/ReplicaSource.js
@@ -76,7 +76,7 @@ class ReplicaSourceUtils {
     if (execution.tasks) {
       execution.tasks.forEach(task => {
         if (task.progress_updates) {
-          task.progress_updates.sort((a, b) => moment(a.created_at).isBefore(moment(b.created_at)))
+          task.progress_updates.sort((a, b) => moment(b.created_at).isBefore(moment(a.created_at)))
         }
       })
     }


### PR DESCRIPTION
The first progress update should also be the first one in the list,
mimicking an actual console output.