### PR TITLE
Add integer support to connection info

### DIFF
--- a/src/components/molecules/EndpointField/EndpointField.jsx
+++ b/src/components/molecules/EndpointField/EndpointField.jsx
@@ -112,6 +112,24 @@ class Field extends React.Component<Props> {
     )
   }
 
+  renderIntInput() {
+    return (
+      <TextInput
+        highlight={this.props.highlight}
+        large={this.props.large}
+        value={this.props.value}
+        onChange={e => {
+          let value = Number(e.target.value.replace(/\D/g, '')) || ''
+          if (this.props.onChange) {
+            this.props.onChange(value)
+          }
+        }}
+        placeholder={LabelDictionary.get(this.props.name)}
+        disabled={this.props.disabled}
+      />
+    )
+  }
+
   renderObjectTable() {
     if (!this.props.properties || !this.props.properties.length) {
       return null
@@ -279,7 +297,7 @@ class Field extends React.Component<Props> {
         if (this.props.minimum || this.props.maximum) {
           return this.renderIntDropdown()
         }
-        return this.renderTextInput()
+        return this.renderIntInput()
       case 'radio':
         return this.renderRadioInput()
       case 'array':

--- a/src/components/organisms/Endpoint/Endpoint.jsx
+++ b/src/components/organisms/Endpoint/Endpoint.jsx
@@ -206,7 +206,7 @@ class Endpoint extends React.Component<Props, State> {
     if (!field || !this.state.endpoint) {
       return ''
     }
-    if (this.state.endpoint[field.name]) {
+    if (this.state.endpoint[field.name] != null) {
       return this.state.endpoint[field.name]
     }
 

--- a/src/plugins/endpoint/default/ContentPlugin.jsx
+++ b/src/plugins/endpoint/default/ContentPlugin.jsx
@@ -100,13 +100,16 @@ class ContentPlugin extends React.Component<Props> {
           </Row>
         ))
       }
-      if (field.useTextArea || schemaIndex === this.props.connectionInfoSchema.length - 1) {
+      if (field.useTextArea) {
+        pushRow(currentField)
+        i -= 1
+      } else if (i % 2 !== 0) {
+        pushRow(lastField, currentField)
+      } else if (schemaIndex === this.props.connectionInfoSchema.length - 1) {
         pushRow(currentField)
         if (field.useTextArea) {
           i -= 1
         }
-      } else if (i % 2 !== 0) {
-        pushRow(lastField, currentField)
       } else {
         lastField = currentField
       }


### PR DESCRIPTION
Currently in use by vsphere and oraclevm 'Port' field.

What this means is that a number is sent to the API instead of a string
and the UI text input allows only numbers as input.

Also includes 'Fix missing field in connection info modal' commit:

A field may be missing in providers without a connection info plugin if
the number of fields is not an odd number.