### PR TITLE
Add support for non-active secret when updating

### DIFF
--- a/src/components/organisms/Endpoint/Endpoint.jsx
+++ b/src/components/organisms/Endpoint/Endpoint.jsx
@@ -155,7 +155,9 @@ class Endpoint extends React.Component<Props, State> {
 
   componentDidMount() {
     providerStore.getConnectionInfoSchema(this.getEndpointType())
-    KeyboardManager.onEnter('endpoint', () => { if (this.isValidateButtonEnabled) this.handleValidateClick() }, 2)
+    KeyboardManager.onEnter('endpoint', () => {
+      if (this.isValidateButtonEnabled) this.handleValidateClick()
+    }, 2)
   }
 
   componentWillReceiveProps(props: Props) {
@@ -281,9 +283,14 @@ class Endpoint extends React.Component<Props, State> {
     }
 
     endpointStore.update(this.state.endpoint).then(() => {
+      let endpoint = endpointStore.endpoints.find(e => this.state.endpoint && e.id === this.state.endpoint.id)
+      if (!endpoint) {
+        throw new Error('endpoint not found')
+      }
+
+      this.setState({ endpoint: ObjectUtils.flatten(endpoint) })
       notificationStore.alert('Validating endpoint ...')
-      // $FlowIssue
-      endpointStore.validate(this.state.endpoint)
+      endpointStore.validate(endpoint)
     })
   }
 
@@ -386,7 +393,9 @@ class Endpoint extends React.Component<Props, State> {
           passwordFields,
           getFieldValue: field => this.getFieldValue(field),
           highlightRequired: () => this.highlightRequired(),
-          handleFieldChange: (field, value) => { if (field) this.handleFieldsChange([{ field, value }]) },
+          handleFieldChange: (field, value) => {
+            if (field) this.handleFieldsChange([{ field, value }])
+          },
           handleFieldsChange: fields => { this.handleFieldsChange(fields) },
           handleValidateClick: () => { this.handleValidateClick() },
           handleCancelClick: () => { this.handleCancelClick() },

--- a/src/stores/EndpointStore.js
+++ b/src/stores/EndpointStore.js
@@ -153,6 +153,9 @@ class EndpointStore {
       this.endpoints = updateEndpoint(updatedEndpoint, this.endpoints)
       this.connectionInfo = { ...updatedEndpoint.connection_info }
       this.updating = false
+    }).catch(e => {
+      this.updating = false
+      throw e
     })
   }
 
@@ -171,8 +174,9 @@ class EndpointStore {
 
       this.connectionInfo = addedEndpoint.connection_info
       this.adding = false
-    }).catch(() => {
+    }).catch(e => {
       this.adding = false
+      throw e
     })
   }
 


### PR DESCRIPTION
When updating or adding a new endpoint, its Barbican secret may not be
active immediately.

A polling is made to make sure the secret is active. If after 10 retries
(2 second waiting period after each request) the secret is still
inactive, the secret payload call gets rejected.