### PR TITLE
Show empty string if dropdown item value is empty

### DIFF
--- a/src/components/molecules/Dropdown/Dropdown.jsx
+++ b/src/components/molecules/Dropdown/Dropdown.jsx
@@ -249,7 +249,13 @@ class Dropdown extends React.Component<Props, State> {
       return this.props.noSelectionMessage
     }
 
-    return (item[labelField] != null && item[labelField].toString()) || (item.value && item.value.toString()) || item.toString()
+    if (item[labelField] != null) {
+      return item[labelField].toString()
+    }
+    if (item.value != null) {
+      return item.value.toString()
+    }
+    return item.toString()
   }
 
   getValue(item: any) {
@@ -420,7 +426,7 @@ class Dropdown extends React.Component<Props, State> {
                   />
                 ) : null}
                 <Labels>
-                  {label}
+                  {label === '' ? '\u00A0' : label}
                   {duplicatedLabel ? <DuplicatedLabel> (<span>{value || ''}</span>)</DuplicatedLabel> : ''}
                 </Labels>
               </ListItem>


### PR DESCRIPTION
If a dropdown item has no label, the value is used.
If it also has no value, an empty string is used.

Previously if it had no label and no value `[object Object]` was
displayed.