### PR TITLE
Fix `Enter` key ignore in some confirmation modals

### DIFF
--- a/src/components/organisms/AlertModal/index.jsx
+++ b/src/components/organisms/AlertModal/index.jsx
@@ -74,7 +74,7 @@ class AlertModal extends React.Component<Props> {
   id: string
 
   componentDidMount() {
-    this.id = new Date().getTime().toString()
+    this.id = `${new Date().getTime().toString()}-${Math.random()}`
     KeyboardManager.onEnter(`alert-${this.id}`, () => {
       if (this.props.isOpen) {
         this.props.onConfirmation()


### PR DESCRIPTION
Sometimes pressing `Enter` would not confirm in a confirmation modal
(ex.: trying to delete replica's disks).
This was caused by the fact that the same id was generated for all
modals in a page, if they were created at exactly the same time.