### PR TITLE
Recreate migration from replica CORWEB-202

### DIFF
--- a/src/components/organisms/MainDetails/MainDetails.jsx
+++ b/src/components/organisms/MainDetails/MainDetails.jsx
@@ -338,6 +338,14 @@ class MainDetails extends React.Component<Props> {
               </Field>
             </Row>
           ) : null}
+          {this.props.item && this.props.item.replica_id ? (
+            <Row>
+              <Field>
+                <Label>Created from Replica</Label>
+                <ValueLink to={`/replica/${this.props.item.replica_id}`}>{this.props.item.replica_id}</ValueLink>
+              </Field>
+            </Row>
+          ) : null}
         </Column>
         <Column width="9.5%">
           <Arrow />

--- a/src/components/pages/ReplicaDetailsPage/ReplicaDetailsPage.jsx
+++ b/src/components/pages/ReplicaDetailsPage/ReplicaDetailsPage.jsx
@@ -40,6 +40,7 @@ import endpointStore from '../../../stores/EndpointStore'
 import scheduleStore from '../../../stores/ScheduleStore'
 import instanceStore from '../../../stores/InstanceStore'
 import networkStore from '../../../stores/NetworkStore'
+import notificationStore from '../../../stores/NotificationStore'
 import configLoader from '../../../utils/Config'
 
 import replicaImage from './images/replica.svg'
@@ -261,7 +262,16 @@ class ReplicaDetailsPage extends React.Component<Props, State> {
   }
 
   migrateReplica(options: Field[]) {
-    migrationStore.migrateReplica(replicaStore.replicaDetails ? replicaStore.replicaDetails.id : '', options)
+    migrationStore.migrateReplica(replicaStore.replicaDetails ? replicaStore.replicaDetails.id : '', options).then(migration => {
+      notificationStore.alert('Migration successfully created from replica.', 'success', {
+        action: {
+          label: 'View Migration Status',
+          callback: () => {
+            this.props.history.push(`/migration/tasks/${migration.id}`)
+          },
+        },
+      })
+    })
     this.handleCloseMigrationModal()
   }
 

--- a/src/stores/MigrationStore.js
+++ b/src/stores/MigrationStore.js
@@ -19,9 +19,7 @@ import { observable, action } from 'mobx'
 import type { MainItem, UpdateData } from '../types/MainItem'
 import type { Field } from '../types/Field'
 import type { Endpoint } from '../types/Endpoint'
-import notificationStore from '../stores/NotificationStore'
 import MigrationSource from '../sources/MigrationSource'
-import DomUtils from '../utils/DomUtils'
 
 class MigrationStore {
   @observable migrations: MainItem[] = []
@@ -93,21 +91,13 @@ class MigrationStore {
     })
   }
 
-  @action migrateReplica(replicaId: string, options: Field[]) {
+  @action migrateReplica(replicaId: string, options: Field[]): Promise<MainItem> {
     return MigrationSource.migrateReplica(replicaId, options).then(migration => {
       this.migrations = [
         migration,
         ...this.migrations,
       ]
-
-      notificationStore.alert('Migration successfully created from replica.', 'success', {
-        action: {
-          label: 'View Migration Status',
-          callback: () => {
-            window.location.href = `/${DomUtils.urlHashPrefix}migration/tasks/${migration.id}`
-          },
-        },
-      })
+      return migration
     })
   }
 

--- a/src/types/MainItem.js
+++ b/src/types/MainItem.js
@@ -45,6 +45,7 @@ export type MainItem = {
   tasks: Task[],
   created_at: Date,
   updated_at: Date,
+  replica_id?: string,
   origin_endpoint_id: string,
   destination_endpoint_id: string,
   instances: string[],


### PR DESCRIPTION
When recreating a migration, recreate it from the original replica, if
the migration was originally created from a replica.

Show the Create Migration from Replica modal if that's the case.

The Migration Details page displays a link to the original replica,
if it has one.