### PR TITLE
Fix duplicated label layout if id is too long

### DIFF
--- a/src/components/molecules/Dropdown/Dropdown.jsx
+++ b/src/components/molecules/Dropdown/Dropdown.jsx
@@ -144,6 +144,7 @@ const Separator = styled.div`
 `
 const Labels = styled.div`
   word-break: break-word;
+  max-width: 100%;
 `
 
 export const updateTipStyle = (listItemsRef: HTMLElement, tipRef: HTMLElement, firstItemRef: HTMLElement) => {


### PR DESCRIPTION
If a label is duplicated in the dropdown list, the ID of the item is
also shown. This fixes a layout issue where the ID is too long.