### PR TITLE
Fix tooltip not showing the first time

### DIFF
--- a/src/components/organisms/WizardOptions/WizardOptions.jsx
+++ b/src/components/organisms/WizardOptions/WizardOptions.jsx
@@ -77,6 +77,10 @@ class WizardOptions extends React.Component<Props> {
     window.addEventListener('resize', this.handleResize)
   }
 
+  componentDidUpdate() {
+    Tooltip.rebuild()
+  }
+
   componentWillUnmount() {
     window.removeEventListener('resize', this.handleResize, false)
   }


### PR DESCRIPTION
When the wizard options are rendered for the first time the tooltips are
not shown when hovering over the question mark symbol (as seen in
advanced Azure options at the Linux Migration Image field).