### PR TITLE
Send default `cloud_profile` on Azure creation

### DIFF
--- a/src/plugins/endpoint/azure/ConnectionSchemaPlugin.js
+++ b/src/plugins/endpoint/azure/ConnectionSchemaPlugin.js
@@ -109,6 +109,10 @@ export default class ConnectionSchemaParser {
     let loginType = data.login_type || 'user_credentials'
     connectionInfo[loginType] = fieldsToPayload(data, schema.properties[loginType])
 
+    if (!data.cloud_profile) {
+      connectionInfo.cloud_profile = 'AzureCloud'
+    }
+
     if (data.cloud_profile === 'CustomCloud') {
       connectionInfo.custom_cloud_properties = {
         endpoints: {


### PR DESCRIPTION
Usually the value of a field is not send to the server if the field has
a default value and the user didn't set a value. We need to send the
default value for Azure even if the user didn't change it in the UI.