### PR TITLE
Fix highlighting of last execution task CORWEB-198

### DIFF
--- a/src/components/molecules/TaskItem/TaskItem.jsx
+++ b/src/components/molecules/TaskItem/TaskItem.jsx
@@ -145,7 +145,7 @@ class TaskItem extends React.Component<Props> {
   getLastMessage() {
     let message
     if (this.props.item.progress_updates.length) {
-      message = this.props.item.progress_updates[this.props.item.progress_updates.length - 1].message
+      message = this.props.item.progress_updates[0].message
     } else {
       message = '-'
     }
@@ -222,7 +222,7 @@ class TaskItem extends React.Component<Props> {
           let messageProgress = this.getMessageProgress(update.message)
 
           return (
-            <ProgressUpdate key={i} secondary={i < this.props.item.progress_updates.length - 1 || this.props.item.status !== 'RUNNING'}>
+            <ProgressUpdate key={i} secondary={i > 0 || this.props.item.status !== 'RUNNING'}>
               <ProgressUpdateDate width={this.props.columnWidths[0]}>
                 <span>{DateUtils.getLocalTime(update.created_at).format('YYYY-MM-DD HH:mm:ss')}</span>
               </ProgressUpdateDate>


### PR DESCRIPTION
Instead of highlighting the last task, the first one was highlighted
when an execution was running.