### PR TITLE
Improve Azure endpoint fields rendering UX

### DIFF
--- a/src/plugins/endpoint/azure/ConnectionSchemaPlugin.js
+++ b/src/plugins/endpoint/azure/ConnectionSchemaPlugin.js
@@ -39,6 +39,11 @@ const fieldsToPayloadUseDefaults = (data, schema) => {
 const azureConnectionParse = schema => {
   let commonFields = connectionSchemaToFields(schema).filter(f => f.type !== 'object' && f.name !== 'secret_ref' && Object.keys(f).findIndex(k => k === 'enum') === -1)
 
+  let subscriptionIdField = commonFields.find(f => f.name === 'subscription_id')
+  if (subscriptionIdField) {
+    subscriptionIdField.required = true
+  }
+
   let getOption = name => {
     return {
       name,
@@ -67,6 +72,16 @@ const azureConnectionParse = schema => {
       ...defaultSchemaToFields(schema.properties.custom_cloud_properties.properties.suffixes),
     ],
   }
+
+  cloudProfileDropdown.custom_cloud_fields.sort((a, b) => {
+    if (a.required && !b.required) {
+      return -1
+    }
+    if (!a.required && b.required) {
+      return 1
+    }
+    return a.name.localeCompare(b.name)
+  })
 
   return [radioGroup, cloudProfileDropdown]
 }


### PR DESCRIPTION
'Subscription ID' is now a required field.

'Tenant' is a dynamically required field: it is required only for
'CustomCloud' cloud profile and for 'Service Principal Credentials'
login method.

Fixes an issue where 'Tenant' is not visible in 'CustomCloud' cloud
profile.

'CustomCloud' fields are now sorted: the required fields are first, then
the fields are sorted alphabetically.