### PR TITLE
Add missing text when source instance is not found

### DIFF
--- a/src/components/organisms/MainDetails/MainDetails.jsx
+++ b/src/components/organisms/MainDetails/MainDetails.jsx
@@ -160,7 +160,7 @@ class MainDetails extends React.Component<Props> {
       }
     })
 
-    return vms.length === 0 ? '-' : vms.map(vm => <div data-test-id={`vm-${vm}`} style={{ marginBottom: '8px' }}>{vm}<br /></div>)
+    return vms.length === 0 ? 'Failed to read network configuration for the original instance' : vms.map(vm => <div data-test-id={`vm-${vm}`} style={{ marginBottom: '8px' }}>{vm}<br /></div>)
   }
 
   getNetworks() {

--- a/src/components/organisms/MainDetails/test.jsx
+++ b/src/components/organisms/MainDetails/test.jsx
@@ -85,6 +85,12 @@ describe('MainDetails Component', () => {
     expect(wrapper.find('loading').length).toBe(0)
   })
 
+  it('renders network map with missing source instance', () => {
+    let wrapper = wrap({ item, endpoints, instancesDetails: [] })
+    let tableItems = wrapper.find('networksTable').prop('items')
+    expect(tableItems[0][1]).toBe('Failed to read network configuration for the original instance')
+  })
+
   it('renders loading', () => {
     let wrapper = wrap({ item: {}, endpoints: [], loading: true })
     expect(wrapper.find('loading').length).toBe(1)


### PR DESCRIPTION
The text was accidentally reverted (back to '-') when a previous merge
conflict was resolved.

A unit test for this case is also included.