### PR TITLE
Improve wizard instances searching

### DIFF
--- a/src/sources/InstanceSource.js
+++ b/src/sources/InstanceSource.js
@@ -20,13 +20,8 @@ import type { Instance } from '../types/Instance'
 import { servicesUrl, wizardConfig } from '../config'
 
 class InstanceSource {
-  static lastEndpointId: string
-
   static loadInstances(endpointId: string, searchText: ?string, lastInstanceId: ?string, skipLimit?: boolean): Promise<Instance[]> {
-    if (this.lastEndpointId) {
-      Api.cancelRequests(this.lastEndpointId)
-      this.lastEndpointId = endpointId
-    }
+    Api.cancelRequests(endpointId)
 
     let url = `${servicesUrl.coriolis}/${Api.projectId}/endpoints/${endpointId}/instances`
     let symbol = '?'

--- a/src/stores/InstanceStore.js
+++ b/src/stores/InstanceStore.js
@@ -99,7 +99,10 @@ class InstanceStore {
       this.cachedInstances = instances
       this.searching = false
       this.searchNotFound = Boolean(instances.length === 0 && searchText)
-    }).catch(() => {
+    }).catch(r => {
+      if (r.canceled) {
+        return
+      }
       this.searching = false
       this.searchNotFound = true
     })

--- a/src/utils/ApiCaller.js
+++ b/src/utils/ApiCaller.js
@@ -121,9 +121,9 @@ class ApiCaller {
           console.log(`%cError No Response: ${axiosOptions.url}`, 'color: #D0021B')
           reject({})
         } else {
-          reject({})
-
-          if (error.constructor.name === 'Cancel') {
+          let canceled = error.constructor.name === 'Cancel'
+          reject({ canceled })
+          if (canceled) {
             return
           }
 


### PR DESCRIPTION
Previously, if a user typed in the instances search input while the
instances were loading from a previous search, unexpected results may
have appeared. Usually the response from the previous search came before
the current search, in which case UI elements were updated incorrectly
for a short time. Rarely, the previous search response came after the
current search, in which case the instances list from the previous
search were displayed instead.

With this patch, typing while still searching is fully supported by
canceling all the previous requests (thus, bandwidth is also improved).