### PR TITLE
Fix networks refresh delay in Wizard Networks page

### DIFF
--- a/src/stores/NetworkStore.js
+++ b/src/stores/NetworkStore.js
@@ -66,6 +66,7 @@ class NetworkStore {
       }
     }
 
+    this.networks = []
     return NetworkSource.loadNetworks(endpointId, environment, options).then((networks: Network[]) => {
       this.loading = false
       this.networks = networks


### PR DESCRIPTION
While new networks are loaded for new Wizard Options, old networks are
still displayed in the Wizard Networks list.