### PR TITLE
Fix '[object object]' label in dropdown

### DIFF
--- a/src/components/molecules/PropertiesTable/index.jsx
+++ b/src/components/molecules/PropertiesTable/index.jsx
@@ -124,7 +124,7 @@ class PropertiesTable extends React.Component<Props> {
       ...items,
     ]
 
-    let selectedItem = items.find(i => i.value === this.props.valueCallback(prop))
+    let selectedItem = items.find(i => !i.separator && i.value === this.props.valueCallback(prop))
 
     return (
       <Dropdown


### PR DESCRIPTION
Appears when rendering for the first time OCI's 'Migration Image Map'
field in the Wizard Options page.
This error was related to the fact that the dropdown had a separator.