### PR TITLE
Add 2 more fields to Openstack API v3 simple form

### DIFF
--- a/src/plugins/endpoint/openstack/ContentPlugin.jsx
+++ b/src/plugins/endpoint/openstack/ContentPlugin.jsx
@@ -21,7 +21,7 @@ import ToggleButtonBar from '../../../components/atoms/ToggleButtonBar'
 import type { Field } from '../../../types/Field'
 import { Wrapper, Fields, FieldStyled, Row } from '../default/ContentPlugin'
 
-const ToggleButtonBarStyled = styled(ToggleButtonBar)`
+const ToggleButtonBarStyled = styled(ToggleButtonBar) `
   margin-top: 16px;
 `
 
@@ -88,18 +88,18 @@ class ContentPlugin extends React.Component<Props, State> {
 
   filterSimpleAdvanced(): Field[] {
     const apiVersion = this.props.getFieldValue(this.props.connectionInfoSchema.find(n => n.name === 'identity_api_version'))
-    const extraAdvancedFields = ['description', 'glance_api_version', 'identity_api_version']
+    const extraAdvancedFields = ['description']
     return this.props.connectionInfoSchema.filter(field => {
       if (this.state.useAdvancedOptions) {
         return true
       }
-      let required
-      if (typeof field.required === 'function') {
-        required = field.required(apiVersion)
+      let isBasic
+      if (typeof field.isBasic === 'function') {
+        isBasic = field.isBasic(apiVersion)
       } else {
-        required = field.required
+        isBasic = field.isBasic
       }
-      return required || extraAdvancedFields.find(fieldName => field.name === fieldName)
+      return field.required || isBasic || extraAdvancedFields.find(fieldName => field.name === fieldName)
     })
   }
 

--- a/src/plugins/endpoint/openstack/SchemaPlugin.js
+++ b/src/plugins/endpoint/openstack/SchemaPlugin.js
@@ -30,7 +30,9 @@ const customSort = (fields: Field[]) => {
     glance_api_version: 7,
     identity_api_version: 8,
     project_domain_name: 9,
-    user_domain_name: 10,
+    project_domain_id: 10,
+    user_domain_name: 11,
+    user_domain_id: 12,
   }
   fields.sort((a, b) => {
     if (sortPriority[a.name] && sortPriority[b.name]) {
@@ -58,11 +60,26 @@ export default class ConnectionSchemaParser {
     customSort(fields)
 
     let projectDomainField = fields.find(f => f.name === 'project_domain_name')
+    let projectDomainIdField = fields.find(f => f.name === 'project_domain_id')
     let userDomainField = fields.find(f => f.name === 'user_domain_name')
-    let requiredFunc = (apiVersion: number) => apiVersion > 2
-    if (projectDomainField && userDomainField) {
-      projectDomainField.required = requiredFunc
-      userDomainField.required = requiredFunc
+    let userDomainIdField = fields.find(f => f.name === 'user_domain_id')
+    let glanceApiVersionField = fields.find(f => f.name === 'glance_api_version')
+    let identityApiVersionField = fields.find(f => f.name === 'identity_api_version')
+    let isBasicFunc = (apiVersion: number) => apiVersion > 2
+    if (
+      projectDomainField &&
+      userDomainField &&
+      glanceApiVersionField &&
+      identityApiVersionField &&
+      userDomainIdField &&
+      projectDomainIdField
+    ) {
+      projectDomainField.isBasic = isBasicFunc
+      projectDomainIdField.isBasic = isBasicFunc
+      userDomainField.isBasic = isBasicFunc
+      userDomainIdField.isBasic = isBasicFunc
+      glanceApiVersionField.isBasic = true
+      glanceApiVersionField.isBasic = true
     }
 
     return fields

--- a/src/types/Field.js
+++ b/src/types/Field.js
@@ -19,7 +19,7 @@ export type Field = {
   type?: string,
   value?: any,
   enum?: string[],
-  required?: boolean | (value: any) => boolean,
+  required?: boolean,
   default?: any,
   items?: Field[],
   fields?: Field[],
@@ -27,4 +27,5 @@ export type Field = {
   maximum?: number,
   parent?: string,
   properties?: Field[],
+  isBasic?: boolean | (value: any) => boolean, // show this field in simple view even if is not 'required'
 }


### PR DESCRIPTION
This is an intermediate PR to quickly solve the issue of not displaying
the fields in the 'Simple' form when v3 API is selected when creating an
Openstack endpoint.