### PR TITLE
Remove references to API's migration 'info' field

### DIFF
--- a/src/components/organisms/MainDetails/MainDetails.jsx
+++ b/src/components/organisms/MainDetails/MainDetails.jsx
@@ -25,6 +25,7 @@ import StatusImage from '../../atoms/StatusImage'
 import Table from '../../molecules/Table'
 import CopyMultilineValue from '../../atoms/CopyMultilineValue'
 
+import type { Instance } from '../../../types/Instance'
 import type { MainItem } from '../../../types/MainItem'
 import type { Endpoint } from '../../../types/Endpoint'
 import StyleProps from '../../styleUtils/StyleProps'
@@ -113,6 +114,8 @@ const PropertyValue = styled.div`
 
 type Props = {
   item: ?MainItem,
+  instancesDetails: Instance[],
+  instancesDetailsLoading: boolean,
   endpoints: Endpoint[],
   bottomControls: React.Node,
   loading: boolean,
@@ -138,19 +141,22 @@ class MainDetails extends React.Component<Props> {
   }
 
   getConnectedVms(networkId: string) {
-    let vms = []
+    if (this.props.instancesDetailsLoading) {
+      return 'Loading...'
+    }
+
     if (!this.props.item) {
       return '-'
     }
-    Object.keys(this.props.item.info).forEach(key => {
-      // $FlowIssue
-      let instance = this.props.item.info[key]
-      if (instance.export_info && instance.export_info.devices.nics.length) {
-        instance.export_info.devices.nics.forEach(nic => {
-          if (nic.network_name === networkId) {
-            vms.push(key)
-          }
-        })
+
+    let vms: string[] = []
+
+    this.props.instancesDetails.forEach(instanceDet => {
+      if (
+        instanceDet.devices && instanceDet.devices.nics && instanceDet.devices.nics.find &&
+        instanceDet.devices.nics.find(n => n.network_name === networkId)
+      ) {
+        vms.push(instanceDet.instance_name)
       }
     })
 

--- a/src/components/organisms/MainDetails/test.jsx
+++ b/src/components/organisms/MainDetails/test.jsx
@@ -34,15 +34,21 @@ let item = {
   destination_endpoint_id: 'endpoint-2',
   id: 'item-id',
   created_at: new Date(2017, 10, 24, 16, 15),
-  info: { instance: { export_info: { devices: { nics: [{ network_name: 'map_1' }] } } } },
+  instances: ['instance_1'],
   destination_environment: {
     description: 'A description',
     network_map: {
-      map_1: 'Mapping 1',
+      network_1: 'Mapping 1',
     },
   },
   type: 'Replica',
 }
+let instancesDetails = [
+  {
+    instance_name: 'instance_1',
+    devices: { nics: [{ network_name: 'network_1' }] },
+  },
+]
 
 describe('MainDetails Component', () => {
   it('renders with endpoint missing', () => {
@@ -52,7 +58,7 @@ describe('MainDetails Component', () => {
   })
 
   it('renders endpoint info', () => {
-    let wrapper = wrap({ item, endpoints })
+    let wrapper = wrap({ item, endpoints, instancesDetails })
     expect(wrapper.find('id').prop('value')).toBe('item-id')
     const localDate = moment(item.created_at).add(-new Date().getTimezoneOffset(), 'minutes')
     expect(wrapper.find('created').prop('value')).toBe(localDate.format('YYYY-MM-DD HH:mm:ss'))
@@ -62,18 +68,18 @@ describe('MainDetails Component', () => {
   })
 
   it('renders endpoints logos', () => {
-    let wrapper = wrap({ item, endpoints })
+    let wrapper = wrap({ item, endpoints, instancesDetails })
     expect(wrapper.find('sourceLogo').prop('endpoint')).toBe('openstack')
     expect(wrapper.find('targetLogo').prop('endpoint')).toBe('azure')
   })
 
   it('renders network_map', () => {
-    let wrapper = wrap({ item, endpoints })
+    let wrapper = wrap({ item, endpoints, instancesDetails })
     let tableItems = wrapper.find('networksTable').prop('items')
     expect(tableItems.length).toBe(1)
     expect(tableItems[0].length).toBe(4)
-    expect(tableItems[0][0]).toBe('map_1')
-    expect(tableItems[0][1][0]).toBe('instance')
+    expect(tableItems[0][0]).toBe('network_1')
+    expect(tableItems[0][1][0]).toBe('instance_1')
     expect(tableItems[0][2]).toBe('Mapping 1')
     expect(tableItems[0][3]).toBe('Existing network')
     expect(wrapper.find('loading').length).toBe(0)

--- a/src/components/organisms/MigrationDetailsContent/MigrationDetailsContent.jsx
+++ b/src/components/organisms/MigrationDetailsContent/MigrationDetailsContent.jsx
@@ -24,6 +24,7 @@ import MainDetails from '../../organisms/MainDetails'
 import Tasks from '../../organisms/Tasks'
 import StyleProps from '../../styleUtils/StyleProps'
 
+import type { Instance } from '../../../types/Instance'
 import type { MainItem } from '../../../types/MainItem'
 import type { Endpoint } from '../../../types/Endpoint'
 
@@ -54,6 +55,8 @@ const NavigationItems = [
 type Props = {
   item: ?MainItem,
   detailsLoading: boolean,
+  instancesDetails: Instance[],
+  instancesDetailsLoading: boolean,
   endpoints: Endpoint[],
   page: string,
   onDeleteMigrationClick: () => void,
@@ -80,6 +83,8 @@ class MigrationDetailsContent extends React.Component<Props> {
     return (
       <MainDetails
         item={this.props.item}
+        instancesDetails={this.props.instancesDetails}
+        instancesDetailsLoading={this.props.instancesDetailsLoading}
         endpoints={this.props.endpoints}
         bottomControls={this.renderBottomControls()}
         loading={this.props.detailsLoading}

--- a/src/components/organisms/ReplicaDetailsContent/ReplicaDetailsContent.jsx
+++ b/src/components/organisms/ReplicaDetailsContent/ReplicaDetailsContent.jsx
@@ -24,6 +24,7 @@ import DetailsNavigation from '../../molecules/DetailsNavigation'
 import MainDetails from '../../organisms/MainDetails'
 import Executions from '../../organisms/Executions'
 import Schedule from '../../organisms/Schedule'
+import type { Instance } from '../../../types/Instance'
 import type { MainItem } from '../../../types/MainItem'
 import type { Endpoint } from '../../../types/Endpoint'
 import type { Execution } from '../../../types/Execution'
@@ -71,6 +72,8 @@ type TimezoneValue = 'utc' | 'local'
 type Props = {
   item: ?MainItem,
   endpoints: Endpoint[],
+  instancesDetails: Instance[],
+  instancesDetailsLoading: boolean,
   scheduleStore: typeof scheduleStore,
   page: string,
   detailsLoading: boolean,
@@ -154,6 +157,8 @@ class ReplicaDetailsContent extends React.Component<Props, State> {
     return (
       <MainDetails
         item={this.props.item}
+        instancesDetails={this.props.instancesDetails}
+        instancesDetailsLoading={this.props.instancesDetailsLoading}
         loading={this.props.detailsLoading}
         endpoints={this.props.endpoints}
         bottomControls={this.renderBottomControls()}

--- a/src/stores/InstanceStore.js
+++ b/src/stores/InstanceStore.js
@@ -165,7 +165,7 @@ class InstanceStore {
     InstanceSource.cancelInstancesDetailsRequests(this.reqId - 1)
 
     instancesInfo.sort((a, b) => a.instance_name.localeCompare(b.instance_name))
-    let hash = i => `${i.instance_name}-${i.id}`
+    let hash = i => `${i.instance_name}-${i.id || endpointId}`
     if (this.instancesDetails.map(hash).join('_') === instancesInfo.map(hash).join('_')) {
       return Promise.resolve()
     }
@@ -202,11 +202,13 @@ class InstanceStore {
             resolve()
           }
         }).catch((resp?: { reqId: number }) => {
+          this.instancesDetailsRemaining -= 1
+          this.loadingInstancesDetails = this.instancesDetailsRemaining > 0
+
           if (!resp || resp.reqId !== this.reqId) {
             return
           }
-          this.instancesDetailsRemaining -= 1
-          this.loadingInstancesDetails = this.instancesDetailsRemaining > 0
+
           if (count === 0) {
             resolve()
           }


### PR DESCRIPTION
The structure or existence of the 'info' field in a replica or a
migration can't be trusted. An alternative method is used to retrieve
the VM instances connected to a specific network, which involves making
an API call for each instance of a replica or a migration.

This affects only the replica and migration details page and the
following changes are visible:

 - a 'Loading...' label is display in the 'Connected VMs' field of the
network table while the migration / replica instances details are
loading.

 - an error message may be shown if there are issues retrieving the
instances details.