### PR TITLE
Group Azure endpoint fields by their required prop

### DIFF
--- a/src/plugins/endpoint/azure/ConnectionSchemaPlugin.js
+++ b/src/plugins/endpoint/azure/ConnectionSchemaPlugin.js
@@ -60,6 +60,7 @@ const azureConnectionParse = schema => {
   let cloudProfileDropdown = {
     name: 'cloud_profile',
     type: 'string',
+    required: true,
     ...schema.properties.cloud_profile,
     custom_cloud_fields: [
       ...defaultSchemaToFields(schema.properties.custom_cloud_properties.properties.endpoints),


### PR DESCRIPTION
The Azure endpoint creation / edit modal now has a simple / advanced
toggle. If 'simple' is selected, only required fields are shown.