### PR TITLE
Browsers autofill passwords in endpoint popup

### DIFF
--- a/src/components/organisms/Endpoint/index.jsx
+++ b/src/components/organisms/Endpoint/index.jsx
@@ -394,6 +394,11 @@ class Endpoint extends React.Component<Props, State> {
         {this.renderButtons()}
         <Tooltip />
         {Tooltip.rebuild()}
+        {/* Fix browsers autofilling password fields */}
+        <div style={{ position: 'absolute', left: '-10000px' }}>
+          <input type="text" />
+          <input type="password" />
+        </div>
       </Content>
     )
   }


### PR DESCRIPTION
This issue may cause unexpected behaviour when creating or editing an
endpoint.
To fix it, 2 inputs for user name and password are created off-screen
which the browsers autofills invisible to the user.