### PR TITLE
Fix random number appearing when loading main list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coriolis-web",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "license": "AGPL-3.0",
   "scripts": {
     "start": "npm run env:dev && node server.js --dev",

--- a/src/components/organisms/MainList/MainList.jsx
+++ b/src/components/organisms/MainList/MainList.jsx
@@ -181,12 +181,16 @@ class MainList extends React.Component<Props> {
       return this.renderList()
     }
 
+    let rebuildTooltip = () => {
+      setTimeout(() => { Tooltip.rebuild() }, 500)
+    }
+
     return (
       <Wrapper>
         {this.props.loading || this.props.items.length === 0 || this.props.showEmptyList ? <Separator /> : null}
         {renderContent()}
         <Tooltip />
-        {setTimeout(() => { Tooltip.rebuild() }, 500)}
+        {rebuildTooltip()}
       </Wrapper>
     )
   }


### PR DESCRIPTION
A random number appears at the bottom of replicas, migrations and
endpoints list, caused by adding the schedule icon tooltip feature.