### PR TITLE
Add project switching support to notifications

### DIFF
--- a/src/components/organisms/PageHeader/PageHeader.jsx
+++ b/src/components/organisms/PageHeader/PageHeader.jsx
@@ -179,6 +179,7 @@ class PageHeader extends React.Component<Props, State> {
   handleProjectChange(project: Project) {
     userStore.switchProject(project.id).then(() => {
       projectStore.getProjects()
+      notificationStore.loadData()
 
       if (this.props.onProjectChange) {
         this.props.onProjectChange(project)

--- a/src/sources/NotificationSource.js
+++ b/src/sources/NotificationSource.js
@@ -18,17 +18,45 @@ import moment from 'moment'
 
 import { servicesUrl } from '../config'
 import Api from '../utils/ApiCaller'
-import type { NotificationItemData } from '../types/NotificationItem'
-
+import type { NotificationItemData, NotificationItem } from '../types/NotificationItem'
 
 class NotificationStorage {
+  static storeName: string = 'seenNotifications'
+
   static loadSeen(): ?NotificationItemData[] {
-    let notifications = localStorage.getItem('seen-notifications')
-    return notifications ? JSON.parse(notifications) : null
+    let storage: ?string = localStorage.getItem(this.storeName)
+
+    if (!storage) {
+      return null
+    }
+
+    let notificationItems: NotificationItem[] = JSON.parse(storage)
+    let notificationItem: ?NotificationItem = notificationItems.find(n => n.projectId === Api.projectId)
+
+    if (!notificationItem) {
+      return null
+    }
+
+    return notificationItem.items
   }
 
-  static saveSeen(notificationItems: NotificationItemData[]) {
-    localStorage.setItem('seen-notifications', JSON.stringify(notificationItems))
+  static saveSeen(items: NotificationItemData[]) {
+    let currentStorage: ?string = localStorage.getItem(this.storeName)
+    let currentItems: NotificationItem[] = []
+
+    if (currentStorage) {
+      currentItems = (JSON.parse(currentStorage): NotificationItem[])
+      currentItems = currentItems.filter(i => i.projectId !== Api.projectId)
+    }
+
+    let newItem: NotificationItem = {
+      projectId: Api.projectId,
+      items,
+    }
+    localStorage.setItem(this.storeName, JSON.stringify([
+      ...currentItems,
+      newItem,
+    ]))
   }
 
   static clean(notificationItems: NotificationItemData[]) {

--- a/src/types/NotificationItem.js
+++ b/src/types/NotificationItem.js
@@ -38,3 +38,7 @@ export type NotificationItemData = {
   updatedAt?: string,
 }
 
+export type NotificationItem = {
+  projectId: string,
+  items: NotificationItemData[],
+}


### PR DESCRIPTION
The seen notifications are now tied to a project id, so switching to a
new project no longer clears all the previously seen ones.
The notifications are now refreshed as soon as the project is switched,
so we don't have to wait for the 5 seconds poll timer after switching.