### PR TITLE
Fix `Edit Replica` modal not scrolling correctly

### DIFF
--- a/src/components/organisms/EditReplica/EditReplica.jsx
+++ b/src/components/organisms/EditReplica/EditReplica.jsx
@@ -48,6 +48,7 @@ const PanelContent = styled.div`
   flex-direction: column;
   justify-content: space-between;
   flex-grow: 1;
+  min-height: 0;
 `
 const LoadingWrapper = styled.div`
   display: flex;


### PR DESCRIPTION
If there are a lot of fields in the Target Options (ex.: Openstack), the
scroll doesn't show up correctly on Chrome and Firefox.