### PR TITLE
Refactor all `null` / `undefined` checks

### DIFF
--- a/server/proxy.js
+++ b/server/proxy.js
@@ -41,7 +41,7 @@ module.exports = app => {
     let url = req.url.substr('/proxy/'.length)
     let headers = {}
     forwardHeaders.forEach(headerName => {
-      if (req.headers[headerName] !== null && req.headers[headerName] !== undefined) {
+      if (req.headers[headerName] != null) {
         headers[headerName] = req.headers[headerName]
       }
     })

--- a/src/components/atoms/Switch/Switch.jsx
+++ b/src/components/atoms/Switch/Switch.jsx
@@ -62,7 +62,7 @@ const getInputBorderColor = props => {
     return Palette.grayscale[5]
   }
 
-  if (props.triState && (props.checked === null || props.checked === undefined)) {
+  if (props.triState && props.checked == null) {
     return Palette.grayscale[2]
   }
 
@@ -84,7 +84,7 @@ const getThumbLeft = props => {
     return props.height - 1
   }
 
-  if (props.triState && (props.checked === null || props.checked === undefined)) {
+  if (props.triState && props.checked == null) {
     return (props.height / 2) - 1
   }
 
@@ -127,7 +127,7 @@ type Props = {
   checkedLabel: string,
   uncheckedLabel: string,
   'data-test-id'?: string,
-  style: {[string]: mixed},
+  style: { [string]: mixed },
 }
 type State = {
   lastChecked: ?boolean,
@@ -150,7 +150,7 @@ class Switch extends React.Component<Props, State> {
 
   getLabel() {
     let label = this.props.checked ? this.props.checkedLabel : this.props.uncheckedLabel
-    if (this.props.triState && (this.props.checked === null || this.props.checked === undefined)) {
+    if (this.props.triState && this.props.checked == null) {
       label = 'Not Set'
     }
 

--- a/src/components/molecules/AutocompleteDropdown/AutocompleteDropdown.jsx
+++ b/src/components/molecules/AutocompleteDropdown/AutocompleteDropdown.jsx
@@ -184,17 +184,17 @@ class AutocompleteDropdown extends React.Component<Props, State> {
   getLabel(item: any) {
     let labelField = this.props.labelField || 'label'
 
-    if (item === null || item === undefined) {
+    if (item == null) {
       return ''
     }
 
-    return (item[labelField] !== null && item[labelField] !== undefined && item[labelField].toString()) || item.toString()
+    return (item[labelField] != null && item[labelField].toString()) || item.toString()
   }
 
   getValue(item: any) {
     let valueField = this.props.valueField || 'value'
 
-    if (item === null || item === undefined) {
+    if (item == null) {
       return null
     }
 
@@ -202,7 +202,7 @@ class AutocompleteDropdown extends React.Component<Props, State> {
       return item
     }
 
-    return (item[valueField] !== null && item[valueField] !== undefined && item[valueField].toString()) || null
+    return (item[valueField] != null && item[valueField].toString()) || null
   }
 
   getFilteredItems(props?: ?Props, searchValue?: string): any[] {
@@ -360,7 +360,7 @@ class AutocompleteDropdown extends React.Component<Props, State> {
               onMouseLeave={() => { this.handleItemMouseLeave(i) }}
               onClick={() => { this.handleItemClick(item) }}
               selected={value !== null && value === selectedValue}
-              dim={this.props.dimNullValue && (value === null || value === undefined)}
+              dim={this.props.dimNullValue && value == null}
             >
               {label}
               {duplicatedLabel ? <DuplicatedLabel> (<span>{value || ''}</span>)</DuplicatedLabel> : ''}

--- a/src/components/molecules/Dropdown/Dropdown.jsx
+++ b/src/components/molecules/Dropdown/Dropdown.jsx
@@ -254,21 +254,21 @@ class Dropdown extends React.Component<Props, State> {
   getLabel(item: any) {
     let labelField = this.props.labelField || 'label'
 
-    if (item === null || item === undefined) {
+    if (item == null) {
       return this.props.noSelectionMessage
     }
 
-    return (item[labelField] !== null && item[labelField] !== undefined && item[labelField].toString()) || (item.value && item.value.toString()) || item.toString()
+    return (item[labelField] != null && item[labelField].toString()) || (item.value && item.value.toString()) || item.toString()
   }
 
   getValue(item: any) {
     let valueField = this.props.valueField || 'value'
 
-    if (item === null || item === undefined) {
+    if (item == null) {
       return null
     }
 
-    return (item[valueField] !== null && item[valueField] !== undefined && item[valueField].toString()) || this.getLabel(item)
+    return (item[valueField] != null && item[valueField].toString()) || this.getLabel(item)
   }
 
   handleScroll() {

--- a/src/components/molecules/ScheduleItem/ScheduleItem.jsx
+++ b/src/components/molecules/ScheduleItem/ScheduleItem.jsx
@@ -109,11 +109,11 @@ type Props = {
 @observer
 class ScheduleItem extends React.Component<Props> {
   getFieldValue(items: Field[], fieldName: string, zeroBasedIndex?: boolean, defaultSelectedIndex?: number) {
-    if (this.props.item.schedule === null || this.props.item.schedule === undefined) {
+    if (this.props.item.schedule == null) {
       return defaultSelectedIndex !== undefined ? items[defaultSelectedIndex] : items[0]
     }
 
-    if (this.props.item.schedule[fieldName] === null || this.props.item.schedule[fieldName] === undefined) {
+    if (this.props.item.schedule[fieldName] == null) {
       return items[0]
     }
 
@@ -153,7 +153,7 @@ class ScheduleItem extends React.Component<Props> {
   }
 
   handleHourChange(hour: number) {
-    if (this.props.timezone === 'local' && hour !== null && hour !== undefined) {
+    if (this.props.timezone === 'local' && hour != null) {
       hour = DateUtils.getUtcHour(hour)
     }
 
@@ -177,7 +177,7 @@ class ScheduleItem extends React.Component<Props> {
     executionOptions.forEach(o => {
       let scheduleValue = this.props.item[o.name]
       let optionValue = o.defaultValue !== undefined ? o.defaultValue : false
-      if (scheduleValue !== undefined && scheduleValue !== null && scheduleValue !== optionValue) {
+      if (scheduleValue != null && scheduleValue !== optionValue) {
         isChanged = true
       }
     })

--- a/src/components/molecules/WizardOptionsField/test.jsx
+++ b/src/components/molecules/WizardOptionsField/test.jsx
@@ -54,13 +54,13 @@ describe('WizardOptionsField Component', () => {
 
   it('renders enum string', () => {
     let wrapper = wrap({
-      name: 'the_name',
+      name: 'port_reuse_policy',
       type: 'string',
       value: 'reuse_ports',
       enum: ['keep_mac', 'reuse_ports', 'replace_mac'],
     })
-    expect(wrapper.find('enumDropdown-the_name').prop('selectedItem').label).toBe('Reuse Existing Ports')
-    expect(wrapper.find('enumDropdown-the_name').prop('items')[3].value).toBe('replace_mac')
+    expect(wrapper.find('enumDropdown-port_reuse_policy').prop('selectedItem').label).toBe('Reuse Existing Ports')
+    expect(wrapper.find('enumDropdown-port_reuse_policy').prop('items')[3].value).toBe('replace_mac')
   })
 
   it('renders object table', () => {

--- a/src/components/organisms/AssessmentDetailsContent/AssessmentDetailsContent.jsx
+++ b/src/components/organisms/AssessmentDetailsContent/AssessmentDetailsContent.jsx
@@ -97,7 +97,7 @@ const LoadingText = styled.div`
   font-size: 18px;
   margin-top: 32px;
 `
-const TableStyled = styled(Table) `
+const TableStyled = styled(Table)`
   margin-top: 62px;
   ${props => props.addWidthPadding ? css`
     margin-left: -24px;
@@ -445,7 +445,7 @@ class AssessmentDetailsContent extends React.Component<Props> {
     }
 
     if (this.props.instancesDetailsLoading) {
-      if (this.props.instancesDetailsProgress !== undefined && this.props.instancesDetailsProgress !== null) {
+      if (this.props.instancesDetailsProgress != null) {
         loadingProgress = Math.round(this.props.instancesDetailsProgress * 100)
       }
       message = 'Loading instances details, please wait ...'

--- a/src/components/organisms/ReplicaExecutionOptions/ReplicaExecutionOptions.jsx
+++ b/src/components/organisms/ReplicaExecutionOptions/ReplicaExecutionOptions.jsx
@@ -49,7 +49,7 @@ const Buttons = styled.div`
   justify-content: space-between;
   width: 100%;
 `
-const WizardOptionsFieldStyled = styled(WizardOptionsField) `
+const WizardOptionsFieldStyled = styled(WizardOptionsField)`
   width: 319px;
   justify-content: space-between;
 `
@@ -86,7 +86,7 @@ class ReplicaExecutionOptions extends React.Component<Props, State> {
   }
 
   getFieldValue(field: Field) {
-    if (!this.props.options || this.props.options[field.name] === null || this.props.options[field.name] === undefined) {
+    if (!this.props.options || this.props.options[field.name] == null) {
       return field.value
     }
 

--- a/src/components/organisms/Schedule/Schedule.jsx
+++ b/src/components/organisms/Schedule/Schedule.jsx
@@ -206,7 +206,7 @@ class Schedule extends React.Component<Props, State> {
     executionOptions.forEach(o => {
       let scheduleValue = schedule[o.name]
       let optionValue = o.defaultValue !== undefined ? o.defaultValue : false
-      if (scheduleValue !== undefined && scheduleValue !== null && scheduleValue !== optionValue) {
+      if (scheduleValue != null && scheduleValue !== optionValue) {
         isChanged = true
       }
     })
@@ -227,7 +227,7 @@ class Schedule extends React.Component<Props, State> {
       return false
     }
     let data = isRootField ? unsavedSchedule : unsavedSchedule.schedule
-    if (data && data[fieldName] !== undefined && data[fieldName] !== null) {
+    if (data && data[fieldName] != null) {
       return true
     }
     return false

--- a/src/components/organisms/WizardPageContent/WizardPageContent.jsx
+++ b/src/components/organisms/WizardPageContent/WizardPageContent.jsx
@@ -202,11 +202,11 @@ class WizardPageContent extends React.Component<Props, State> {
           return false
         }
         if (fieldValue === undefined) {
-          return field.default !== null && field.default !== undefined
+          return field.default != null
         }
         return Boolean(fieldValue)
       }
-      return field.default !== null && field.default !== undefined
+      return field.default != null
     }
 
     let schema = this.props.providerStore.optionsSchema

--- a/src/components/organisms/WizardSummary/WizardSummary.jsx
+++ b/src/components/organisms/WizardSummary/WizardSummary.jsx
@@ -150,21 +150,21 @@ class WizardSummary extends React.Component<Props> {
       return null
     }
 
-    if (scheduleInfo.month === undefined || scheduleInfo.month === null) {
+    if (scheduleInfo.month == null) {
       monthLabel = 'Every month'
     } else {
       monthLabel = `Every ${moment.months()[scheduleInfo.month ? scheduleInfo.month - 1 : 0]}`
     }
 
     let dayOfMonthLabel
-    if (scheduleInfo.dom === null || scheduleInfo.dom === undefined) {
+    if (scheduleInfo.dom == null) {
       dayOfMonthLabel = 'every day'
     } else {
       dayOfMonthLabel = `every ${DateUtils.getOrdinalDay(scheduleInfo.dom)}`
     }
 
     let dayOfWeekLabel
-    if (scheduleInfo.dow === null || scheduleInfo.dow === undefined) {
+    if (scheduleInfo.dow == null) {
       dayOfWeekLabel = 'every weekday'
     } else {
       // $FlowIssue
@@ -174,13 +174,13 @@ class WizardSummary extends React.Component<Props> {
 
     let padNumber = number => (number || 0) < 10 ? `0${number || 0}` : (number || 0).toString()
     let timeLabel
-    if (scheduleInfo.minute === null || scheduleInfo.minute === undefined) {
-      if (scheduleInfo.hour === null || scheduleInfo.hour === undefined) {
+    if (scheduleInfo.minute == null) {
+      if (scheduleInfo.hour == null) {
         timeLabel = 'every hour, every minute'
       } else {
         timeLabel = `at ${padNumber(scheduleInfo.hour)} o'clock, every minute`
       }
-    } else if (scheduleInfo.hour === null || scheduleInfo.hour === undefined) {
+    } else if (scheduleInfo.hour == null) {
       timeLabel = `every hour, at minute ${padNumber(scheduleInfo.minute)}`
     } else {
       timeLabel = `at ${padNumber(scheduleInfo.hour)}:${padNumber(scheduleInfo.minute)}`
@@ -249,9 +249,7 @@ class WizardSummary extends React.Component<Props> {
           {this.props.wizardType === 'replica' ? executeNowOption : null}
           {this.props.data.selectedInstances && this.props.data.selectedInstances.length > 1 ? separateVmOption : null}
           {data.options ? Object.keys(data.options).map(optionName => {
-            if (optionName === 'execute_now' || optionName === 'separate_vm'
-              // $FlowIssue  
-              || data.options[optionName] === null || data.options[optionName] === undefined) {
+            if (optionName === 'execute_now' || optionName === 'separate_vm' || !data.options || data.options[optionName] == null) {
               return null
             }
 
@@ -275,7 +273,7 @@ class WizardSummary extends React.Component<Props> {
   renderNetworksSection() {
     let data = this.props.data
 
-    if (data.networks === null || data.networks === undefined) {
+    if (data.networks == null) {
       return null
     }
 

--- a/src/components/pages/WizardPage/WizardPage.jsx
+++ b/src/components/pages/WizardPage/WizardPage.jsx
@@ -34,7 +34,6 @@ import notificationStore from '../../../stores/NotificationStore'
 import scheduleStore from '../../../stores/ScheduleStore'
 import replicaStore from '../../../stores/ReplicaStore'
 import KeyboardManager from '../../../utils/KeyboardManager'
-import O from '../../../utils/ObjectUtils'
 import { wizardConfig, executionOptions, providersWithExtraOptions } from '../../../config'
 import type { MainItem } from '../../../types/MainItem'
 import type { Endpoint as EndpointType } from '../../../types/Endpoint'
@@ -312,7 +311,7 @@ class WizardPage extends React.Component<Props, State> {
         let envData = {}
         validFields.forEach(fn => {
           envData[fn] = wizardStore.data.options ? wizardStore.data.options[fn] : null
-          if (!O.isValid(envData[fn])) {
+          if (envData[fn] == null) {
             let schemaField = findFieldInSchema(fn)
             if (schemaField && schemaField.default) {
               envData[fn] = schemaField.default
@@ -403,7 +402,7 @@ class WizardPage extends React.Component<Props, State> {
     let data = wizardStore.data
     let separateVms = true
 
-    if (data.options && data.options.separate_vm !== null && data.options.separate_vm !== undefined) {
+    if (data.options && data.options.separate_vm != null) {
       separateVms = data.options.separate_vm
     }
 
@@ -436,7 +435,7 @@ class WizardPage extends React.Component<Props, State> {
   executeCreatedReplica(replica: MainItem) {
     let options = wizardStore.data.options
     let executeNow = true
-    if (options && options.execute_now !== null && options.execute_now !== undefined) {
+    if (options && options.execute_now != null) {
       executeNow = options.execute_now
     }
     if (!executeNow) {
@@ -444,7 +443,7 @@ class WizardPage extends React.Component<Props, State> {
     }
 
     let executeNowOptions = executionOptions.map(field => {
-      if (options && options[field.name] !== null && options[field.name] !== undefined) {
+      if (options && options[field.name] != null) {
         return { name: field.name, value: options[field.name] }
       }
       return field

--- a/src/plugins/endpoint/default/OptionsSchemaPlugin.js
+++ b/src/plugins/endpoint/default/OptionsSchemaPlugin.js
@@ -71,9 +71,7 @@ export const defaultGetDestinationEnv = (data: WizardData): any => {
 
   if (data.options) {
     Object.keys(data.options).forEach(optionName => {
-      if (specialOptions.find(o => o === optionName)
-        // $FlowIssue
-        || data.options[optionName] === null || data.options[optionName] === undefined) {
+      if (specialOptions.find(o => o === optionName) || !data.options || data.options[optionName] == null) {
         return
       }
       if (optionName.indexOf('/') > 0) {

--- a/src/sources/AssessmentSource.js
+++ b/src/sources/AssessmentSource.js
@@ -52,7 +52,7 @@ class AssessmentSource {
       if (option.name === 'use_replica') {
         return
       }
-      if (option.value !== null && option.value !== undefined) {
+      if (option.value != null) {
         payload[type][option.name] = option.value
       }
     })

--- a/src/sources/ProjectSource.js
+++ b/src/sources/ProjectSource.js
@@ -17,11 +17,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import Api from '../utils/ApiCaller'
 
 import UserSource from './UserSource'
-import ObjectUtils from '../utils/ObjectUtils'
 import { servicesUrl, coriolisUrl } from '../config'
-/* eslint import/no-duplicates: off */
-import type { Project, Role } from '../types/Project'
-import type { RoleAssignment } from '../types/Project'
+import type { Project, Role, RoleAssignment } from '../types/Project'
 import type { User } from '../types/User'
 
 class ProjectsSource {
@@ -87,13 +84,13 @@ class ProjectsSource {
 
   static update(projectId: string, project: Project): Promise<Project> {
     let data = { project: {} }
-    if (ObjectUtils.isValid(project.name)) {
+    if (project.name != null) {
       data.project.name = project.name
     }
-    if (ObjectUtils.isValid(project.description)) {
+    if (project.description != null) {
       data.project.description = project.description
     }
-    if (ObjectUtils.isValid(project.enabled)) {
+    if (project.description != null) {
       data.project.enabled = project.enabled
     }
 
@@ -115,10 +112,10 @@ class ProjectsSource {
     let data = { project: {} }
 
     data.project.name = project.name
-    if (ObjectUtils.isValid(project.enabled)) {
+    if (project.enabled != null) {
       data.project.enabled = project.enabled
     }
-    if (ObjectUtils.isValid(project.description)) {
+    if (project.description != null) {
       data.project.description = project.description
     }
     let addedProject: Project

--- a/src/sources/ReplicaSource.js
+++ b/src/sources/ReplicaSource.js
@@ -36,7 +36,7 @@ class ReplicaSourceUtils {
       return executions
     }
 
-    return executions.filter(execution => execution.deleted_at === null || execution.deleted_at === undefined)
+    return executions.filter(execution => execution.deleted_at == null)
   }
 
   static sortReplicas(replicas) {

--- a/src/sources/ScheduleSource.js
+++ b/src/sources/ScheduleSource.js
@@ -26,8 +26,8 @@ class ScheduleSource {
     let payload = {
       schedule: {},
       expiration_date: null,
-      enabled: scheduleData.enabled === null || scheduleData.enabled === undefined ? false : scheduleData.enabled,
-      shutdown_instance: scheduleData.shutdown_instances === null || scheduleData.shutdown_instances === undefined ? false : scheduleData.shutdown_instances,
+      enabled: scheduleData.enabled == null ? false : scheduleData.enabled,
+      shutdown_instance: scheduleData.shutdown_instances == null ? false : scheduleData.shutdown_instances,
     }
 
     if (scheduleData.expiration_date) {
@@ -35,10 +35,9 @@ class ScheduleSource {
       payload.expiration_date = moment(scheduleData.expiration_date).toISOString()
     }
 
-    if (scheduleData.schedule !== null && scheduleData.schedule !== undefined) {
+    if (scheduleData.schedule != null) {
       Object.keys(scheduleData.schedule).forEach(prop => {
-        // $FlowIssue
-        if (scheduleData.schedule[prop] !== null && scheduleData.schedule[prop] !== undefined) {
+        if (scheduleData.schedule && scheduleData.schedule[prop] != null) {
           payload.schedule[prop] = scheduleData.schedule[prop]
         }
       })
@@ -104,21 +103,21 @@ class ScheduleSource {
     unsavedData: ?Schedule
   ): Promise<Schedule> {
     let payload = {}
-    if (scheduleData.enabled !== null && scheduleData.enabled !== undefined) {
+    if (scheduleData.enabled != null) {
       payload.enabled = scheduleData.enabled
     }
-    if (scheduleData.shutdown_instances !== null && scheduleData.shutdown_instances !== undefined) {
+    if (scheduleData.shutdown_instances != null) {
       payload.shutdown_instance = scheduleData.shutdown_instances
     }
     if (unsavedData && unsavedData.expiration_date) {
       payload.expiration_date = moment(unsavedData.expiration_date).toISOString()
     }
-    if (unsavedData && unsavedData.schedule !== null && unsavedData.schedule !== undefined && Object.keys(unsavedData.schedule).length) {
+    if (unsavedData && unsavedData.schedule != null && Object.keys(unsavedData.schedule).length) {
       if (scheduleOldData) {
         payload.schedule = { ...scheduleOldData.schedule }
       }
       Object.keys(unsavedData.schedule).forEach(prop => {
-        if (unsavedData && unsavedData.schedule && unsavedData.schedule[prop] !== null && unsavedData.schedule[prop] !== undefined) {
+        if (unsavedData && unsavedData.schedule && unsavedData.schedule[prop] != null) {
           payload.schedule[prop] = unsavedData.schedule[prop]
         } else {
           delete payload.schedule[prop]

--- a/src/sources/UserSource.js
+++ b/src/sources/UserSource.js
@@ -182,7 +182,7 @@ class UserSource {
     if (user.description || oldData.description) {
       data.user.description = user.description
     }
-    if (user.enabled !== undefined && user.enabled !== null) {
+    if (user.enabled != null) {
       data.user.enabled = user.enabled
     }
     if (user.name) {
@@ -231,7 +231,7 @@ class UserSource {
     let data = { user: {} }
     data.user.name = user.name
     data.user.password = user.password || ''
-    data.user.enabled = user.enabled === null || user.enabled === undefined ? true : user.enabled
+    data.user.enabled = user.enabled == null ? true : user.enabled
 
     if (user.email) {
       data.user.email = user.email

--- a/src/sources/WizardSource.js
+++ b/src/sources/WizardSource.js
@@ -34,7 +34,7 @@ class WizardSource {
       notes: '',
     }
 
-    if (data.options && data.options.skip_os_morphing !== null && data.options.skip_os_morphing !== undefined) {
+    if (data.options && data.options.skip_os_morphing != null) {
       payload[type].skip_os_morphing = data.options.skip_os_morphing
     }
 

--- a/src/stores/ScheduleStore.js
+++ b/src/stores/ScheduleStore.js
@@ -23,7 +23,7 @@ const updateSchedule = (schedules, id, data) => {
   return schedules.map(schedule => {
     if (schedule.id === id) {
       let newSchedule = { ...schedule, ...data }
-      if (data.schedule !== null && data.schedule !== undefined && Object.keys(data.schedule).length) {
+      if (data.schedule != null && Object.keys(data.schedule).length) {
         newSchedule.schedule = { ...schedule.schedule, ...data.schedule || {} }
       }
       return newSchedule

--- a/src/utils/ObjectUtils.js
+++ b/src/utils/ObjectUtils.js
@@ -54,10 +54,6 @@ class ObjectUtils {
 
     return result
   }
-
-  static isValid(value: any): boolean {
-    return value !== null && value !== undefined
-  }
 }
 
 export default ObjectUtils


### PR DESCRIPTION
In Javascript there's no need to check for both `null` and `undefined`
if the equality operator (`==`) is used instead of the identity operator
(`===`).
The rule (according to default 'eslint' and 'flow' specs) is that the
`===` operator should always be used with one exception, which is when
checking for `null` / `undefined` since `== null` will only coerce a
value to null only if the value is null or undefined.