### PR TITLE
Update Wizard Summary page labels

### DIFF
--- a/src/components/organisms/WizardSummary/WizardSummary.jsx
+++ b/src/components/organisms/WizardSummary/WizardSummary.jsx
@@ -184,12 +184,12 @@ class WizardSummary extends React.Component<Props> {
       if (scheduleInfo.hour == null) {
         timeLabel = 'every hour, every minute'
       } else {
-        timeLabel = `at ${padNumber(scheduleInfo.hour)} o'clock, every minute`
+        timeLabel = `at ${padNumber(scheduleInfo.hour)} o'clock, every minute UTC`
       }
     } else if (scheduleInfo.hour == null) {
-      timeLabel = `every hour, at minute ${padNumber(scheduleInfo.minute)}`
+      timeLabel = `every hour, at minute ${padNumber(scheduleInfo.minute)} UTC`
     } else {
-      timeLabel = `at ${padNumber(scheduleInfo.hour)}:${padNumber(scheduleInfo.minute)}`
+      timeLabel = `at ${padNumber(scheduleInfo.hour)}:${padNumber(scheduleInfo.minute)} UTC`
     }
 
     return `${monthLabel}, ${dayOfMonthLabel}, ${dayOfWeekLabel}, ${timeLabel}`
@@ -357,7 +357,7 @@ class WizardSummary extends React.Component<Props> {
             <OverviewLabel>Type</OverviewLabel>
             <OverviewRowData>
               <StatusPill
-                alert
+                alert={type === 'Replica'}
                 small
                 label={this.props.wizardType.toUpperCase()}
                 data-test-id="wSummary-typePill"

--- a/src/components/organisms/WizardSummary/test.jsx
+++ b/src/components/organisms/WizardSummary/test.jsx
@@ -93,7 +93,7 @@ describe('WizardSummary Component', () => {
   it('renders schedule section', () => {
     let wrapper = wrap({ data, schedules, wizardType: 'replica' })
     expect(wrapper.findText(`scheduleItem-${schedules[0].id}`))
-      .toBe('Every February, every 14th, every Wednesday, at 17:00')
+      .toBe('Every February, every 14th, every Wednesday, at 17:00 UTC')
   })
 })
 


### PR DESCRIPTION
Displays blue 'Coriolis Migration' label in wizard summary page.

Shows UTC when displaying time in the Schedule section of the wizard
summary page.