### PR TITLE
Fix options field rendering of empty 'enum' array

### DIFF
--- a/src/components/molecules/WizardOptionsField/WizardOptionsField.jsx
+++ b/src/components/molecules/WizardOptionsField/WizardOptionsField.jsx
@@ -197,7 +197,7 @@ class WizardOptionsField extends React.Component<Props> {
         field = this.renderSwitch({ triState: true })
         break
       case 'string':
-        if (this.props.enum) {
+        if (this.props.enum && this.props.enum.length) {
           field = this.renderEnumDropdown()
         } else {
           field = this.renderTextInput()


### PR DESCRIPTION
If the field is an enum with an empty array, don't render a dropdown
with an empty list, instead render a text input.