### PR TITLE
Use dictionary values for string enums

### DIFF
--- a/src/components/molecules/WizardOptionsField/index.jsx
+++ b/src/components/molecules/WizardOptionsField/index.jsx
@@ -122,7 +122,7 @@ class WizardOptionsField extends React.Component<Props> {
       }
 
       return {
-        label: typeof e === 'string' ? e : e.name,
+        label: typeof e === 'string' ? LabelDictionary.get(e) : e.name,
         value: typeof e === 'string' ? e : e.id,
       }
     })


### PR DESCRIPTION
If a field has string enumerations (no objects enumerations with 'id'
and 'name), use the dictionary for their label.