### PR TITLE
Use local timezone label in schedule component

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "mobx": "^3.6.1",
     "mobx-react": "^4.4.2",
     "moment": "^2.18.1",
+    "moment-timezone": "^0.5.21",
     "ms-rest-azure": "^2.4.5",
     "path": "^0.12.7",
     "raw-loader": "^0.5.1",

--- a/private/cypress/integration/4 - migrations and replicas/VmWare -> Azure Replica/2 - Scheduler Operations.js
+++ b/private/cypress/integration/4 - migrations and replicas/VmWare -> Azure Replica/2 - Scheduler Operations.js
@@ -54,7 +54,7 @@ describe('Scheduler Operations', () => {
   })
 
   it('Changes timezone', () => {
-    cy.get('div').contains('Local Time').click()
+    cy.get('[data-test-id="schedule-timezoneDropdown"]').click()
     cy.get('div').contains('UTC').click()
     let utcTime = 4 + (new Date().getTimezoneOffset() / 60)
     if (utcTime < 10) {

--- a/src/components/organisms/Schedule/Schedule.jsx
+++ b/src/components/organisms/Schedule/Schedule.jsx
@@ -16,6 +16,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from 'react'
 import styled from 'styled-components'
+import moment from 'moment-timezone'
 import { observer } from 'mobx-react'
 
 import Button from '../../atoms/Button'
@@ -320,7 +321,7 @@ class Schedule extends React.Component<Props, State> {
     }
 
     let timezoneItems = [
-      { label: 'Local Time', value: 'local' },
+      { label: `${moment.tz(moment.tz.guess()).zoneAbbr()} (local time)`, value: 'local' },
       { label: 'UTC', value: 'utc' },
     ]
     let selectedItem = this.props.timezone || timezoneItems[0].value

--- a/yarn.lock
+++ b/yarn.lock
@@ -5578,6 +5578,16 @@ mobx@^3.6.1:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/mobx/-/mobx-3.6.1.tgz#ae63a8f00e1485a740d0f91ae2f6a5f68e303bea"
 
+moment-timezone@^0.5.21:
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.21.tgz#3cba247d84492174dbf71de2a9848fa13207b845"
+  dependencies:
+    moment ">= 2.9.0"
+
+"moment@>= 2.9.0":
+  version "2.22.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
+
 moment@^2.18.1, moment@~2.18.1:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"


### PR DESCRIPTION
Using `moment-timezone` module we can get the local timezone label
abbreviation (ex.: EET, EEST, PST).