### PR TITLE
Handle migration creation fail in Wizard

### DIFF
--- a/src/components/pages/WizardPage/WizardPage.jsx
+++ b/src/components/pages/WizardPage/WizardPage.jsx
@@ -397,6 +397,8 @@ class WizardPage extends React.Component<Props, State> {
         return
       }
       this.handleCreationSuccess([item])
+    }).catch(() => {
+      this.setState({ nextButtonDisabled: false })
     })
   }
 

--- a/src/stores/WizardStore.js
+++ b/src/stores/WizardStore.js
@@ -125,6 +125,7 @@ class WizardStore {
       this.creatingItem = false
     }).catch(() => {
       this.creatingItem = false
+      return Promise.reject()
     })
   }
 


### PR DESCRIPTION
If a migration can't be created don't redirect to user, instead
re-enable the Finish / Next button, while displaying the error message.