### PR TITLE
Replica / Migration destination env. is not set

### DIFF
--- a/src/plugins/endpoint/default/OptionsSchemaPlugin.js
+++ b/src/plugins/endpoint/default/OptionsSchemaPlugin.js
@@ -85,6 +85,7 @@ export const defaultGetDestinationEnv = (data: WizardData): any => {
       }
     })
   }
+  return env
 }
 
 export const defaultGetNetworkMap = (data: WizardData) => {


### PR DESCRIPTION
The destination environment is not set when creating a replica /
migration.
A 'return' statement was forgotten.