### PR TITLE
Render object fields with no dest options values

### DIFF
--- a/src/plugins/endpoint/default/ConnectionSchemaPlugin.js
+++ b/src/plugins/endpoint/default/ConnectionSchemaPlugin.js
@@ -22,13 +22,19 @@ export const defaultSchemaToFields = (schema: SchemaProperties, schemaDefinition
   let fields = Object.keys(schema.properties).map(fieldName => {
     let properties: any = schema.properties[fieldName]
 
-    if (typeof schema.properties[fieldName].$ref === 'string' && schemaDefinitions) {
-      const definitionName = schema.properties[fieldName].$ref.substr(schema.properties[fieldName].$ref.lastIndexOf('/') + 1)
+    if (typeof properties.$ref === 'string' && schemaDefinitions) {
+      const definitionName = properties.$ref.substr(properties.$ref.lastIndexOf('/') + 1)
       properties = schemaDefinitions[definitionName]
       return {
         name: fieldName,
         type: properties.type ? properties.type : '',
         properties: properties.properties ? defaultSchemaToFields(properties, null, fieldName) : [],
+      }
+    } else if (properties.type === 'object' && properties.properties && Object.keys(properties.properties).length) {
+      return {
+        name: fieldName,
+        type: 'object',
+        properties: defaultSchemaToFields(properties, null, fieldName),
       }
     }
 

--- a/src/stores/ProviderStore.js
+++ b/src/stores/ProviderStore.js
@@ -119,8 +119,9 @@ class ProviderStore {
     return ProviderSource.loadDestinationSchema(providerName, schemaType).then((fields: Field[]) => {
       this.destinationSchemaLoading = false
       this.destinationSchema = fields
-    }).catch(() => {
+    }).catch(err => {
       this.destinationSchemaLoading = false
+      throw err
     })
   }
 


### PR DESCRIPTION
The object fields should now render even though they don't have values
from the destination options API call.

This happens, for example, when editing an Openstack replica and its
dest-options call is disabled in `config.js`.