### PR TITLE
Use a javascript source map for production builds

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -109,8 +109,13 @@ const config = createConfig([
       app: sourcePath,
     }),
     splitVendor(),
+    () => ({ devtool: 'nosources-source-map' }),
     addPlugins([
-      new webpack.optimize.UglifyJsPlugin({ compress: { warnings: false }, mangle: { keep_fnames: true } }),
+      new webpack.optimize.UglifyJsPlugin({
+        compress: { warnings: false },
+        mangle: { keep_fnames: true },
+        sourceMap: true,
+      }),
     ]),
   ]),
 ])


### PR DESCRIPTION
This will allow the user to see the original file name and the source
code line number in the case of a Javascript error when using browser's
developer tools.

Note that the full source code can also be enabled in the developer
tools if needed by changing `nosources-source-map` to `source-map` in
`webpack.config` before building.