### PR TITLE
Disable endpoint auto-deletion on creation cancel

### DIFF
--- a/src/components/organisms/PageHeader/PageHeader.jsx
+++ b/src/components/organisms/PageHeader/PageHeader.jsx
@@ -54,7 +54,7 @@ const Title = styled.div`
 `
 const Controls = styled.div`
   display: flex;
-  
+
   & > div {
     margin-left: 16px;
   }
@@ -269,7 +269,6 @@ class PageHeader extends React.Component<Props, State> {
           onRequestClose={() => { this.handleCloseEndpointModal() }}
         >
           <Endpoint
-            deleteOnCancel
             type={this.state.providerType}
             cancelButtonText="Back"
             onCancelClick={options => { this.handleBackEndpointModal(options) }}

--- a/src/components/pages/EndpointsPage/EndpointsPage.jsx
+++ b/src/components/pages/EndpointsPage/EndpointsPage.jsx
@@ -351,7 +351,6 @@ class EndpointsPage extends React.Component<{}, State> {
           onRequestClose={() => { this.handleCloseEndpointModal() }}
         >
           <Endpoint
-            deleteOnCancel
             type={this.state.providerType}
             onCancelClick={() => { this.handleCloseEndpointModal() }}
           />

--- a/src/components/pages/WizardPage/WizardPage.jsx
+++ b/src/components/pages/WizardPage/WizardPage.jsx
@@ -491,7 +491,6 @@ class WizardPage extends React.Component<Props, State> {
           onRequestClose={() => { this.handleCloseNewEndpointModal() }}
         >
           <Endpoint
-            deleteOnCancel
             type={this.state.newEndpointType}
             onCancelClick={autoClose => { this.handleCloseNewEndpointModal(autoClose) }}
           />


### PR DESCRIPTION
If an endpoint's connection info is not valid, the endpoint is no longer
deleted when clicking on Cancel / Back button.