### PR TITLE
Fix progress text getting outside of panel bounds

### DIFF
--- a/private/storybook/Decorator.jsx
+++ b/private/storybook/Decorator.jsx
@@ -14,6 +14,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // @flow
 
+import 'babel-polyfill'
+
 import * as React from 'react'
 import styled, { injectGlobal } from 'styled-components'
 import Palette from '../../src/components/styleUtils/Palette'

--- a/src/components/molecules/TaskItem/TaskItem.jsx
+++ b/src/components/molecules/TaskItem/TaskItem.jsx
@@ -110,6 +110,8 @@ const Value = styled.div`
 `
 const ExceptionText = styled.div`
   cursor: pointer;
+  text-overflow: ellipsis;
+  overflow: hidden;
   &:hover > span {
     opacity: 1;
   }

--- a/src/components/organisms/ProjectMemberModal/ProjectMemberModal.jsx
+++ b/src/components/organisms/ProjectMemberModal/ProjectMemberModal.jsx
@@ -262,7 +262,6 @@ class ProjectMemberModal extends React.Component<Props, State> {
         disabled={this.props.loading}
         enum={field.enum}
         password={field.name === 'password' || field.name === 'confirm_password'}
-        // $FlowIssue
         required={field.required}
         highlight={Boolean(this.state.highlightFieldNames.find(n => n === field.name))}
         noSelectionMessage="Choose a project"


### PR DESCRIPTION
Progress text in execution's task gets outside of panel bounds if the
text has a very long word like a long error ID.