### PR TITLE
Fix issue with switching pages from notifications

### DIFF
--- a/src/components/pages/MigrationDetailsPage/MigrationDetailsPage.jsx
+++ b/src/components/pages/MigrationDetailsPage/MigrationDetailsPage.jsx
@@ -55,13 +55,13 @@ class MigrationDetailsPage extends React.Component<Props, State> {
     document.title = 'Migration Details'
 
     endpointStore.getEndpoints()
-    this.loadMigrationWithInstances()
+    this.loadMigrationWithInstances(this.props.match.params.id)
     this.pollInterval = setInterval(() => { this.pollData() }, requestPollTimeout)
   }
 
   componentWillReceiveProps(newProps: any) {
     if (newProps.match.params.id !== this.props.match.params.id) {
-      this.loadMigrationWithInstances()
+      this.loadMigrationWithInstances(newProps.match.params.id)
     }
   }
 
@@ -70,8 +70,8 @@ class MigrationDetailsPage extends React.Component<Props, State> {
     clearInterval(this.pollInterval)
   }
 
-  loadMigrationWithInstances() {
-    migrationStore.getMigration(this.props.match.params.id, true).then(() => {
+  loadMigrationWithInstances(migrationId: string) {
+    migrationStore.getMigration(migrationId, true).then(() => {
       if (migrationStore.migrationDetails) {
         instanceStore.loadInstancesDetails(
           migrationStore.migrationDetails.origin_endpoint_id,

--- a/src/components/pages/ReplicaDetailsPage/ReplicaDetailsPage.jsx
+++ b/src/components/pages/ReplicaDetailsPage/ReplicaDetailsPage.jsx
@@ -72,15 +72,15 @@ class ReplicaDetailsPage extends React.Component<Props, State> {
   componentDidMount() {
     document.title = 'Replica Details'
 
-    this.loadReplicaWithInstances()
+    this.loadReplicaWithInstances(this.props.match.params.id)
     endpointStore.getEndpoints()
     scheduleStore.getSchedules(this.props.match.params.id)
     this.pollData(true)
   }
 
-  componentWillReceiveProps(newProps: any) {
+  componentWillReceiveProps(newProps: Props) {
     if (newProps.match.params.id !== this.props.match.params.id) {
-      this.loadReplicaWithInstances()
+      this.loadReplicaWithInstances(newProps.match.params.id)
       scheduleStore.getSchedules(newProps.match.params.id)
     }
   }
@@ -91,8 +91,8 @@ class ReplicaDetailsPage extends React.Component<Props, State> {
     clearTimeout(this.pollTimeout)
   }
 
-  loadReplicaWithInstances() {
-    replicaStore.getReplica(this.props.match.params.id).then(() => {
+  loadReplicaWithInstances(replicaId: string) {
+    replicaStore.getReplica(replicaId).then(() => {
       if (replicaStore.replicaDetails) {
         instanceStore.loadInstancesDetails(
           replicaStore.replicaDetails.origin_endpoint_id,


### PR DESCRIPTION
Previously, a new migration details page would not load if visited from
the notifications dropdown, while currently on another migration details
page. Same issue applied to the replica details page.