### PR TITLE
Remove unused code from previous notification sys.

### DIFF
--- a/src/components/pages/AssessmentDetailsPage/AssessmentDetailsPage.jsx
+++ b/src/components/pages/AssessmentDetailsPage/AssessmentDetailsPage.jsx
@@ -233,7 +233,7 @@ class AssessmentDetailsPage extends React.Component<Props, State> {
       this.setState({ showMigrationOptions: false })
       let useReplicaOption = options.find(o => o.name === 'use_replica')
       let type = useReplicaOption && useReplicaOption.value ? 'Replica' : 'Migration'
-      notificationStore.alert(`${type} was succesfully created`, 'success', { persist: true, persistInfo: { title: `${type} created` } })
+      notificationStore.alert(`${type} was succesfully created`, 'success')
 
       if (type === 'Replica') {
         assessmentStore.migrations.forEach(replica => {

--- a/src/components/pages/WizardPage/WizardPage.jsx
+++ b/src/components/pages/WizardPage/WizardPage.jsx
@@ -103,7 +103,7 @@ class WizardPage extends React.Component<Props, State> {
 
   handleCreationSuccess(items: MainItem[]) {
     let typeLabel = this.state.type.charAt(0).toUpperCase() + this.state.type.substr(1)
-    notificationStore.alert(`${typeLabel} was succesfully created`, 'success', { persist: true, persistInfo: { title: `${typeLabel} created` } })
+    notificationStore.alert(`${typeLabel} was succesfully created`, 'success')
     let schedulePromise = Promise.resolve()
 
     if (this.state.type === 'replica') {

--- a/src/sources/AssessmentSource.js
+++ b/src/sources/AssessmentSource.js
@@ -71,10 +71,7 @@ class AssessmentSource {
       let newData = { ...data }
       newData.selectedInstances = [instance]
       return this.migrate(newData).catch(() => {
-        notificationStore.alert(`Error while migrating instance ${instance.name}`, 'error', {
-          persist: true,
-          persistInfo: { title: 'Migration creation error' },
-        })
+        notificationStore.alert(`Error while migrating instance ${instance.name}`, 'error')
         return null
       })
     })).then(items => items.filter(Boolean).map(i => i))

--- a/src/sources/WizardSource.js
+++ b/src/sources/WizardSource.js
@@ -54,10 +54,7 @@ class WizardSource {
       let newData = { ...data }
       newData.selectedInstances = [instance]
       return WizardSource.create(type, newData).catch(() => {
-        notificationStore.alert(`Error while creating ${type} for instance ${instance.name}`, 'error', {
-          persist: true,
-          persistInfo: { title: `${type} creation error` },
-        })
+        notificationStore.alert(`Error while creating ${type} for instance ${instance.name}`, 'error')
         return null
       })
     })).then(mainItems => mainItems.filter(Boolean).map(i => i))

--- a/src/stores/MigrationStore.js
+++ b/src/stores/MigrationStore.js
@@ -91,8 +91,6 @@ class MigrationStore {
             window.location.href = `/#/migration/tasks/${migration.id}`
           },
         },
-        persist: true,
-        persistInfo: { title: 'Migration created' },
       })
     })
   }

--- a/src/types/NotificationItem.js
+++ b/src/types/NotificationItem.js
@@ -16,8 +16,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 export type AlertInfo = {
   options?: {
-    persist?: boolean,
-    persistInfo?: { title: string },
     action?: {
       label: string,
       callback: () => void,


### PR DESCRIPTION
Persisted notification are no longer a thing, so the code pertaining to
that is no longer needed.

Previously a regular notification could be made 'persisted', using
`persist: true` option, by saving it and displaying it in 'Bell'
component dropdown.

Currently, the 'Bell' component dropdown displays a different set of
predefined notifications.