### PR TITLE
Dynamically change 'Separate / VM' label CORWEB-206

### DIFF
--- a/src/components/molecules/WizardOptionsField/WizardOptionsField.jsx
+++ b/src/components/molecules/WizardOptionsField/WizardOptionsField.jsx
@@ -70,6 +70,7 @@ type Props = {
   enum: string[],
   required: boolean,
   width?: number,
+  label?: string,
   skipNullValue?: boolean,
   'data-test-id'?: string,
   style?: { [string]: mixed },
@@ -223,7 +224,7 @@ class WizardOptionsField extends React.Component<Props> {
     return (
       <Label>
         <LabelText data-test-id="wOptionsField-label" noMargin={!description && !this.props.required}>
-          {LabelDictionary.get(this.props.name)}
+          {this.props.label || LabelDictionary.get(this.props.name)}
         </LabelText>
         {description ? <InfoIcon text={description} marginLeft={-20} /> : null}
         {this.props.required ? <Asterisk data-test-id="wOptionsField-required" marginLeft={description ? '4px' : '-16px'} /> : null}

--- a/src/components/organisms/WizardOptions/WizardOptions.jsx
+++ b/src/components/organisms/WizardOptions/WizardOptions.jsx
@@ -29,6 +29,7 @@ import type { Instance } from '../../../types/Instance'
 import type { StorageBackend } from '../../../types/Endpoint'
 
 import { executionOptions } from '../../../constants'
+import LabelDictionary from '../../../utils/LabelDictionary'
 
 const Wrapper = styled.div`
   display: flex;
@@ -127,7 +128,9 @@ class WizardOptions extends React.Component<Props> {
     }
 
     if (this.props.selectedInstances && this.props.selectedInstances.length > 1) {
-      fieldsSchema.unshift({ name: 'separate_vm', type: 'strict-boolean', default: true })
+      let dictionaryLabel = LabelDictionary.get('separate_vm')
+      let label = this.props.wizardType === 'migration' ? dictionaryLabel : dictionaryLabel.replace('Migration', 'Replica')
+      fieldsSchema.unshift({ name: 'separate_vm', label, type: 'strict-boolean', default: true })
     }
 
     if (this.props.wizardType === 'replica') {
@@ -180,6 +183,7 @@ class WizardOptions extends React.Component<Props> {
         required={field.required}
         data-test-id={`wOptions-field-${field.name}`}
         width={this.props.fieldWidth}
+        label={field.label}
         {...additionalProps}
       />
     )


### PR DESCRIPTION
Use 'Separate Replica/VM' if wizard type is replica and 'Migration' if
wizard type is migration.