### PR TITLE
Use clearer Azure Migrate invalid auth. message

### DIFF
--- a/server/proxy.js
+++ b/server/proxy.js
@@ -18,7 +18,7 @@ import axios from 'axios'
 
 const forwardHeaders = ['authorization']
 
-let buildError = (status, message) => {
+let buildError = message => {
   return {
     error: { message: `Proxy - ${message}` },
   }
@@ -30,7 +30,7 @@ module.exports = app => {
   app.post('/azure-login', jsonParser, (req, res) => {
     MsRest.loginWithUsernamePassword(req.body.username, req.body.password, (err, credentials) => {
       if (err) {
-        res.status(400).send(err)
+        res.status(401).send(buildError(`Couldn't authenticate user: ${req.body.username}`))
       } else {
         res.send(credentials)
       }
@@ -50,11 +50,11 @@ module.exports = app => {
       res.send(response.data)
     }).catch(error => {
       if (error.response) {
-        res.status(error.response.status).send(buildError(error.response.status, error.response.data.error.message))
+        res.status(error.response.status).send(buildError(error.response.data.error.message))
       } else if (error.request) {
-        res.status(500).send(buildError(500, 'No Response!'))
+        res.status(500).send(buildError('No Response!'))
       } else {
-        res.status(500).send(buildError(500, 'Error creating request!'))
+        res.status(500).send(buildError('Error creating request!'))
       }
     })
   })

--- a/src/components/organisms/Notifications/style.js
+++ b/src/components/organisms/Notifications/style.js
@@ -65,6 +65,7 @@ const NotificationsStyle = css`
     font-weight: 400 !important;
     width: 160px;
     margin-bottom: 8px !important;
+    word-break: break-word;
   }
   .notification-message {
     font-size: 14px !important;

--- a/src/stores/AzureStore.js
+++ b/src/stores/AzureStore.js
@@ -40,6 +40,7 @@ class AzureStore {
       this.authenticating = false
     }).catch(() => {
       this.authenticating = false
+      return Promise.reject()
     })
   }
 


### PR DESCRIPTION
If the Azure endpoint doesn't have valid credentials, show a clearer
message and cancel subsequent requests to Azure services.

Previously, only the subsequent's request error message was displayed,
the login error was ignored by UI.