### PR TITLE
Use the first instance as notification item name

### DIFF
--- a/src/components/organisms/MainDetails/MainDetails.jsx
+++ b/src/components/organisms/MainDetails/MainDetails.jsx
@@ -160,7 +160,7 @@ class MainDetails extends React.Component<Props> {
       }
     })
 
-    return vms.length === 0 ? '-' : vms
+    return vms.length === 0 ? '-' : vms.join(', ')
   }
 
   getNetworks() {

--- a/src/sources/NotificationSource.js
+++ b/src/sources/NotificationSource.js
@@ -130,7 +130,7 @@ class NotificationSource {
           id: item.id,
           status: mainInfo.status,
           type: item.type,
-          name: item.instances.join(', '),
+          name: item.instances[0],
           updatedAt: mainInfo.updated_at,
           description: DataUtils.getItemDescription(item),
         }


### PR DESCRIPTION
The name of a notification item should be the same name used to name
replicas and migrations: the name of the first instance. Previously the
concatenation of all instances names was used for notification item
name.