### PR TITLE
Enable Oracle VM Server destination options call

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -93,6 +93,7 @@ export const wizardConfig = {
 // If the item has `envRequiredFields`, an additional API call will be made once the specified fields are filled
 export const providersWithExtraOptions = [
   'openstack',
+  'oracle_vm',
   {
     name: 'azure',
     envRequiredFields: ['location', 'resource_group'],


### PR DESCRIPTION
Note: If the API is not enabled, an error notification will be displayed.