### PR TITLE
Fix long line layout in validation error message

### DIFF
--- a/src/components/organisms/Endpoint/index.jsx
+++ b/src/components/organisms/Endpoint/index.jsx
@@ -69,6 +69,7 @@ const ShowErrorButton = styled.span`
   cursor: pointer;
 `
 const StatusError = styled.div`
+  max-width: 100%;
   margin-top: 16px;
   max-height: 140px;
   overflow: auto;

--- a/src/components/organisms/EndpointValidation/index.jsx
+++ b/src/components/organisms/EndpointValidation/index.jsx
@@ -43,6 +43,8 @@ const Validation = styled.div`
   ${contentStyle}
 `
 const Message = styled.div`
+  max-width: 100%;
+  overflow: auto;
   margin-top: 48px;
   text-align: center;
 `


### PR DESCRIPTION
If the validation error message has a long line (with no spaces), the
layout wouldn't display properly. To see the effect try filling an
invalid username for an OCI endpoint.