### PR TITLE
Don't show instance not found in replica page

### DIFF
--- a/src/components/organisms/MainDetails/MainDetails.jsx
+++ b/src/components/organisms/MainDetails/MainDetails.jsx
@@ -160,7 +160,7 @@ class MainDetails extends React.Component<Props> {
       }
     })
 
-    return vms.length === 0 ? '-' : vms.join(', ')
+    return vms.length === 0 ? 'Failed to read network configuration for the original instance' : vms.join(', ')
   }
 
   getNetworks() {

--- a/src/components/pages/MigrationDetailsPage/MigrationDetailsPage.jsx
+++ b/src/components/pages/MigrationDetailsPage/MigrationDetailsPage.jsx
@@ -76,7 +76,9 @@ class MigrationDetailsPage extends React.Component<Props, State> {
         instanceStore.loadInstancesDetails(
           migrationStore.migrationDetails.origin_endpoint_id,
           // $FlowIgnore
-          migrationStore.migrationDetails.instances.map(n => { return { instance_name: n } }))
+          migrationStore.migrationDetails.instances.map(n => { return { instance_name: n } }),
+          false, true
+        )
       }
     })
   }

--- a/src/components/pages/ReplicaDetailsPage/ReplicaDetailsPage.jsx
+++ b/src/components/pages/ReplicaDetailsPage/ReplicaDetailsPage.jsx
@@ -97,7 +97,9 @@ class ReplicaDetailsPage extends React.Component<Props, State> {
         instanceStore.loadInstancesDetails(
           replicaStore.replicaDetails.origin_endpoint_id,
           // $FlowIgnore
-          replicaStore.replicaDetails.instances.map(n => { return { instance_name: n } }))
+          replicaStore.replicaDetails.instances.map(n => { return { instance_name: n } }),
+          false, true
+        )
       }
     })
   }

--- a/src/sources/InstanceSource.js
+++ b/src/sources/InstanceSource.js
@@ -45,10 +45,11 @@ class InstanceSource {
     })
   }
 
-  static loadInstanceDetails(endpointId: string, instanceName: string, reqId: number): Promise<{ instance: Instance, reqId: number }> {
+  static loadInstanceDetails(endpointId: string, instanceName: string, reqId: number, quietError?: boolean): Promise<{ instance: Instance, reqId: number }> {
     return Api.send({
       url: `${servicesUrl.coriolis}/${Api.projectId}/endpoints/${endpointId}/instances/${btoa(instanceName)}`,
       cancelId: `instanceDetail-${reqId}`,
+      quietError,
     }).then(response => {
       return { instance: response.data.instance, reqId }
     })

--- a/src/stores/InstanceStore.js
+++ b/src/stores/InstanceStore.js
@@ -237,7 +237,7 @@ class InstanceStore {
     })
   }
 
-  @action loadInstancesDetails(endpointId: string, instancesInfo: Instance[], useLocalStorage?: boolean): Promise<void> {
+  @action loadInstancesDetails(endpointId: string, instancesInfo: Instance[], useLocalStorage?: boolean, quietError?: boolean): Promise<void> {
     // Use reqId to be able to uniquely identify the request so all but the latest request can be igonred and canceled
     this.reqId = !this.reqId ? 1 : this.reqId + 1
     InstanceSource.cancelInstancesDetailsRequests(this.reqId - 1)
@@ -268,7 +268,7 @@ class InstanceStore {
 
     return new Promise((resolve) => {
       instancesInfo.forEach(instanceInfo => {
-        InstanceSource.loadInstanceDetails(endpointId, instanceInfo.instance_name, this.reqId).then((resp: { instance: Instance, reqId: number }) => {
+        InstanceSource.loadInstanceDetails(endpointId, instanceInfo.instance_name, this.reqId, quietError).then((resp: { instance: Instance, reqId: number }) => {
           if (resp.reqId !== this.reqId) {
             return
           }


### PR DESCRIPTION
If the instance is not found in order to display the 'Connected VMs' in
network mapping, don't show a notification popup 'Instance Not Found'
error, instead show a clearer message in the 'Connected VMs' column.