### PR TITLE
Skip notifications data polling logs

### DIFF
--- a/src/sources/NotificationSource.js
+++ b/src/sources/NotificationSource.js
@@ -115,8 +115,8 @@ class DataUtils {
 class NotificationSource {
   static loadData(): Promise<NotificationItemData[]> {
     return Promise.all([
-      Api.get(`${servicesUrl.coriolis}/${Api.projectId}/migrations`),
-      Api.get(`${servicesUrl.coriolis}/${Api.projectId}/replicas/detail`),
+      Api.send({ url: `${servicesUrl.coriolis}/${Api.projectId}/migrations`, skipLog: true }),
+      Api.send({ url: `${servicesUrl.coriolis}/${Api.projectId}/replicas/detail`, skipLog: true }),
     ]).then(([migrationsResponse, replicasResponse]) => {
       let migrations = migrationsResponse.data.migrations
       let replicas = replicasResponse.data.replicas

--- a/src/utils/ApiCaller.js
+++ b/src/utils/ApiCaller.js
@@ -33,6 +33,7 @@ type RequestOptions = {
   data?: any,
   responseType?: 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream',
   quietError?: boolean,
+  skipLog?: boolean,
 }
 
 let cancelables: Cancelable[] = []
@@ -84,10 +85,14 @@ class ApiCaller {
         addCancelable({ requestId: options.cancelId, cancel })
       }
 
-      console.log(`%cSending ${axiosOptions.method || 'GET'} Request to ${axiosOptions.url}`, 'color: #F5A623')
+      if (!options.skipLog) {
+        console.log(`%cSending ${axiosOptions.method || 'GET'} Request to ${axiosOptions.url}`, 'color: #F5A623')
+      }
 
       axios(axiosOptions).then((response) => {
-        console.log(`%cResponse ${axiosOptions.url}`, 'color: #0044CA', response.data)
+        if (!options.skipLog) {
+          console.log(`%cResponse ${axiosOptions.url}`, 'color: #0044CA', response.data)
+        }
         resolve(response)
       }).catch(error => {
         const loginUrl = '#/'


### PR DESCRIPTION
The notifications polling floods the logs (`console.log`) and makes it
difficult to track other requests.