### PR TITLE
Remove unnecessary label phrases from dictionary

### DIFF
--- a/src/utils/LabelDictionary.js
+++ b/src/utils/LabelDictionary.js
@@ -15,94 +15,35 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // @flow
 
 class LabelDictionary {
+  // The word will be uppercased
+  static acronyms = ['id', 'api', 'url', 'vm', 'os', 'dhcp', 'sql', 'oci']
+
+  // The word will be replaced
+  static abbreviations = {
+    migr: 'Migration',
+    auth: 'Authentication',
+    fip: 'Floating IP',
+  }
+
   static dictionary = {
-    username: 'Username',
-    password: 'Password',
-    host: 'Host',
-    port: 'Port',
-    api_endpoint: 'API Endpoint',
-    allow_untrusted: 'Allow Untrusted',
-    identity_api_version: 'Identity Version',
-    identity_domain: 'Identity Domain',
     auth_url: 'Auth URL',
-    storage_api_endpoint: 'Storage Api Endpoint',
-    storage_auth_endpoint: 'Storage Authentication Endpoint',
-    user_domain_name: 'User Domain Name',
-    project_name: 'Project Name',
-    project_domain_name: 'Project Domain Name',
-    flavor_name: 'Flavor Name',
-    hypervisor_type: 'Hypervisor Type',
-    container_format: 'Container Format',
-    disk_format: 'Disk Format',
-    glance_upload: 'Glance Upload',
-    keypair_name: 'Keypair Name',
-    fip_pool_name: 'Floating IP Pool',
-    migr_fip_pool_name: 'Migration Floating IP Pool',
-    migr_flavor_name: 'Migration Flavor Name',
     migr_image: 'Migration Image Name or Id',
-    migr_image_map: 'Migration Image Map',
     migr_network: 'Migration Network Name or ID',
     migr_worker_boot_from_volume: 'Boot Migration Workers from Volume',
     volumes_are_zeroed: 'Volumes on destination are created zeroed',
-    port_reuse_policy: 'Port Reuse Policy',
     keep_mac: 'Keep MAC address',
     reuse_ports: 'Reuse Existing Ports',
-    replace_mac: 'Replace MAC address',
-    migr_image_name: 'Migration Image Name',
-    migr_image_name_map: 'Migration Image Name Map',
-    migr_image_id: 'Migration Image ID',
+    replace_mac: 'Replace MAC Address',
     migr_worker_use_config_drive: 'Migration Worker use ConfigDrive',
     migr_worker_use_fip: 'Migration Worker use FIP',
-    delete_disks_on_vm_termination: 'Delete Disks on VM termination',
-    set_dhcp: 'Set DHCP',
-    vm_size: 'VM Size',
-    location: 'Location',
-    resource_group: 'Resource Group',
-    worker_size: 'Worker Size',
-    subscription_id: 'Subscription ID',
-    user_credentials: 'User Credentials',
-    service_principal_credentials: 'Service Principal Credentials',
-    region_name: 'Region Name',
-    nova_region_name: 'Nova Region Name',
-    neutron_region_name: 'Neutron Region Name',
-    glance_region_name: 'Glance Region Name',
-    cinder_region_name: 'Cinder Region Name',
-    swift_region_name: 'Swift Region Name',
-    list_all_destination_networks: 'List All Destination Networks',
-    tenant_id: 'Tenant ID',
-    client_id: 'Client ID',
-    client_secret: 'Client Secret',
-    server_pool_name: 'Server Pool Name',
-    migr_template_name: 'Migration Template Name',
-    migr_template_username: 'Migration Template Username',
-    migr_template_password: 'Migration Template Password',
-    repository_name: 'Repository Name',
-    shape_name: 'Shape Name',
-    migr_shape_name: 'Migration Shape Name',
-    allow_untrusted_swift: 'Allow Untrusted Swift',
-    glance_api_version: 'Glance API Version',
-    region: 'Region',
-    access_key_id: 'Access Key ID',
-    secret_access_key: 'Secret Access Key',
-    session_token: 'Session Token',
-    clone_disks: 'Clone Disks',
-    force: 'Force',
-    skip_os_morphing: 'Skip OS Morphing',
-    shutdown_instances: 'Shutdown Instances',
     aws: 'Amazon',
     openstack: 'OpenStack',
-    oracle_vm: 'Oracle VM',
     opc: 'Oracle Cloud',
-    azure: 'Azure',
     vmware_vsphere: 'VMware',
-    oci: 'OCI',
     migr_subnet_id: 'Migration Subnet ID',
     separate_vm: 'Separate Migration/VM?',
-    use_replica: 'Use replica',
     windows_migr_image: { label: 'Windows Migration Image', description: 'The Windows Migration Image information found on the Azure page' },
     linux_migr_image: { label: 'Linux Migration Image', description: 'The Linux Migration Image information found on the Azure page' },
-    user_domain_id: 'User Domain ID',
-    project_domain_id: 'Project Domain ID',
     duplicate_to_project: { label: 'Project', description: 'Duplicate endpoint to selected project' },
   }
 
@@ -118,7 +59,11 @@ class LabelDictionary {
     }
 
     let words = fieldName ? fieldName.split('_') : []
-    words = words.map(word => word.charAt(0).toUpperCase() + word.substr(1))
+    words = words.map(word => {
+      let acronym = this.acronyms.find(a => a === word)
+      let newWord = acronym ? acronym.toUpperCase() : (this.abbreviations[word] || word)
+      return newWord.charAt(0).toUpperCase() + newWord.substr(1)
+    })
     return words.join(' ')
   }
 


### PR DESCRIPTION
If the name of the field is the same as its label, a dictionary entry is
not necessary.
Common abbreviations and acronyms can also be defined:
'migr' -> 'Migration', 'api' -> 'API' respectively.

So 'migr_worker' will be labeled 'Migration Worker' and 'client_id' will
be labeled 'Client ID'.