### PR TITLE
Refactor 'Source' classes

### DIFF
--- a/src/components/organisms/DetailsPageHeader/DetailsPageHeader.jsx
+++ b/src/components/organisms/DetailsPageHeader/DetailsPageHeader.jsx
@@ -42,7 +42,7 @@ const Logo = styled.a`
   background: url('${logoImage}') no-repeat;
   cursor: pointer;
 `
-const UserDropdownStyled = styled(UserDropdown) `
+const UserDropdownStyled = styled(UserDropdown)`
   margin-left: 16px;
 `
 const Menu = styled.div`
@@ -57,10 +57,14 @@ const User = styled.div`
 type Props = {
   user?: ?UserType,
   onUserItemClick: (userItem: { label: string, value: string }) => void,
+  testMode?: boolean,
 }
 @observer
 export class DetailsPageHeader extends React.Component<Props> {
   componentDidMount() {
+    if (this.props.testMode) {
+      return
+    }
     notificationStore.loadNotifications()
   }
 

--- a/src/components/organisms/DetailsPageHeader/test.jsx
+++ b/src/components/organisms/DetailsPageHeader/test.jsx
@@ -18,16 +18,26 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import sinon from 'sinon'
 import TW from '../../../utils/TestWrapper'
+import type { User } from '../../../types/User'
 import { DetailsPageHeader } from '.'
 
-const wrap = props => new TW(shallow(
-  // $FlowIgnore
-  <DetailsPageHeader notificationStore={{}} {...props} />
+type Props = {
+  user?: ?User,
+}
+
+const wrap = (props: Props) => new TW(shallow(
+  <DetailsPageHeader
+    onUserItemClick={() => { }}
+    testMode
+    {...props}
+  />
 ), 'dpHeader')
 
 let user = {
   name: 'User name',
   email: 'email@email.com',
+  id: 'user',
+  project: { id: '', name: '' },
 }
 
 describe('DetailsPageHeader Component', () => {

--- a/src/components/pages/AssessmentsPage/AssessmentsPage.jsx
+++ b/src/components/pages/AssessmentsPage/AssessmentsPage.jsx
@@ -49,6 +49,8 @@ class AssessmentsPage extends React.Component<Props, State> {
   }
 
   componentWillMount() {
+    document.title = 'Coriolis Planning'
+
     projectStore.getProjects()
 
     if (!azureStore.isLoadedForCurrentProject()) {

--- a/src/sources/AssessmentSource.js
+++ b/src/sources/AssessmentSource.js
@@ -14,8 +14,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // @flow
 
-import cookie from 'js-cookie'
-
 import type { MigrationInfo } from '../types/Assessment'
 import type { MainItem } from '../types/MainItem'
 import Api from '../utils/ApiCaller'
@@ -38,7 +36,6 @@ class AssessmentSourceUtils {
 
 class AssessmentSource {
   static migrate(data: MigrationInfo): Promise<MainItem> {
-    let projectId = cookie.get('projectId')
     let useReplicaField = data.options.find(o => o.name === 'use_replica')
     let type = useReplicaField && useReplicaField.value ? 'replica' : 'migration'
     let payload = {}
@@ -61,7 +58,7 @@ class AssessmentSource {
     })
 
     return Api.send({
-      url: `${servicesUrl.coriolis}/${projectId || 'null'}/${type}s`,
+      url: `${servicesUrl.coriolis}/${Api.projectId}/${type}s`,
       method: 'POST',
       data: payload,
     }).then(response => {

--- a/src/sources/AssessmentSource.js
+++ b/src/sources/AssessmentSource.js
@@ -38,66 +38,49 @@ class AssessmentSourceUtils {
 
 class AssessmentSource {
   static migrate(data: MigrationInfo): Promise<MainItem> {
-    return new Promise((resolve, reject) => {
-      let projectId = cookie.get('projectId')
-      let useReplicaField = data.options.find(o => o.name === 'use_replica')
-      let type = useReplicaField && useReplicaField.value ? 'replica' : 'migration'
-      let payload = {}
-      payload[type] = {
-        origin_endpoint_id: data.source ? data.source.id : 'null',
-        destination_endpoint_id: data.target.id,
-        destination_environment: AssessmentSourceUtils.getDestinationEnv(data),
-        instances: data.selectedInstances.map(i => i.instance_name),
-        notes: '',
-        security_groups: ['testgroup'],
+    let projectId = cookie.get('projectId')
+    let useReplicaField = data.options.find(o => o.name === 'use_replica')
+    let type = useReplicaField && useReplicaField.value ? 'replica' : 'migration'
+    let payload = {}
+    payload[type] = {
+      origin_endpoint_id: data.source ? data.source.id : 'null',
+      destination_endpoint_id: data.target.id,
+      destination_environment: AssessmentSourceUtils.getDestinationEnv(data),
+      instances: data.selectedInstances.map(i => i.instance_name),
+      notes: '',
+      security_groups: ['testgroup'],
+    }
+
+    data.options.forEach(option => {
+      if (option.name === 'use_replica') {
+        return
       }
+      if (option.value !== null && option.value !== undefined) {
+        payload[type][option.name] = option.value
+      }
+    })
 
-      data.options.forEach(option => {
-        if (option.name === 'use_replica') {
-          return
-        }
-        if (option.value !== null && option.value !== undefined) {
-          payload[type][option.name] = option.value
-        }
-      })
-
-      Api.send({
-        url: `${servicesUrl.coriolis}/${projectId || 'null'}/${type}s`,
-        method: 'POST',
-        data: payload,
-      }).then(response => {
-        resolve(response.data[type])
-      }, reject).catch(reject)
+    return Api.send({
+      url: `${servicesUrl.coriolis}/${projectId || 'null'}/${type}s`,
+      method: 'POST',
+      data: payload,
+    }).then(response => {
+      return response.data[type]
     })
   }
 
   static migrateMultiple(data: MigrationInfo): Promise<MainItem[]> {
-    return new Promise((resolve, reject) => {
-      let items = []
-      let count = 0
-
-      data.selectedInstances.forEach(instance => {
-        let newData = { ...data }
-        newData.selectedInstances = [instance]
-        this.migrate(newData).then(item => {
-          count += 1
-          items.push(item)
-          if (count === data.selectedInstances.length) {
-            if (items.length > 0) {
-              resolve(items)
-            } else {
-              reject()
-            }
-          }
-        }, () => {
-          count += 1
-          notificationStore.notify(`Error while migrating instance ${instance.name}`, 'error', {
-            persist: true,
-            persistInfo: { title: 'Migration creation error' },
-          })
+    return Promise.all(data.selectedInstances.map(instance => {
+      let newData = { ...data }
+      newData.selectedInstances = [instance]
+      return this.migrate(newData).catch(() => {
+        notificationStore.notify(`Error while migrating instance ${instance.name}`, 'error', {
+          persist: true,
+          persistInfo: { title: 'Migration creation error' },
         })
+        return null
       })
-    })
+    })).then(items => items.filter(Boolean).map(i => i))
   }
 }
 

--- a/src/sources/EndpointSource.js
+++ b/src/sources/EndpointSource.js
@@ -14,7 +14,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // @flow
 
-import cookie from 'js-cookie'
 import moment from 'moment'
 
 import Api from '../utils/ApiCaller'
@@ -39,27 +38,21 @@ let getBarbicanPayload = data => {
 
 class EdnpointSource {
   static getEndpoints(): Promise<Endpoint[]> {
-    let projectId = cookie.get('projectId')
-    if (projectId) {
-      return Api.get(`${servicesUrl.coriolis}/${projectId}/endpoints`).then(response => {
-        let connections = []
-        if (response.data.endpoints.length) {
-          response.data.endpoints.forEach(endpoint => {
-            connections.push(endpoint)
-          })
-        }
+    return Api.get(`${servicesUrl.coriolis}/${Api.projectId}/endpoints`).then(response => {
+      let connections = []
+      if (response.data.endpoints.length) {
+        response.data.endpoints.forEach(endpoint => {
+          connections.push(endpoint)
+        })
+      }
 
-        connections.sort((c1, c2) => moment(c2.created_at).diff(moment(c1.created_at)))
-        return connections
-      })
-    }
-    return Promise.reject('No Project ID!')
+      connections.sort((c1, c2) => moment(c2.created_at).diff(moment(c1.created_at)))
+      return connections
+    })
   }
   static delete(endpoint: Endpoint): Promise<string> {
-    let projectId: any = cookie.get('projectId')
-
     return Api.send({
-      url: `${servicesUrl.coriolis}/${projectId}/endpoints/${endpoint.id}`,
+      url: `${servicesUrl.coriolis}/${Api.projectId}/endpoints/${endpoint.id}`,
       method: 'DELETE',
     }).then(() => {
       if (endpoint.connection_info && endpoint.connection_info.secret_ref) {
@@ -107,9 +100,8 @@ class EdnpointSource {
   }
 
   static validate(endpoint: Endpoint): Promise<Validation> {
-    let projectId = cookie.get('projectId')
     return Api.send({
-      url: `${servicesUrl.coriolis}/${projectId || ''}/endpoints/${endpoint.id}/actions`,
+      url: `${servicesUrl.coriolis}/${Api.projectId}/endpoints/${endpoint.id}/actions`,
       method: 'POST',
       data: { 'validate-connection': null },
     }).then(response => {
@@ -118,7 +110,6 @@ class EdnpointSource {
   }
 
   static update(endpoint: Endpoint): Promise<Endpoint> {
-    let projectId = cookie.get('projectId')
     let parsedEndpoint = SchemaParser.fieldsToPayload(endpoint)
 
     if (parsedEndpoint.connection_info && parsedEndpoint.connection_info.secret_ref) {
@@ -147,7 +138,7 @@ class EdnpointSource {
           },
         }
         return Api.send({
-          url: `${servicesUrl.coriolis}/${projectId || ''}/endpoints/${endpoint.id}`,
+          url: `${servicesUrl.coriolis}/${Api.projectId}/endpoints/${endpoint.id}`,
           method: 'PUT',
           data: newPayload,
         })
@@ -171,7 +162,7 @@ class EdnpointSource {
     }
 
     return Api.send({
-      url: `${servicesUrl.coriolis}/${projectId || ''}/endpoints/${endpoint.id}`,
+      url: `${servicesUrl.coriolis}/${Api.projectId}/endpoints/${endpoint.id}`,
       method: 'PUT',
       data: { endpoint: parsedEndpoint },
     }).then(response => {
@@ -181,7 +172,6 @@ class EdnpointSource {
 
   static add(endpoint: Endpoint, skipSchemaParser: boolean = false): Promise<Endpoint> {
     let parsedEndpoint = skipSchemaParser ? { ...endpoint } : SchemaParser.fieldsToPayload(endpoint)
-    let projectId = cookie.get('projectId')
     let newEndpoint: any = {}
     let connectionInfo = {}
     if (useSecret) {
@@ -200,7 +190,7 @@ class EdnpointSource {
           },
         }
         return Api.send({
-          url: `${servicesUrl.coriolis}/${projectId || ''}/endpoints`,
+          url: `${servicesUrl.coriolis}/${Api.projectId}/endpoints`,
           method: 'POST',
           data: newPayload,
         })
@@ -224,7 +214,7 @@ class EdnpointSource {
     }
 
     return Api.send({
-      url: `${servicesUrl.coriolis}/${projectId || ''}/endpoints`,
+      url: `${servicesUrl.coriolis}/${Api.projectId}/endpoints`,
       method: 'POST',
       data: { endpoint: parsedEndpoint },
     }).then(response => {

--- a/src/sources/EndpointSource.js
+++ b/src/sources/EndpointSource.js
@@ -39,46 +39,39 @@ let getBarbicanPayload = data => {
 
 class EdnpointSource {
   static getEndpoints(): Promise<Endpoint[]> {
-    return new Promise((resolve, reject) => {
-      let projectId = cookie.get('projectId')
-      if (projectId) {
-        Api.get(`${servicesUrl.coriolis}/${projectId}/endpoints`).then(response => {
-          let connections = []
-          if (response.data.endpoints.length) {
-            response.data.endpoints.forEach(endpoint => {
-              connections.push(endpoint)
-            })
-          }
+    let projectId = cookie.get('projectId')
+    if (projectId) {
+      return Api.get(`${servicesUrl.coriolis}/${projectId}/endpoints`).then(response => {
+        let connections = []
+        if (response.data.endpoints.length) {
+          response.data.endpoints.forEach(endpoint => {
+            connections.push(endpoint)
+          })
+        }
 
-          connections.sort((c1, c2) => moment(c2.created_at).diff(moment(c1.created_at)))
-
-          resolve(connections)
-        }).catch(reject)
-      } else {
-        reject()
-      }
-    })
+        connections.sort((c1, c2) => moment(c2.created_at).diff(moment(c1.created_at)))
+        return connections
+      })
+    }
+    return Promise.reject('No Project ID!')
   }
   static delete(endpoint: Endpoint): Promise<string> {
-    return new Promise((resolve, reject) => {
-      let projectId: any = cookie.get('projectId')
+    let projectId: any = cookie.get('projectId')
 
-      Api.send({
-        url: `${servicesUrl.coriolis}/${projectId}/endpoints/${endpoint.id}`,
-        method: 'DELETE',
-      }).then(() => {
-        if (endpoint.connection_info && endpoint.connection_info.secret_ref) {
-          let uuidIndex = endpoint.connection_info.secret_ref.lastIndexOf('/')
-          // $FlowIssue
-          let uuid = endpoint.connection_info.secret_ref.substr(uuidIndex + 1)
-          Api.send({
-            url: `${servicesUrl.barbican}/v1/secrets/${uuid}`,
-            method: 'DELETE',
-          }).then(() => { resolve(endpoint.id) }).catch(reject)
-        } else {
-          resolve(endpoint.id)
-        }
-      }).catch(reject)
+    return Api.send({
+      url: `${servicesUrl.coriolis}/${projectId}/endpoints/${endpoint.id}`,
+      method: 'DELETE',
+    }).then(() => {
+      if (endpoint.connection_info && endpoint.connection_info.secret_ref) {
+        let uuidIndex = endpoint.connection_info.secret_ref.lastIndexOf('/')
+        // $FlowIssue
+        let uuid = endpoint.connection_info.secret_ref.substr(uuidIndex + 1)
+        return Api.send({
+          url: `${servicesUrl.barbican}/v1/secrets/${uuid}`,
+          method: 'DELETE',
+        }).then(() => { return endpoint.id })
+      }
+      return endpoint.id
     })
   }
 
@@ -90,175 +83,152 @@ class EdnpointSource {
       return Promise.resolve(endpoint.connection_info)
     }
 
-    return new Promise((resolve, reject) => {
-      Api.send({
-        url: `${servicesUrl.barbican}/v1/secrets/${uuid || 'undefined'}/payload`,
-        responseType: 'text',
-        headers: { Accept: 'text/plain' },
-      }).then((response) => {
-        resolve(response.data)
-      }).catch(reject)
+    return Api.send({
+      url: `${servicesUrl.barbican}/v1/secrets/${uuid || 'undefined'}/payload`,
+      responseType: 'text',
+      headers: { Accept: 'text/plain' },
+    }).then((response) => {
+      return response.data
     })
   }
 
   static getConnectionsInfo(endpoints: Endpoint[]): Promise<Endpoint[]> {
-    return new Promise(resolve => {
-      if (!endpoints || endpoints.length === 0) {
-        resolve([])
-        return
-      }
-
-      let count = 0
-      let connectionsInfo = []
-      let isDone = () => {
-        count += 1
-        if (count === endpoints.length) {
-          resolve(connectionsInfo)
-        }
-      }
-
-      endpoints.forEach(endpoint => {
-        let index = endpoint.connection_info.secret_ref ? endpoint.connection_info.secret_ref.lastIndexOf('/') : ''
-        let uuid = endpoint.connection_info.secret_ref && index ? endpoint.connection_info.secret_ref.substr(index + 1) : ''
-        Api.send({
-          url: `${servicesUrl.barbican}/v1/secrets/${uuid}/payload`,
-          responseType: 'text',
-          headers: { Accept: 'text/plain' },
-        }).then(response => {
-          connectionsInfo.push({ ...endpoint, connection_info: response.data })
-          isDone()
-        }, isDone).catch(isDone)
+    return Promise.all(endpoints.map(endpoint => {
+      let index = endpoint.connection_info.secret_ref ? endpoint.connection_info.secret_ref.lastIndexOf('/') : ''
+      let uuid = endpoint.connection_info.secret_ref && index ? endpoint.connection_info.secret_ref.substr(index + 1) : ''
+      return Api.send({
+        url: `${servicesUrl.barbican}/v1/secrets/${uuid}/payload`,
+        responseType: 'text',
+        headers: { Accept: 'text/plain' },
+      }).then(response => {
+        return { ...endpoint, connection_info: response.data }
       })
-    })
+    }))
   }
 
   static validate(endpoint: Endpoint): Promise<Validation> {
-    return new Promise((resolve, reject) => {
-      let projectId = cookie.get('projectId')
-      Api.send({
-        url: `${servicesUrl.coriolis}/${projectId || ''}/endpoints/${endpoint.id}/actions`,
-        method: 'POST',
-        data: { 'validate-connection': null },
-      }).then(response => {
-        resolve(response.data['validate-connection'])
-      }).catch(reject)
+    let projectId = cookie.get('projectId')
+    return Api.send({
+      url: `${servicesUrl.coriolis}/${projectId || ''}/endpoints/${endpoint.id}/actions`,
+      method: 'POST',
+      data: { 'validate-connection': null },
+    }).then(response => {
+      return response.data['validate-connection']
     })
   }
 
   static update(endpoint: Endpoint): Promise<Endpoint> {
-    return new Promise((resolve, reject) => {
-      let projectId = cookie.get('projectId')
-      let parsedEndpoint = SchemaParser.fieldsToPayload(endpoint)
+    let projectId = cookie.get('projectId')
+    let parsedEndpoint = SchemaParser.fieldsToPayload(endpoint)
 
-      if (parsedEndpoint.connection_info && parsedEndpoint.connection_info.secret_ref) {
-        // $FlowIgnore
-        let uuidIndex = parsedEndpoint.connection_info.secret_ref.lastIndexOf('/')
-        // $FlowIgnore
-        let uuid = parsedEndpoint.connection_info.secret_ref.substr(uuidIndex + 1)
-
-        Api.send({
-          url: `${servicesUrl.barbican}/v1/secrets/${uuid}`,
-          method: 'DELETE',
-        })
-
-        Api.send({
+    if (parsedEndpoint.connection_info && parsedEndpoint.connection_info.secret_ref) {
+      // $FlowIgnore
+      let uuidIndex = parsedEndpoint.connection_info.secret_ref.lastIndexOf('/')
+      // $FlowIgnore
+      let uuid = parsedEndpoint.connection_info.secret_ref.substr(uuidIndex + 1)
+      let newEndpoint: any = {}
+      let connectionInfo = {}
+      return Api.send({
+        url: `${servicesUrl.barbican}/v1/secrets/${uuid}`,
+        method: 'DELETE',
+      }).then(() => {
+        return Api.send({
           url: `${servicesUrl.barbican}/v1/secrets`,
           method: 'POST',
           data: getBarbicanPayload(ObjectUtils.skipField(parsedEndpoint.connection_info, 'secret_ref')),
-        }).then(response => {
-          let connectionInfo = { secret_ref: response.data.secret_ref }
-          let newPayload = {
-            endpoint: {
-              name: parsedEndpoint.name,
-              description: parsedEndpoint.description,
-              connection_info: connectionInfo,
-            },
-          }
-          Api.send({
-            url: `${servicesUrl.coriolis}/${projectId || ''}/endpoints/${endpoint.id}`,
-            method: 'PUT',
-            data: newPayload,
-          }).then(putResponse => {
-            uuidIndex = connectionInfo.secret_ref.lastIndexOf('/')
-            uuid = connectionInfo.secret_ref.substr(uuidIndex + 1)
-            let newEndpoint = putResponse.data.endpoint
-
-            Api.send({
-              url: `${servicesUrl.barbican}/v1/secrets/${uuid}/payload`,
-              method: 'GET',
-              responseType: 'text',
-              headers: { Accept: 'text/plain' },
-            }).then(conInfoResponse => {
-              newEndpoint.connection_info = {
-                ...newEndpoint.connection_info,
-                ...conInfoResponse.data,
-              }
-              resolve(newEndpoint)
-            }).catch(reject)
-          }).catch(reject)
-        }).catch(reject)
-      } else {
-        Api.send({
+        })
+      }).then(response => {
+        connectionInfo = { secret_ref: response.data.secret_ref }
+        let newPayload = {
+          endpoint: {
+            name: parsedEndpoint.name,
+            description: parsedEndpoint.description,
+            connection_info: connectionInfo,
+          },
+        }
+        return Api.send({
           url: `${servicesUrl.coriolis}/${projectId || ''}/endpoints/${endpoint.id}`,
           method: 'PUT',
-          data: { endpoint: parsedEndpoint },
-        }).then(response => {
-          resolve(response.data.endpoint)
-        }).catch(reject)
-      }
+          data: newPayload,
+        })
+      }).then(putResponse => {
+        uuidIndex = connectionInfo.secret_ref.lastIndexOf('/')
+        uuid = connectionInfo.secret_ref.substr(uuidIndex + 1)
+        newEndpoint = putResponse.data.endpoint
+        return Api.send({
+          url: `${servicesUrl.barbican}/v1/secrets/${uuid}/payload`,
+          method: 'GET',
+          responseType: 'text',
+          headers: { Accept: 'text/plain' },
+        })
+      }).then(conInfoResponse => {
+        newEndpoint.connection_info = {
+          ...newEndpoint.connection_info,
+          ...conInfoResponse.data,
+        }
+        return newEndpoint
+      })
+    }
+
+    return Api.send({
+      url: `${servicesUrl.coriolis}/${projectId || ''}/endpoints/${endpoint.id}`,
+      method: 'PUT',
+      data: { endpoint: parsedEndpoint },
+    }).then(response => {
+      return response.data.endpoint
     })
   }
 
   static add(endpoint: Endpoint, skipSchemaParser: boolean = false): Promise<Endpoint> {
-    return new Promise((resolve, reject) => {
-      let parsedEndpoint = skipSchemaParser ? { ...endpoint } : SchemaParser.fieldsToPayload(endpoint)
-      let projectId = cookie.get('projectId')
-      if (useSecret) {
-        Api.send({
-          url: `${servicesUrl.barbican}/v1/secrets`,
-          method: 'POST',
-          data: getBarbicanPayload(ObjectUtils.skipField(parsedEndpoint.connection_info, 'secret_ref')),
-        }).then(response => {
-          let connectionInfo = { secret_ref: response.data.secret_ref }
-          let newPayload = {
-            endpoint: {
-              name: parsedEndpoint.name,
-              description: parsedEndpoint.description,
-              type: endpoint.type,
-              connection_info: connectionInfo,
-            },
-          }
-          Api.send({
-            url: `${servicesUrl.coriolis}/${projectId || ''}/endpoints`,
-            method: 'POST',
-            data: newPayload,
-          }).then(postResponse => {
-            let uuidIndex = connectionInfo.secret_ref.lastIndexOf('/')
-            let uuid = connectionInfo.secret_ref.substr(uuidIndex + 1)
-            let newEndpoint = postResponse.data.endpoint
-
-            Api.send({
-              url: `${servicesUrl.barbican}/v1/secrets/${uuid}/payload`,
-              responseType: 'text',
-              headers: { Accept: 'text/plain' },
-            }).then(conInfoResponse => {
-              newEndpoint.connection_info = {
-                ...newEndpoint.connection_info,
-                ...conInfoResponse.data,
-              }
-              resolve(newEndpoint)
-            }).catch(reject)
-          }).catch(reject)
-        }).catch(reject)
-      } else {
-        Api.send({
+    let parsedEndpoint = skipSchemaParser ? { ...endpoint } : SchemaParser.fieldsToPayload(endpoint)
+    let projectId = cookie.get('projectId')
+    let newEndpoint: any = {}
+    let connectionInfo = {}
+    if (useSecret) {
+      return Api.send({
+        url: `${servicesUrl.barbican}/v1/secrets`,
+        method: 'POST',
+        data: getBarbicanPayload(ObjectUtils.skipField(parsedEndpoint.connection_info, 'secret_ref')),
+      }).then(response => {
+        connectionInfo = { secret_ref: response.data.secret_ref }
+        let newPayload = {
+          endpoint: {
+            name: parsedEndpoint.name,
+            description: parsedEndpoint.description,
+            type: endpoint.type,
+            connection_info: connectionInfo,
+          },
+        }
+        return Api.send({
           url: `${servicesUrl.coriolis}/${projectId || ''}/endpoints`,
           method: 'POST',
-          data: { endpoint: parsedEndpoint },
-        }).then(response => {
-          resolve(response.data.endpoint)
-        }).catch(reject)
-      }
+          data: newPayload,
+        })
+      }).then(postResponse => {
+        let uuidIndex = connectionInfo.secret_ref.lastIndexOf('/')
+        let uuid = connectionInfo.secret_ref.substr(uuidIndex + 1)
+        newEndpoint = postResponse.data.endpoint
+
+        return Api.send({
+          url: `${servicesUrl.barbican}/v1/secrets/${uuid}/payload`,
+          responseType: 'text',
+          headers: { Accept: 'text/plain' },
+        })
+      }).then(conInfoResponse => {
+        newEndpoint.connection_info = {
+          ...newEndpoint.connection_info,
+          ...conInfoResponse.data,
+        }
+        return newEndpoint
+      })
+    }
+
+    return Api.send({
+      url: `${servicesUrl.coriolis}/${projectId || ''}/endpoints`,
+      method: 'POST',
+      data: { endpoint: parsedEndpoint },
+    }).then(response => {
+      return response.data.endpoint
     })
   }
 }

--- a/src/sources/InstanceSource.js
+++ b/src/sources/InstanceSource.js
@@ -14,8 +14,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // @flow
 
-import cookie from 'js-cookie'
-
 import Api from '../utils/ApiCaller'
 import type { Instance } from '../types/Instance'
 
@@ -30,8 +28,7 @@ class InstanceSource {
       this.lastEndpointId = endpointId
     }
 
-    let projectId = cookie.get('projectId')
-    let url = `${servicesUrl.coriolis}/${projectId || 'null'}/endpoints/${endpointId}/instances`
+    let url = `${servicesUrl.coriolis}/${Api.projectId}/endpoints/${endpointId}/instances`
     let symbol = '?'
 
     if (!skipLimit) {
@@ -54,10 +51,8 @@ class InstanceSource {
   }
 
   static loadInstanceDetails(endpointId: string, instanceName: string, reqId: number): Promise<{ instance: Instance, reqId: number }> {
-    let projectId = cookie.get('projectId') || 'undefined'
-
     return Api.send({
-      url: `${servicesUrl.coriolis}/${projectId}/endpoints/${endpointId}/instances/${btoa(instanceName)}`,
+      url: `${servicesUrl.coriolis}/${Api.projectId}/endpoints/${endpointId}/instances/${btoa(instanceName)}`,
       cancelId: `instanceDetail-${reqId}`,
     }).then(response => {
       return { instance: response.data.instance, reqId }

--- a/src/sources/InstanceSource.js
+++ b/src/sources/InstanceSource.js
@@ -22,48 +22,45 @@ import type { Instance } from '../types/Instance'
 import { servicesUrl, wizardConfig } from '../config'
 
 class InstanceSource {
-  static endpointId: string
+  static lastEndpointId: string
 
   static loadInstances(endpointId: string, searchText: ?string, lastInstanceId: ?string, skipLimit?: boolean): Promise<Instance[]> {
-    this.endpointId = endpointId
+    if (this.lastEndpointId) {
+      Api.cancelRequests(this.lastEndpointId)
+      this.lastEndpointId = endpointId
+    }
 
-    return new Promise((resolve, reject) => {
-      let projectId = cookie.get('projectId')
-      let url = `${servicesUrl.coriolis}/${projectId || 'null'}/endpoints/${endpointId}/instances`
-      let symbol = '?'
+    let projectId = cookie.get('projectId')
+    let url = `${servicesUrl.coriolis}/${projectId || 'null'}/endpoints/${endpointId}/instances`
+    let symbol = '?'
 
-      if (!skipLimit) {
-        url = `${url + symbol}limit=${wizardConfig.instancesItemsPerPage + 1}`
-        symbol = '&'
-      }
+    if (!skipLimit) {
+      url = `${url + symbol}limit=${wizardConfig.instancesItemsPerPage + 1}`
+      symbol = '&'
+    }
 
-      if (searchText) {
-        url = `${url + symbol}name=${searchText}`
-        symbol = '&'
-      }
+    if (searchText) {
+      url = `${url + symbol}name=${searchText}`
+      symbol = '&'
+    }
 
-      if (lastInstanceId) {
-        url = `${url + symbol}&marker=${lastInstanceId}`
-      }
+    if (lastInstanceId) {
+      url = `${url + symbol}&marker=${lastInstanceId}`
+    }
 
-      Api.get(url).then(response => {
-        if (this.endpointId === endpointId) {
-          resolve(response.data.instances)
-        }
-      }).catch(reject)
+    return Api.send({ url, cancelId: endpointId }).then(response => {
+      return response.data.instances
     })
   }
 
   static loadInstanceDetails(endpointId: string, instanceName: string, reqId: number): Promise<{ instance: Instance, reqId: number }> {
-    return new Promise((resolve, reject) => {
-      let projectId = cookie.get('projectId') || 'undefined'
+    let projectId = cookie.get('projectId') || 'undefined'
 
-      Api.send({
-        url: `${servicesUrl.coriolis}/${projectId}/endpoints/${endpointId}/instances/${btoa(instanceName)}`,
-        cancelId: `instanceDetail-${reqId}`,
-      }).then(response => {
-        resolve({ instance: response.data.instance, reqId })
-      }, response => { reject({ response, reqId }) }).catch(reject)
+    return Api.send({
+      url: `${servicesUrl.coriolis}/${projectId}/endpoints/${endpointId}/instances/${btoa(instanceName)}`,
+      cancelId: `instanceDetail-${reqId}`,
+    }).then(response => {
+      return { instance: response.data.instance, reqId }
     })
   }
 

--- a/src/sources/MigrationSource.js
+++ b/src/sources/MigrationSource.js
@@ -14,7 +14,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // @flow
 
-import cookie from 'js-cookie'
 import moment from 'moment'
 
 import Api from '../utils/ApiCaller'
@@ -51,8 +50,7 @@ class MigrationSourceUtils {
 
 class MigrationSource {
   static getMigrations(): Promise<MainItem[]> {
-    let projectId = cookie.get('projectId') || 'null'
-    return Api.get(`${servicesUrl.coriolis}/${projectId}/migrations/detail`).then(response => {
+    return Api.get(`${servicesUrl.coriolis}/${Api.projectId}/migrations/detail`).then(response => {
       let migrations = response.data.migrations
       MigrationSourceUtils.sortMigrations(migrations)
       return migrations
@@ -60,9 +58,7 @@ class MigrationSource {
   }
 
   static getMigration(migrationId: string): Promise<MainItem> {
-    let projectId = cookie.get('projectId') || 'null'
-
-    return Api.get(`${servicesUrl.coriolis}/${projectId}/migrations/${migrationId}`).then(response => {
+    return Api.get(`${servicesUrl.coriolis}/${Api.projectId}/migrations/${migrationId}`).then(response => {
       let migration = response.data.migration
       MigrationSourceUtils.sortTaskUpdates(migration)
       return migration
@@ -70,25 +66,21 @@ class MigrationSource {
   }
 
   static cancel(migrationId: string): Promise<string> {
-    let projectId = cookie.get('projectId') || 'null'
-
     return Api.send({
-      url: `${servicesUrl.coriolis}/${projectId}/migrations/${migrationId}/actions`,
+      url: `${servicesUrl.coriolis}/${Api.projectId}/migrations/${migrationId}/actions`,
       method: 'POST',
       data: { cancel: null },
     }).then(() => migrationId)
   }
 
   static delete(migrationId: string): Promise<string> {
-    let projectId = cookie.get('projectId')
     return Api.send({
-      url: `${servicesUrl.coriolis}/${projectId || 'null'}/migrations/${migrationId}`,
+      url: `${servicesUrl.coriolis}/${Api.projectId}/migrations/${migrationId}`,
       method: 'DELETE',
     }).then(() => migrationId)
   }
 
   static migrateReplica(replicaId: string, options: Field[]): Promise<MainItem> {
-    let projectId = cookie.get('projectId')
     let payload = {
       migration: {
         replica_id: replicaId,
@@ -99,7 +91,7 @@ class MigrationSource {
     })
 
     return Api.send({
-      url: `${servicesUrl.coriolis}/${projectId || 'null'}/migrations`,
+      url: `${servicesUrl.coriolis}/${Api.projectId}/migrations`,
       method: 'POST',
       data: payload,
     }).then(response => response.data.migration)

--- a/src/sources/MigrationSource.js
+++ b/src/sources/MigrationSource.js
@@ -51,73 +51,58 @@ class MigrationSourceUtils {
 
 class MigrationSource {
   static getMigrations(): Promise<MainItem[]> {
-    return new Promise((resolve, reject) => {
-      let projectId = cookie.get('projectId') || 'null'
-      Api.get(`${servicesUrl.coriolis}/${projectId}/migrations/detail`).then(response => {
-        let migrations = response.data.migrations
-        MigrationSourceUtils.sortMigrations(migrations)
-        resolve(migrations)
-      }).catch(reject)
+    let projectId = cookie.get('projectId') || 'null'
+    return Api.get(`${servicesUrl.coriolis}/${projectId}/migrations/detail`).then(response => {
+      let migrations = response.data.migrations
+      MigrationSourceUtils.sortMigrations(migrations)
+      return migrations
     })
   }
 
   static getMigration(migrationId: string): Promise<MainItem> {
-    return new Promise((resolve, reject) => {
-      let projectId = cookie.get('projectId') || 'null'
+    let projectId = cookie.get('projectId') || 'null'
 
-      Api.get(`${servicesUrl.coriolis}/${projectId}/migrations/${migrationId}`).then(response => {
-        let migration = response.data.migration
-        MigrationSourceUtils.sortTaskUpdates(migration)
-        resolve(migration)
-      }).catch(reject)
+    return Api.get(`${servicesUrl.coriolis}/${projectId}/migrations/${migrationId}`).then(response => {
+      let migration = response.data.migration
+      MigrationSourceUtils.sortTaskUpdates(migration)
+      return migration
     })
   }
 
   static cancel(migrationId: string): Promise<string> {
-    return new Promise((resolve, reject) => {
-      let projectId = cookie.get('projectId') || 'null'
+    let projectId = cookie.get('projectId') || 'null'
 
-      Api.send({
-        url: `${servicesUrl.coriolis}/${projectId}/migrations/${migrationId}/actions`,
-        method: 'POST',
-        data: { cancel: null },
-      }).then(() => {
-        resolve(migrationId)
-      }).catch(reject)
-    })
+    return Api.send({
+      url: `${servicesUrl.coriolis}/${projectId}/migrations/${migrationId}/actions`,
+      method: 'POST',
+      data: { cancel: null },
+    }).then(() => migrationId)
   }
 
   static delete(migrationId: string): Promise<string> {
-    return new Promise((resolve, reject) => {
-      let projectId = cookie.get('projectId')
-      Api.send({
-        url: `${servicesUrl.coriolis}/${projectId || 'null'}/migrations/${migrationId}`,
-        method: 'DELETE',
-      }).then(() => { resolve(migrationId) }, reject).catch(reject)
-    })
+    let projectId = cookie.get('projectId')
+    return Api.send({
+      url: `${servicesUrl.coriolis}/${projectId || 'null'}/migrations/${migrationId}`,
+      method: 'DELETE',
+    }).then(() => migrationId)
   }
 
   static migrateReplica(replicaId: string, options: Field[]): Promise<MainItem> {
-    return new Promise((resolve, reject) => {
-      let projectId = cookie.get('projectId')
-      let payload = {
-        migration: {
-          replica_id: replicaId,
-        },
-      }
-      options.forEach(o => {
-        payload.migration[o.name] = o.value || false
-      })
-
-      Api.send({
-        url: `${servicesUrl.coriolis}/${projectId || 'null'}/migrations`,
-        method: 'POST',
-        data: payload,
-      }).then(response => {
-        let migration = response.data.migration
-        resolve(migration)
-      }).catch(reject)
+    let projectId = cookie.get('projectId')
+    let payload = {
+      migration: {
+        replica_id: replicaId,
+      },
+    }
+    options.forEach(o => {
+      payload.migration[o.name] = o.value || false
     })
+
+    return Api.send({
+      url: `${servicesUrl.coriolis}/${projectId || 'null'}/migrations`,
+      method: 'POST',
+      data: payload,
+    }).then(response => response.data.migration)
   }
 }
 

--- a/src/sources/NetworkSource.js
+++ b/src/sources/NetworkSource.js
@@ -14,8 +14,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // @flow
 
-import cookie from 'js-cookie'
-
 import Api from '../utils/ApiCaller'
 import type { Network } from '../types/Network'
 
@@ -23,8 +21,7 @@ import { servicesUrl } from '../config'
 
 class NetworkSource {
   static loadNetworks(enpointId: string, environment: ?{ [string]: mixed }): Promise<Network[]> {
-    let projectId = cookie.get('projectId')
-    let url = `${servicesUrl.coriolis}/${projectId || 'null'}/endpoints/${enpointId}/networks`
+    let url = `${servicesUrl.coriolis}/${Api.projectId}/endpoints/${enpointId}/networks`
     if (environment) {
       url = `${url}?env=${btoa(JSON.stringify(environment))}`
     }

--- a/src/sources/NetworkSource.js
+++ b/src/sources/NetworkSource.js
@@ -23,18 +23,16 @@ import { servicesUrl } from '../config'
 
 class NetworkSource {
   static loadNetworks(enpointId: string, environment: ?{ [string]: mixed }): Promise<Network[]> {
-    return new Promise((resolve, reject) => {
-      let projectId = cookie.get('projectId')
-      let url = `${servicesUrl.coriolis}/${projectId || 'null'}/endpoints/${enpointId}/networks`
-      if (environment) {
-        url = `${url}?env=${btoa(JSON.stringify(environment))}`
-      }
+    let projectId = cookie.get('projectId')
+    let url = `${servicesUrl.coriolis}/${projectId || 'null'}/endpoints/${enpointId}/networks`
+    if (environment) {
+      url = `${url}?env=${btoa(JSON.stringify(environment))}`
+    }
 
-      Api.get(url).then(response => {
-        let networks = response.data.networks.filter(n => n.name.indexOf('coriolis-migrnet') === -1)
-        networks.sort((a, b) => a.name.localeCompare(b.name))
-        resolve(networks)
-      }).catch(reject)
+    return Api.get(url).then(response => {
+      let networks = response.data.networks.filter(n => n.name.indexOf('coriolis-migrnet') === -1)
+      networks.sort((a, b) => a.name.localeCompare(b.name))
+      return networks
     })
   }
 }

--- a/src/sources/NotificationSource.js
+++ b/src/sources/NotificationSource.js
@@ -18,31 +18,25 @@ import type { NotificationItem } from '../types/NotificationItem'
 
 class NotificationSource {
   static notify(message: string, level?: $PropertyType<NotificationItem, 'level'>, options?: $PropertyType<NotificationItem, 'options'>): Promise<NotificationItem> {
-    return new Promise(resolve => {
-      let notifications = JSON.parse(localStorage.getItem('notifications') || '[]')
-      let newItem = {
-        id: new Date().getTime().toString(),
-        message,
-        level,
-        options,
-      }
-      notifications.push(newItem)
-      localStorage.setItem('notifications', JSON.stringify(notifications))
-      resolve(newItem)
-    })
+    let notifications = JSON.parse(localStorage.getItem('notifications') || '[]')
+    let newItem = {
+      id: new Date().getTime().toString(),
+      message,
+      level,
+      options,
+    }
+    notifications.push(newItem)
+    localStorage.setItem('notifications', JSON.stringify(notifications))
+    return Promise.resolve(newItem)
   }
 
   static loadNotifications(): Promise<NotificationItem[]> {
-    return new Promise(resolve => {
-      resolve(JSON.parse(localStorage.getItem('notifications') || '[]'))
-    })
+    return Promise.resolve(JSON.parse(localStorage.getItem('notifications') || '[]'))
   }
 
   static clearNotifications(): Promise<void> {
-    return new Promise(resolve => {
-      localStorage.setItem('notifications', '[]')
-      resolve()
-    })
+    localStorage.setItem('notifications', '[]')
+    return Promise.resolve()
   }
 }
 

--- a/src/sources/NotificationSource.js
+++ b/src/sources/NotificationSource.js
@@ -16,6 +16,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import type { NotificationItem } from '../types/NotificationItem'
 
+
 class NotificationSource {
   static notify(message: string, level?: $PropertyType<NotificationItem, 'level'>, options?: $PropertyType<NotificationItem, 'options'>): Promise<NotificationItem> {
     let notifications = JSON.parse(localStorage.getItem('notifications') || '[]')

--- a/src/sources/ProviderSource.js
+++ b/src/sources/ProviderSource.js
@@ -25,52 +25,43 @@ import type { DestinationOption } from '../types/Endpoint'
 
 class ProviderSource {
   static getConnectionInfoSchema(providerName: string): Promise<Field[]> {
-    return new Promise((resolve, reject) => {
-      let projectId = cookie.get('projectId')
+    let projectId = cookie.get('projectId')
 
-      Api.get(`${servicesUrl.coriolis}/${projectId || 'null'}/providers/${providerName}/schemas/${providerTypes.CONNECTION}`).then(response => {
-        let schema = response.data.schemas.connection_info_schema
-        schema = SchemaParser.connectionSchemaToFields(providerName, schema)
-        resolve(schema)
-      }).catch(reject)
+    return Api.get(`${servicesUrl.coriolis}/${projectId || 'null'}/providers/${providerName}/schemas/${providerTypes.CONNECTION}`).then(response => {
+      let schema = response.data.schemas.connection_info_schema
+      schema = SchemaParser.connectionSchemaToFields(providerName, schema)
+      return schema
     })
   }
 
   static loadProviders(): Promise<Providers> {
-    return new Promise((resolve, reject) => {
-      let projectId = cookie.get('projectId')
+    let projectId = cookie.get('projectId')
 
-      Api.get(`${servicesUrl.coriolis}/${projectId || 'null'}/providers`).then(response => {
-        resolve(response.data.providers)
-      }).catch(reject)
-    })
+    return Api.get(`${servicesUrl.coriolis}/${projectId || 'null'}/providers`)
+      .then(response => response.data.providers)
   }
 
   static loadOptionsSchema(providerName: string, schemaType: string): Promise<Field[]> {
-    return new Promise((resolve, reject) => {
-      let projectId = cookie.get('projectId')
-      let schemaTypeInt = schemaType === 'migration' ? providerTypes.TARGET_MIGRATION : providerTypes.TARGET_REPLICA
+    let projectId = cookie.get('projectId')
+    let schemaTypeInt = schemaType === 'migration' ? providerTypes.TARGET_MIGRATION : providerTypes.TARGET_REPLICA
 
-      Api.get(`${servicesUrl.coriolis}/${projectId || 'null'}/providers/${providerName}/schemas/${schemaTypeInt}`).then(response => {
-        let schema = response.data.schemas.destination_environment_schema
-        let fields = SchemaParser.optionsSchemaToFields(providerName, schema)
-        resolve(fields)
-      }).catch(reject)
+    return Api.get(`${servicesUrl.coriolis}/${projectId || 'null'}/providers/${providerName}/schemas/${schemaTypeInt}`).then(response => {
+      let schema = response.data.schemas.destination_environment_schema
+      let fields = SchemaParser.optionsSchemaToFields(providerName, schema)
+      return fields
     })
   }
 
   static getDestinationOptions(endpointId: string, envData: ?{ [string]: mixed }): Promise<DestinationOption[]> {
-    return new Promise((resolve, reject) => {
-      let projectId = cookie.get('projectId')
-      let envString = ''
-      if (envData) {
-        envString = `?env=${btoa(JSON.stringify(envData))}`
-      }
+    let projectId = cookie.get('projectId')
+    let envString = ''
+    if (envData) {
+      envString = `?env=${btoa(JSON.stringify(envData))}`
+    }
 
-      Api.get(`${servicesUrl.coriolis}/${projectId || 'null'}/endpoints/${endpointId}/destination-options${envString}`).then(response => {
-        let options = response.data.destination_options
-        resolve(options)
-      }).catch(() => { reject() })
+    return Api.get(`${servicesUrl.coriolis}/${projectId || 'null'}/endpoints/${endpointId}/destination-options${envString}`).then(response => {
+      let options = response.data.destination_options
+      return options
     })
   }
 }

--- a/src/sources/ProviderSource.js
+++ b/src/sources/ProviderSource.js
@@ -14,8 +14,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // @flow
 
-import cookie from 'js-cookie'
-
 import Api from '../utils/ApiCaller'
 import { servicesUrl, providerTypes } from '../config'
 import { SchemaParser } from './Schemas'
@@ -25,9 +23,7 @@ import type { DestinationOption } from '../types/Endpoint'
 
 class ProviderSource {
   static getConnectionInfoSchema(providerName: string): Promise<Field[]> {
-    let projectId = cookie.get('projectId')
-
-    return Api.get(`${servicesUrl.coriolis}/${projectId || 'null'}/providers/${providerName}/schemas/${providerTypes.CONNECTION}`).then(response => {
+    return Api.get(`${servicesUrl.coriolis}/${Api.projectId}/providers/${providerName}/schemas/${providerTypes.CONNECTION}`).then(response => {
       let schema = response.data.schemas.connection_info_schema
       schema = SchemaParser.connectionSchemaToFields(providerName, schema)
       return schema
@@ -35,17 +31,14 @@ class ProviderSource {
   }
 
   static loadProviders(): Promise<Providers> {
-    let projectId = cookie.get('projectId')
-
-    return Api.get(`${servicesUrl.coriolis}/${projectId || 'null'}/providers`)
+    return Api.get(`${servicesUrl.coriolis}/${Api.projectId}/providers`)
       .then(response => response.data.providers)
   }
 
   static loadOptionsSchema(providerName: string, schemaType: string): Promise<Field[]> {
-    let projectId = cookie.get('projectId')
     let schemaTypeInt = schemaType === 'migration' ? providerTypes.TARGET_MIGRATION : providerTypes.TARGET_REPLICA
 
-    return Api.get(`${servicesUrl.coriolis}/${projectId || 'null'}/providers/${providerName}/schemas/${schemaTypeInt}`).then(response => {
+    return Api.get(`${servicesUrl.coriolis}/${Api.projectId}/providers/${providerName}/schemas/${schemaTypeInt}`).then(response => {
       let schema = response.data.schemas.destination_environment_schema
       let fields = SchemaParser.optionsSchemaToFields(providerName, schema)
       return fields
@@ -53,13 +46,12 @@ class ProviderSource {
   }
 
   static getDestinationOptions(endpointId: string, envData: ?{ [string]: mixed }): Promise<DestinationOption[]> {
-    let projectId = cookie.get('projectId')
     let envString = ''
     if (envData) {
       envString = `?env=${btoa(JSON.stringify(envData))}`
     }
 
-    return Api.get(`${servicesUrl.coriolis}/${projectId || 'null'}/endpoints/${endpointId}/destination-options${envString}`).then(response => {
+    return Api.get(`${servicesUrl.coriolis}/${Api.projectId}/endpoints/${endpointId}/destination-options${envString}`).then(response => {
       let options = response.data.destination_options
       return options
     })

--- a/src/sources/ReplicaSource.js
+++ b/src/sources/ReplicaSource.js
@@ -14,7 +14,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // @flow
 
-import cookie from 'js-cookie'
 import moment from 'moment'
 
 import Api from '../utils/ApiCaller'
@@ -85,8 +84,7 @@ class ReplicaSourceUtils {
 
 class ReplicaSource {
   static getReplicas(): Promise<MainItem[]> {
-    let projectId = cookie.get('projectId') || 'undefined'
-    return Api.get(`${servicesUrl.coriolis}/${projectId}/replicas/detail`).then(response => {
+    return Api.get(`${servicesUrl.coriolis}/${Api.projectId}/replicas/detail`).then(response => {
       let replicas = response.data.replicas
       replicas = ReplicaSourceUtils.filterDeletedExecutionsInReplicas(replicas)
       ReplicaSourceUtils.sortReplicas(replicas)
@@ -95,8 +93,7 @@ class ReplicaSource {
   }
 
   static getReplicaExecutions(replicaId: string): Promise<Execution[]> {
-    let projectId = cookie.get('projectId') || 'undefined'
-    return Api.get(`${servicesUrl.coriolis}/${projectId}/replicas/${replicaId}/executions/detail`).then((response) => {
+    return Api.get(`${servicesUrl.coriolis}/${Api.projectId}/replicas/${replicaId}/executions/detail`).then((response) => {
       let executions = response.data.executions
       ReplicaSourceUtils.sortExecutionsAndTaskUpdates(executions)
 
@@ -105,9 +102,7 @@ class ReplicaSource {
   }
 
   static getReplica(replicaId: string): Promise<MainItem> {
-    let projectId = cookie.get('projectId') || 'undefined'
-
-    return Api.get(`${servicesUrl.coriolis}/${projectId}/replicas/${replicaId}`).then(response => {
+    return Api.get(`${servicesUrl.coriolis}/${Api.projectId}/replicas/${replicaId}`).then(response => {
       let replica = response.data.replica
       replica.executions = ReplicaSourceUtils.filterDeletedExecutions(replica.executions)
       ReplicaSourceUtils.sortExecutions(replica.executions)
@@ -122,10 +117,8 @@ class ReplicaSource {
         payload.execution[f.name] = f.value || false
       })
     }
-    let projectId = cookie.get('projectId') || 'undefined'
-
     return Api.send({
-      url: `${servicesUrl.coriolis}/${projectId}/replicas/${replicaId}/executions`,
+      url: `${servicesUrl.coriolis}/${Api.projectId}/replicas/${replicaId}/executions`,
       method: 'POST',
       data: payload,
     }).then((response) => {
@@ -136,38 +129,30 @@ class ReplicaSource {
   }
 
   static cancelExecution(replicaId: string, executionId: string): Promise<string> {
-    let projectId = cookie.get('projectId')
-
     return Api.send({
-      url: `${servicesUrl.coriolis}/${projectId || 'null'}/replicas/${replicaId}/executions/${executionId}/actions`,
+      url: `${servicesUrl.coriolis}/${Api.projectId}/replicas/${replicaId}/executions/${executionId}/actions`,
       method: 'POST',
       data: { cancel: null },
     }).then(() => replicaId)
   }
 
   static deleteExecution(replicaId: string, executionId: string): Promise<string> {
-    let projectId = cookie.get('projectId')
-
     return Api.send({
-      url: `${servicesUrl.coriolis}/${projectId || 'null'}/replicas/${replicaId}/executions/${executionId}`,
+      url: `${servicesUrl.coriolis}/${Api.projectId}/replicas/${replicaId}/executions/${executionId}`,
       method: 'DELETE',
     }).then(() => replicaId)
   }
 
   static delete(replicaId: string): Promise<string> {
-    let projectId = cookie.get('projectId')
-
     return Api.send({
-      url: `${servicesUrl.coriolis}/${projectId || 'null'}/replicas/${replicaId}`,
+      url: `${servicesUrl.coriolis}/${Api.projectId}/replicas/${replicaId}`,
       method: 'DELETE',
     }).then(() => replicaId)
   }
 
   static deleteDisks(replicaId: string): Promise<Execution> {
-    let projectId = cookie.get('projectId')
-
     return Api.send({
-      url: `${servicesUrl.coriolis}/${projectId || 'null'}/replicas/${replicaId}/actions`,
+      url: `${servicesUrl.coriolis}/${Api.projectId}/replicas/${replicaId}/actions`,
       method: 'POST',
       data: { 'delete-disks': null },
     }).then(response => response.data.execution)

--- a/src/sources/ReplicaSource.js
+++ b/src/sources/ReplicaSource.js
@@ -85,114 +85,92 @@ class ReplicaSourceUtils {
 
 class ReplicaSource {
   static getReplicas(): Promise<MainItem[]> {
-    return new Promise((resolve, reject) => {
-      let projectId = cookie.get('projectId')
-      Api.get(`${servicesUrl.coriolis}/${projectId || 'null'}/replicas/detail`).then(response => {
-        let replicas = response.data.replicas
-        replicas = ReplicaSourceUtils.filterDeletedExecutionsInReplicas(replicas)
-        ReplicaSourceUtils.sortReplicas(replicas)
-        resolve(replicas)
-      }).catch(reject)
+    let projectId = cookie.get('projectId') || 'undefined'
+    return Api.get(`${servicesUrl.coriolis}/${projectId}/replicas/detail`).then(response => {
+      let replicas = response.data.replicas
+      replicas = ReplicaSourceUtils.filterDeletedExecutionsInReplicas(replicas)
+      ReplicaSourceUtils.sortReplicas(replicas)
+      return replicas
     })
   }
 
   static getReplicaExecutions(replicaId: string): Promise<Execution[]> {
-    return new Promise((resolve, reject) => {
-      let projectId = cookie.get('projectId')
-      Api.get(`${servicesUrl.coriolis}/${projectId || 'null'}/replicas/${replicaId}/executions/detail`).then((response) => {
-        let executions = response.data.executions
-        ReplicaSourceUtils.sortExecutionsAndTaskUpdates(executions)
+    let projectId = cookie.get('projectId') || 'undefined'
+    return Api.get(`${servicesUrl.coriolis}/${projectId}/replicas/${replicaId}/executions/detail`).then((response) => {
+      let executions = response.data.executions
+      ReplicaSourceUtils.sortExecutionsAndTaskUpdates(executions)
 
-        resolve(executions)
-      }).catch(reject)
+      return executions
     })
   }
 
   static getReplica(replicaId: string): Promise<MainItem> {
-    return new Promise((resolve, reject) => {
-      let projectId = cookie.get('projectId')
+    let projectId = cookie.get('projectId') || 'undefined'
 
-      Api.get(`${servicesUrl.coriolis}/${projectId || 'null'}/replicas/${replicaId}`).then(response => {
-        let replica = response.data.replica
-        replica.executions = ReplicaSourceUtils.filterDeletedExecutions(replica.executions)
-        ReplicaSourceUtils.sortExecutions(replica.executions)
-        resolve(replica)
-      }).catch(reject)
+    return Api.get(`${servicesUrl.coriolis}/${projectId}/replicas/${replicaId}`).then(response => {
+      let replica = response.data.replica
+      replica.executions = ReplicaSourceUtils.filterDeletedExecutions(replica.executions)
+      ReplicaSourceUtils.sortExecutions(replica.executions)
+      return replica
     })
   }
 
   static execute(replicaId: string, fields?: Field[]): Promise<Execution> {
-    return new Promise((resolve, reject) => {
-      let payload = { execution: { shutdown_instances: false } }
-      if (fields) {
-        fields.forEach(f => {
-          payload.execution[f.name] = f.value || false
-        })
-      }
-      let projectId = cookie.get('projectId')
+    let payload = { execution: { shutdown_instances: false } }
+    if (fields) {
+      fields.forEach(f => {
+        payload.execution[f.name] = f.value || false
+      })
+    }
+    let projectId = cookie.get('projectId') || 'undefined'
 
-      Api.send({
-        url: `${servicesUrl.coriolis}/${projectId || 'null'}/replicas/${replicaId}/executions`,
-        method: 'POST',
-        data: payload,
-      }).then((response) => {
-        let execution = response.data.execution
-        ReplicaSourceUtils.sortTaskUpdates(execution)
-        resolve(execution)
-      }).catch(reject)
+    return Api.send({
+      url: `${servicesUrl.coriolis}/${projectId}/replicas/${replicaId}/executions`,
+      method: 'POST',
+      data: payload,
+    }).then((response) => {
+      let execution = response.data.execution
+      ReplicaSourceUtils.sortTaskUpdates(execution)
+      return execution
     })
   }
 
   static cancelExecution(replicaId: string, executionId: string): Promise<string> {
-    return new Promise((resolve, reject) => {
-      let projectId = cookie.get('projectId')
+    let projectId = cookie.get('projectId')
 
-      Api.send({
-        url: `${servicesUrl.coriolis}/${projectId || 'null'}/replicas/${replicaId}/executions/${executionId}/actions`,
-        method: 'POST',
-        data: { cancel: null },
-      }).then(() => {
-        resolve(replicaId)
-      }).catch(reject)
-    })
+    return Api.send({
+      url: `${servicesUrl.coriolis}/${projectId || 'null'}/replicas/${replicaId}/executions/${executionId}/actions`,
+      method: 'POST',
+      data: { cancel: null },
+    }).then(() => replicaId)
   }
 
   static deleteExecution(replicaId: string, executionId: string): Promise<string> {
-    return new Promise((resolve, reject) => {
-      let projectId = cookie.get('projectId')
+    let projectId = cookie.get('projectId')
 
-      Api.send({
-        url: `${servicesUrl.coriolis}/${projectId || 'null'}/replicas/${replicaId}/executions/${executionId}`,
-        method: 'DELETE',
-      }).then(() => {
-        resolve(replicaId)
-      }).catch(reject)
-    })
+    return Api.send({
+      url: `${servicesUrl.coriolis}/${projectId || 'null'}/replicas/${replicaId}/executions/${executionId}`,
+      method: 'DELETE',
+    }).then(() => replicaId)
   }
 
   static delete(replicaId: string): Promise<string> {
-    return new Promise((resolve, reject) => {
-      let projectId = cookie.get('projectId')
+    let projectId = cookie.get('projectId')
 
-      Api.send({
-        url: `${servicesUrl.coriolis}/${projectId || 'null'}/replicas/${replicaId}`,
-        method: 'DELETE',
-      }).then(() => { resolve(replicaId) }, reject).catch(reject)
-    })
+    return Api.send({
+      url: `${servicesUrl.coriolis}/${projectId || 'null'}/replicas/${replicaId}`,
+      method: 'DELETE',
+    }).then(() => replicaId)
   }
 
   static deleteDisks(replicaId: string): Promise<Execution> {
-    return new Promise((resolve, reject) => {
-      let projectId = cookie.get('projectId')
+    let projectId = cookie.get('projectId')
 
-      Api.send({
-        url: `${servicesUrl.coriolis}/${projectId || 'null'}/replicas/${replicaId}/actions`,
-        method: 'POST',
-        data: { 'delete-disks': null },
-      }).then(response => {
-        resolve(response.data.execution)
-      }).catch(reject)
-    })
+    return Api.send({
+      url: `${servicesUrl.coriolis}/${projectId || 'null'}/replicas/${replicaId}/actions`,
+      method: 'POST',
+      data: { 'delete-disks': null },
+    }).then(response => response.data.execution)
   }
 }
 

--- a/src/sources/ScheduleSource.js
+++ b/src/sources/ScheduleSource.js
@@ -14,7 +14,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // @flow
 
-import cookie from 'js-cookie'
 import moment from 'moment'
 
 import Api from '../utils/ApiCaller'
@@ -24,7 +23,6 @@ import type { Schedule } from '../types/Schedule'
 
 class ScheduleSource {
   static scheduleSinge(replicaId: string, scheduleData: Schedule): Promise<Schedule> {
-    let projectId = cookie.get('projectId')
     let payload = {
       schedule: {},
       expiration_date: null,
@@ -47,7 +45,7 @@ class ScheduleSource {
     }
 
     return Api.send({
-      url: `${servicesUrl.coriolis}/${projectId || 'null'}/replicas/${replicaId}/schedules`,
+      url: `${servicesUrl.coriolis}/${Api.projectId}/replicas/${replicaId}/schedules`,
       method: 'POST',
       data: payload,
     }).then(response => response.data.schedule)
@@ -60,9 +58,7 @@ class ScheduleSource {
   }
 
   static getSchedules(replicaId: string): Promise<Schedule[]> {
-    let projectId = cookie.get('projectId')
-
-    return Api.get(`${servicesUrl.coriolis}/${projectId || 'null'}/replicas/${replicaId}/schedules`).then(response => {
+    return Api.get(`${servicesUrl.coriolis}/${Api.projectId}/replicas/${replicaId}/schedules`).then(response => {
       let schedules = [...response.data.schedules]
       schedules.forEach(s => {
         if (s.expiration_date) {
@@ -78,7 +74,6 @@ class ScheduleSource {
   }
 
   static addSchedule(replicaId: string, schedule: Schedule): Promise<Schedule> {
-    let projectId = cookie.get('projectId')
     let payload = {
       schedule: { hour: 0, minute: 0 },
       enabled: false,
@@ -88,16 +83,15 @@ class ScheduleSource {
     }
 
     return Api.send({
-      url: `${servicesUrl.coriolis}/${projectId || 'null'}/replicas/${replicaId}/schedules`,
+      url: `${servicesUrl.coriolis}/${Api.projectId}/replicas/${replicaId}/schedules`,
       method: 'POST',
       data: payload,
     }).then(response => response.data.schedule)
   }
 
   static removeSchedule(replicaId: string, scheduleId: string): Promise<void> {
-    let projectId = cookie.get('projectId')
     return Api.send({
-      url: `${servicesUrl.coriolis}/${projectId || 'null'}/replicas/${replicaId}/schedules/${scheduleId}`,
+      url: `${servicesUrl.coriolis}/${Api.projectId}/replicas/${replicaId}/schedules/${scheduleId}`,
       method: 'DELETE',
     }).then(() => { })
   }
@@ -109,7 +103,6 @@ class ScheduleSource {
     scheduleOldData: ?Schedule,
     unsavedData: ?Schedule
   ): Promise<Schedule> {
-    let projectId = cookie.get('projectId')
     let payload = {}
     if (scheduleData.enabled !== null && scheduleData.enabled !== undefined) {
       payload.enabled = scheduleData.enabled
@@ -136,7 +129,7 @@ class ScheduleSource {
     }
 
     return Api.send({
-      url: `${servicesUrl.coriolis}/${projectId || 'null'}/replicas/${replicaId}/schedules/${scheduleId}`,
+      url: `${servicesUrl.coriolis}/${Api.projectId}/replicas/${replicaId}/schedules/${scheduleId}`,
       method: 'PUT',
       data: payload,
     }).then(response => {

--- a/src/sources/ScheduleSource.js
+++ b/src/sources/ScheduleSource.js
@@ -24,110 +24,82 @@ import type { Schedule } from '../types/Schedule'
 
 class ScheduleSource {
   static scheduleSinge(replicaId: string, scheduleData: Schedule): Promise<Schedule> {
-    return new Promise((resolve, reject) => {
-      let projectId = cookie.get('projectId')
-      let payload = {
-        schedule: {},
-        expiration_date: null,
-        enabled: scheduleData.enabled === null || scheduleData.enabled === undefined ? false : scheduleData.enabled,
-        shutdown_instance: scheduleData.shutdown_instances === null || scheduleData.shutdown_instances === undefined ? false : scheduleData.shutdown_instances,
-      }
+    let projectId = cookie.get('projectId')
+    let payload = {
+      schedule: {},
+      expiration_date: null,
+      enabled: scheduleData.enabled === null || scheduleData.enabled === undefined ? false : scheduleData.enabled,
+      shutdown_instance: scheduleData.shutdown_instances === null || scheduleData.shutdown_instances === undefined ? false : scheduleData.shutdown_instances,
+    }
 
-      if (scheduleData.expiration_date) {
+    if (scheduleData.expiration_date) {
+      // $FlowIssue
+      payload.expiration_date = moment(scheduleData.expiration_date).toISOString()
+    }
+
+    if (scheduleData.schedule !== null && scheduleData.schedule !== undefined) {
+      Object.keys(scheduleData.schedule).forEach(prop => {
         // $FlowIssue
-        payload.expiration_date = moment(scheduleData.expiration_date).toISOString()
-      }
+        if (scheduleData.schedule[prop] !== null && scheduleData.schedule[prop] !== undefined) {
+          payload.schedule[prop] = scheduleData.schedule[prop]
+        }
+      })
+    }
 
-      if (scheduleData.schedule !== null && scheduleData.schedule !== undefined) {
-        Object.keys(scheduleData.schedule).forEach(prop => {
-          // $FlowIssue
-          if (scheduleData.schedule[prop] !== null && scheduleData.schedule[prop] !== undefined) {
-            payload.schedule[prop] = scheduleData.schedule[prop]
-          }
-        })
-      }
-
-      Api.send({
-        url: `${servicesUrl.coriolis}/${projectId || 'null'}/replicas/${replicaId}/schedules`,
-        method: 'POST',
-        data: payload,
-      }).then(response => {
-        resolve(response.data.schedule)
-      }).catch(reject)
-    })
+    return Api.send({
+      url: `${servicesUrl.coriolis}/${projectId || 'null'}/replicas/${replicaId}/schedules`,
+      method: 'POST',
+      data: payload,
+    }).then(response => response.data.schedule)
   }
 
   static scheduleMultiple(replicaId: string, schedules: Schedule[]): Promise<Schedule[]> {
-    return new Promise((resolve, reject) => {
-      let createdSchedules = []
-      let count = 0
-      schedules.forEach(schedule => {
-        ScheduleSource.scheduleSinge(replicaId, schedule).then(createdSchedule => {
-          count += 1
-          createdSchedules.push(createdSchedule)
-          if (count === schedules.length) {
-            if (createdSchedules.length > 0) {
-              resolve(createdSchedules)
-            } else {
-              reject()
-            }
-          }
-        }, () => { count += 1 })
-      })
-    })
+    return Promise.all(schedules.map(schedule => {
+      return ScheduleSource.scheduleSinge(replicaId, schedule)
+    }))
   }
 
   static getSchedules(replicaId: string): Promise<Schedule[]> {
-    return new Promise((resolve, reject) => {
-      let projectId = cookie.get('projectId')
+    let projectId = cookie.get('projectId')
 
-      Api.get(`${servicesUrl.coriolis}/${projectId || 'null'}/replicas/${replicaId}/schedules`).then(response => {
-        let schedules = [...response.data.schedules]
-
-        schedules.forEach(s => {
-          if (s.expiration_date) {
-            s.expiration_date = DateUtils.getLocalTime(s.expiration_date)
-          }
-
-          if (s.shutdown_instance) {
-            s.shutdown_instances = s.shutdown_instance
-          }
-        })
-        schedules.sort((a, b) => moment(a.created_at).diff(b.created_at))
-        resolve(schedules)
-      }).catch(reject)
+    return Api.get(`${servicesUrl.coriolis}/${projectId || 'null'}/replicas/${replicaId}/schedules`).then(response => {
+      let schedules = [...response.data.schedules]
+      schedules.forEach(s => {
+        if (s.expiration_date) {
+          s.expiration_date = DateUtils.getLocalTime(s.expiration_date)
+        }
+        if (s.shutdown_instance) {
+          s.shutdown_instances = s.shutdown_instance
+        }
+      })
+      schedules.sort((a, b) => moment(a.created_at).diff(b.created_at))
+      return schedules
     })
   }
 
   static addSchedule(replicaId: string, schedule: Schedule): Promise<Schedule> {
-    return new Promise((resolve, reject) => {
-      let projectId = cookie.get('projectId')
-      let payload = {
-        schedule: { hour: 0, minute: 0 },
-        enabled: false,
-      }
-      if (schedule && schedule.schedule) {
-        payload.schedule = { ...schedule.schedule }
-      }
+    let projectId = cookie.get('projectId')
+    let payload = {
+      schedule: { hour: 0, minute: 0 },
+      enabled: false,
+    }
+    if (schedule && schedule.schedule) {
+      payload.schedule = { ...schedule.schedule }
+    }
 
-      Api.send({
-        url: `${servicesUrl.coriolis}/${projectId || 'null'}/replicas/${replicaId}/schedules`,
-        method: 'POST',
-        data: payload,
-      }).then(response => {
-        resolve(response.data.schedule)
-      }).catch(reject)
-    })
+    return Api.send({
+      url: `${servicesUrl.coriolis}/${projectId || 'null'}/replicas/${replicaId}/schedules`,
+      method: 'POST',
+      data: payload,
+    }).then(response => response.data.schedule)
   }
 
   static removeSchedule(replicaId: string, scheduleId: string): Promise<void> {
-    return new Promise((resolve, reject) => {
-      let projectId = cookie.get('projectId')
-      Api.send({
-        url: `${servicesUrl.coriolis}/${projectId || 'null'}/replicas/${replicaId}/schedules/${scheduleId}`,
-        method: 'DELETE',
-      }).then(() => { resolve() }).catch(reject)
-    })
+    let projectId = cookie.get('projectId')
+    return Api.send({
+      url: `${servicesUrl.coriolis}/${projectId || 'null'}/replicas/${replicaId}/schedules/${scheduleId}`,
+      method: 'DELETE',
+    }).then(() => { })
   }
 
   static updateSchedule(
@@ -137,47 +109,45 @@ class ScheduleSource {
     scheduleOldData: ?Schedule,
     unsavedData: ?Schedule
   ): Promise<Schedule> {
-    return new Promise((resolve, reject) => {
-      let projectId = cookie.get('projectId')
-      let payload = {}
-      if (scheduleData.enabled !== null && scheduleData.enabled !== undefined) {
-        payload.enabled = scheduleData.enabled
+    let projectId = cookie.get('projectId')
+    let payload = {}
+    if (scheduleData.enabled !== null && scheduleData.enabled !== undefined) {
+      payload.enabled = scheduleData.enabled
+    }
+    if (scheduleData.shutdown_instances !== null && scheduleData.shutdown_instances !== undefined) {
+      payload.shutdown_instance = scheduleData.shutdown_instances
+    }
+    if (unsavedData && unsavedData.expiration_date) {
+      payload.expiration_date = moment(unsavedData.expiration_date).toISOString()
+    }
+    if (unsavedData && unsavedData.schedule !== null && unsavedData.schedule !== undefined && Object.keys(unsavedData.schedule).length) {
+      if (scheduleOldData) {
+        payload.schedule = { ...scheduleOldData.schedule }
       }
-      if (scheduleData.shutdown_instances !== null && scheduleData.shutdown_instances !== undefined) {
-        payload.shutdown_instance = scheduleData.shutdown_instances
-      }
-      if (unsavedData && unsavedData.expiration_date) {
-        payload.expiration_date = moment(unsavedData.expiration_date).toISOString()
-      }
-      if (unsavedData && unsavedData.schedule !== null && unsavedData.schedule !== undefined && Object.keys(unsavedData.schedule).length) {
-        if (scheduleOldData) {
-          payload.schedule = { ...scheduleOldData.schedule }
-        }
+      // $FlowIssue
+      Object.keys(unsavedData.schedule).forEach(prop => {
         // $FlowIssue
-        Object.keys(unsavedData.schedule).forEach(prop => {
-          // $FlowIssue
-          if (unsavedData.schedule[prop] !== null && unsavedData.schedule[prop] !== undefined) {
-            payload.schedule[prop] = unsavedData.schedule[prop]
-          } else {
-            delete payload.schedule[prop]
-          }
-        })
-      }
+        if (unsavedData.schedule[prop] !== null && unsavedData.schedule[prop] !== undefined) {
+          payload.schedule[prop] = unsavedData.schedule[prop]
+        } else {
+          delete payload.schedule[prop]
+        }
+      })
+    }
 
-      Api.send({
-        url: `${servicesUrl.coriolis}/${projectId || 'null'}/replicas/${replicaId}/schedules/${scheduleId}`,
-        method: 'PUT',
-        data: payload,
-      }).then(response => {
-        let s = { ...response.data.schedule }
-        if (s.expiration_date) {
-          s.expiration_date = DateUtils.getLocalTime(s.expiration_date)
-        }
-        if (s.shutdown_instance) {
-          s.shutdown_instances = s.shutdown_instance
-        }
-        resolve(s)
-      }).catch(reject)
+    return Api.send({
+      url: `${servicesUrl.coriolis}/${projectId || 'null'}/replicas/${replicaId}/schedules/${scheduleId}`,
+      method: 'PUT',
+      data: payload,
+    }).then(response => {
+      let s = { ...response.data.schedule }
+      if (s.expiration_date) {
+        s.expiration_date = DateUtils.getLocalTime(s.expiration_date)
+      }
+      if (s.shutdown_instance) {
+        s.shutdown_instances = s.shutdown_instance
+      }
+      return s
     })
   }
 }

--- a/src/sources/WizardSource.js
+++ b/src/sources/WizardSource.js
@@ -14,8 +14,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // @flow
 
-import cookie from 'js-cookie'
-
 import Api from '../utils/ApiCaller'
 import notificationStore from '../stores/NotificationStore'
 import { OptionsSchemaPlugin } from '../plugins/endpoint'
@@ -26,8 +24,6 @@ import type { MainItem } from '../types/MainItem'
 
 class WizardSource {
   static create(type: string, data: WizardData): Promise<MainItem> {
-    let projectId = cookie.get('projectId')
-
     const parser = data.target ? OptionsSchemaPlugin[data.target.type] || OptionsSchemaPlugin.default : OptionsSchemaPlugin.default
     let payload = {}
     payload[type] = {
@@ -43,7 +39,7 @@ class WizardSource {
     }
 
     return Api.send({
-      url: `${servicesUrl.coriolis}/${projectId || 'null'}/${type}s`,
+      url: `${servicesUrl.coriolis}/${Api.projectId}/${type}s`,
       method: 'POST',
       data: payload,
     }).then(response => response.data[type])

--- a/src/stores/AzureStore.js
+++ b/src/stores/AzureStore.js
@@ -81,8 +81,6 @@ class AzureStore {
       }
       this.assessmentsProjectId = cookieProjectId
       this.assessments = assessments
-    }).catch(() => {
-      this.loadingAssessments = false
     })
   }
 

--- a/src/utils/ApiCaller.js
+++ b/src/utils/ApiCaller.js
@@ -101,7 +101,7 @@ class ApiCaller {
             }
           }
 
-          if (error.response.status === 401 && window.location.hash !== loginUrl) {
+          if (error.response.status === 401 && window.location.hash !== loginUrl && error.request.responseURL.indexOf('/proxy/') === -1) {
             window.location.href = '/'
           }
 

--- a/src/utils/ApiCaller.js
+++ b/src/utils/ApiCaller.js
@@ -16,6 +16,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import axios from 'axios'
 import type { AxiosXHRConfig, $AxiosXHR } from 'axios'
+import cookie from 'js-cookie'
 
 import notificationStore from '../stores/NotificationStore'
 
@@ -47,6 +48,10 @@ const addCancelable = (cancelable: Cancelable) => {
 class ApiCaller {
   constructor() {
     axios.defaults.headers.common['Content-Type'] = 'application/json'
+  }
+
+  get projectId(): string {
+    return cookie.get('projectId') || 'undefined'
   }
 
   cancelRequests(cancelRequestId: string) {


### PR DESCRIPTION
**Remove redundant `Promise` wrapper from API calls**

The 'axios' API Caller returns a promise so it is no longer necessary to
wrap the API calls with a `Promise`.

This also includes using `Promise.all` when depending on multiple API
call responses.

**Remove cookie dependencies from all 'Source' files**

Project ID is no longer retrieved from cookies in all 'Source' files,
instead it is retrieved from the API Caller class, which now handles the
retrieval of project ID from cookies. This allows having one place where
cookie retrieval and validation happens.

Includes an update to a unit test.