### PR TITLE
Shows 'Use Current for Authentication' switch

### DIFF
--- a/src/components/organisms/Endpoint/Endpoint.jsx
+++ b/src/components/organisms/Endpoint/Endpoint.jsx
@@ -254,7 +254,7 @@ class Endpoint extends React.Component<Props, State> {
     if (!endpointStore.validation) {
       return
     }
-    // $FlowIssue
+
     let succesful = DomUtils.copyTextToClipboard(endpointStore.validation.message)
 
     if (succesful) {

--- a/src/config.js
+++ b/src/config.js
@@ -29,7 +29,12 @@ export const servicesUrl = {
 
 export const userDomain = 'default'
 
-export const useSecret = true // use secret_ref when creating and endpoint
+// Whether to use Barbican secrets when creating a new endpoint
+export const useSecret = true
+
+// Shows the 'Use Current User/Project/Domain for Authentification' switch
+// when creating a new openstack endpoint
+export const showOpenstackCurrentUserSwitch = false
 
 export const navigationMenu = [
   { label: 'Replicas', value: 'replicas' },

--- a/src/sources/EndpointSource.js
+++ b/src/sources/EndpointSource.js
@@ -42,7 +42,7 @@ class EdnpointSource {
       let connections = []
       if (response.data.endpoints.length) {
         response.data.endpoints.forEach(endpoint => {
-          connections.push(endpoint)
+          connections.push(SchemaParser.parseConnectionResponse(endpoint))
         })
       }
 
@@ -115,10 +115,8 @@ class EdnpointSource {
   static update(endpoint: Endpoint): Promise<Endpoint> {
     let parsedEndpoint = SchemaParser.fieldsToPayload(endpoint)
 
-    if (parsedEndpoint.connection_info && parsedEndpoint.connection_info.secret_ref) {
-      // $FlowIgnore
+    if (parsedEndpoint.connectionInfo && Object.keys(parsedEndpoint.connectionInfo).length > 0 && parsedEndpoint.connection_info.secret_ref) {
       let uuidIndex = parsedEndpoint.connection_info.secret_ref.lastIndexOf('/')
-      // $FlowIgnore
       let uuid = parsedEndpoint.connection_info.secret_ref.substr(uuidIndex + 1)
       let newEndpoint: any = {}
       let connectionInfo = {}
@@ -169,7 +167,7 @@ class EdnpointSource {
       method: 'PUT',
       data: { endpoint: parsedEndpoint },
     }).then(response => {
-      return response.data.endpoint
+      return SchemaParser.parseConnectionResponse(response.data.endpoint)
     })
   }
 
@@ -177,7 +175,7 @@ class EdnpointSource {
     let parsedEndpoint: any = skipSchemaParser ? { ...endpoint } : SchemaParser.fieldsToPayload(endpoint)
     let newEndpoint: any = {}
     let connectionInfo = {}
-    if (useSecret) {
+    if (useSecret && parsedEndpoint.connectionInfo && Object.keys(parsedEndpoint.connectionInfo).length > 0) {
       return Api.send({
         url: `${servicesUrl.barbican}/v1/secrets`,
         method: 'POST',
@@ -226,7 +224,7 @@ class EdnpointSource {
         },
       },
     }).then(response => {
-      return response.data.endpoint
+      return SchemaParser.parseConnectionResponse(response.data.endpoint)
     })
   }
 

--- a/src/sources/Schemas.js
+++ b/src/sources/Schemas.js
@@ -17,6 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import { ConnectionSchemaPlugin } from '../plugins/endpoint'
 import { defaultSchemaToFields } from '../plugins/endpoint/default/ConnectionSchemaPlugin'
 import type { Schema } from '../types/Schema'
+import type { Endpoint } from '../types/Endpoint'
 
 class SchemaParser {
   static storedConnectionsSchemas = {}
@@ -54,6 +55,14 @@ class SchemaParser {
     let payload = parsers.parseFieldsToPayload(data, storedSchema)
 
     return payload
+  }
+
+  static parseConnectionResponse(endpoint: Endpoint) {
+    let parseConnectionResponse = ConnectionSchemaPlugin[endpoint.type] && ConnectionSchemaPlugin[endpoint.type].parseConnectionResponse
+    if (!parseConnectionResponse) {
+      return endpoint
+    }
+    return parseConnectionResponse(endpoint)
   }
 }
 

--- a/src/utils/LabelDictionary.js
+++ b/src/utils/LabelDictionary.js
@@ -52,6 +52,7 @@ class LabelDictionary {
     sql_server_hostname: 'SQL Server Hostname Suffix',
     storage_endpoint: 'Storage Endpoint Suffix',
     preserve_nic_ips: 'Preserve NIC IPs',
+    openstack_use_current_user: 'Use Current User/Project/Domain for Authentification',
   }
 
   // Fields which have enums for which dictionary labels should be used.


### PR DESCRIPTION
The switch appears when creating or editing an Openstack endpoint if the
option is enabled in `config.js` (`showOpenstackCurrentUserSwitch`).

If the switch is toggled an empty `connection_string` is sent to the
API.