### PR TITLE
Don't use the label dictionary for all enum values

### DIFF
--- a/src/components/molecules/WizardOptionsField/WizardOptionsField.jsx
+++ b/src/components/molecules/WizardOptionsField/WizardOptionsField.jsx
@@ -118,13 +118,14 @@ class WizardOptionsField extends React.Component<Props> {
   }
 
   renderEnumDropdown() {
+    const useDictionary = LabelDictionary.enumFields.find(f => f === this.props.name)
     let items = this.props.enum.map(e => {
       if (typeof e !== 'string' && e.separator === true) {
         return e
       }
 
       return {
-        label: typeof e === 'string' ? LabelDictionary.get(e) : e.name,
+        label: typeof e === 'string' ? (useDictionary ? LabelDictionary.get(e) : e) : e.name,
         value: typeof e === 'string' ? e : e.id,
       }
     })

--- a/src/utils/LabelDictionary.js
+++ b/src/utils/LabelDictionary.js
@@ -47,6 +47,10 @@ class LabelDictionary {
     duplicate_to_project: { label: 'Project', description: 'Duplicate endpoint to selected project' },
   }
 
+  // Fields which have enums for which dictionary labels should be used.
+  // If a field has enums and is not in this array, their values will be used as labels
+  static enumFields = ['port_reuse_policy']
+
   static get(fieldName: ?string): string {
     let labelInfo = fieldName ? this.dictionary[fieldName] : null
     if (labelInfo) {


### PR DESCRIPTION
Enum values should not be transformed by the dictionary in order to be
displayed.
There's a new property in the dictionary which holds all the enum fields
which are an exception to this rule (currently there's only one such
field: 'port_reuse_policy', which means that the enums of this field
will be transformed by the dictionary).