### PR TITLE
Handle invalid response from dest. options API

### DIFF
--- a/src/components/pages/WizardPage/WizardPage.jsx
+++ b/src/components/pages/WizardPage/WizardPage.jsx
@@ -250,7 +250,12 @@ class WizardPage extends React.Component<Props, State> {
   handleOptionsChange(field: Field, value: any) {
     wizardStore.updateData({ networks: null })
     wizardStore.updateOptions({ field, value })
-    this.loadEnvDestinationOptions(field)
+    // If the field is a string and doesn't have an enum property,
+    // we can't call destination options on "change" since too many calls will be made,
+    // it also means a potential problem with the server not populating the "enum" prop.
+    if (field.type !== 'string' || field.enum) {
+      this.loadEnvDestinationOptions(field)
+    }
     wizardStore.setPermalink(wizardStore.data)
   }
 


### PR DESCRIPTION
This issue only applies to providers which have destination options API
calls with additional parameters (see config.js, currently Azure and
OCI).
If the destination options API doesn't return the expected values for
the env. required fields (i.e. missing "enum" property for the
"envRequiredFields" fields specified in config.js), the UI may keep
making requests on every character typed in those fields.