### PR TITLE
Improve Azure Migrate VM matching

### DIFF
--- a/src/components/molecules/AssessedVmListItem/AssessedVmListItem.jsx
+++ b/src/components/molecules/AssessedVmListItem/AssessedVmListItem.jsx
@@ -53,11 +53,13 @@ const Value = styled.div`
 `
 const DisplayNameLabel = styled.div`
   margin-left: 8px;
+  word-break: break-word;
 `
-const InfoIconStyled = styled(InfoIcon) `
+const InfoIconStyled = styled(InfoIcon)`
   position: absolute;
   left: -36px;
   top: 0px;
+  z-index: 10000;
 `
 
 type Props = {

--- a/src/components/organisms/AssessmentDetailsContent/AssessmentDetailsContent.jsx
+++ b/src/components/organisms/AssessmentDetailsContent/AssessmentDetailsContent.jsx
@@ -204,7 +204,7 @@ class AssessmentDetailsContent extends React.Component<Props> {
     }
 
     if (this.props.instances.length > 0 &&
-      !this.props.instances.find(i => i.instance_name === `${vm.properties.datacenterContainer}/${vm.properties.displayName}`)) {
+      !this.props.instances.find(i => i.id === `${vm.properties.datacenterMachineId}`)) {
       return false
     }
 
@@ -322,7 +322,6 @@ class AssessmentDetailsContent extends React.Component<Props> {
     }
 
     let items = this.props.filteredAssessedVms.map(vm => {
-      let filteredVm = this.props.filteredAssessedVms.find(v => v.id === vm.id)
       return (
         <AssessedVmListItem
           item={vm}
@@ -330,7 +329,7 @@ class AssessmentDetailsContent extends React.Component<Props> {
           onSelectedChange={(vm, selected) => { this.props.onVmSelectedChange(vm, selected) }}
           disabled={!this.doesVmMatchSource(vm)}
           loadingVmSizes={this.props.loadingVmSizes}
-          recommendedVmSize={filteredVm ? filteredVm.properties.recommendedSize : ''}
+          recommendedVmSize={vm.properties.recommendedSize}
           vmSizes={this.props.vmSizes}
           selectedVmSize={this.props.onGetVmSize(vm)}
           onVmSizeChange={size => { this.props.onVmSizeChange(vm, size) }}

--- a/src/components/pages/AssessmentDetailsPage/AssessmentDetailsPage.jsx
+++ b/src/components/pages/AssessmentDetailsPage/AssessmentDetailsPage.jsx
@@ -132,7 +132,7 @@ class AssessmentDetailsPage extends React.Component<Props, State> {
     }
     return azureStore.assessedVms.filter(vm => {
       if (vm.properties.datacenterManagementServer.toLowerCase() === sourceHost.toLowerCase() &&
-        instanceStore.instances.find(i => i.instance_name === `${vm.properties.datacenterContainer}/${vm.properties.displayName}`)) {
+        instanceStore.instances.find(i => i.id === `${vm.properties.datacenterMachineId}`)) {
         return true
       }
       return false
@@ -209,10 +209,10 @@ class AssessmentDetailsPage extends React.Component<Props, State> {
 
   handleMigrationExecute(options: Field[]) {
     let selectedInstances = instanceStore.instancesDetails
-      .filter(i => this.state.selectedVms.find(m => i.instance_name === `${m.properties.datacenterContainer}/${m.properties.displayName}`))
+      .filter(i => this.state.selectedVms.find(m => i.id === `${m.properties.datacenterMachineId}`))
     let vmSizes = {}
     selectedInstances.forEach(i => {
-      let vm = this.state.selectedVms.find(m => i.instance_name === `${m.properties.datacenterContainer}/${m.properties.displayName}`)
+      let vm = this.state.selectedVms.find(m => i.id === `${m.properties.datacenterMachineId}`)
       vmSizes[i.instance_name] = vm ? this.state.vmSizes[vm.id].name : ''
     })
 
@@ -320,7 +320,7 @@ class AssessmentDetailsPage extends React.Component<Props, State> {
   }
 
   loadInstancesDetails() {
-    let instances = instanceStore.instances.filter(i => this.state.selectedVms.find(m => i.instance_name === `${m.properties.datacenterContainer}/${m.properties.displayName}`))
+    let instances = instanceStore.instances.filter(i => this.state.selectedVms.find(m => i.id === `${m.properties.datacenterMachineId}`))
     instanceStore.clearInstancesDetails()
     instanceStore.loadInstancesDetails(this.getSourceEndpointId(), instances)
   }

--- a/src/types/Assessment.js
+++ b/src/types/Assessment.js
@@ -35,6 +35,7 @@ export type VmItem = {
     },
     datacenterContainer: string,
     datacenterManagementServer: string,
+    datacenterMachineId: string,
     displayName: string,
     operatingSystem: string,
   },


### PR DESCRIPTION
Use VMWare's machine id to match VMs between VMWare and Azure.

Previously, VM path was used.