### PR TITLE
Add 'source-options' API support

### DIFF
--- a/config.js
+++ b/config.js
@@ -37,10 +37,17 @@ const conf: Config = {
   // - `Infinity` value means no `limit` will be used, i.e. all VMs will be listed.
   instancesListBackgroundLoading: { default: 10, ovm: Infinity },
 
+  // A list of providers for which `source-options` API call(s) will be made
+  // If the item is just a string with the provider name, only one API call will be made
+  // If the item has `envRequiredFields`, an additional API call will be made once the specified fields are filled
+  sourceProvidersWithExtraOptions: [
+    'aws',
+  ],
+
   // A list of providers for which `destination-options` API call(s) will be made
   // If the item is just a string with the provider name, only one API call will be made
   // If the item has `envRequiredFields`, an additional API call will be made once the specified fields are filled
-  providersWithExtraOptions: [
+  destinationProvidersWithExtraOptions: [
     'openstack',
     'oracle_vm',
     'aws',

--- a/src/components/atoms/DropdownButton/DropdownButton.jsx
+++ b/src/components/atoms/DropdownButton/DropdownButton.jsx
@@ -35,7 +35,7 @@ const getLabelColor = props => {
 }
 const Label = styled.div`
   color: ${props => getLabelColor(props)};
-  margin: 0 32px 0 16px;
+  margin: 0 32px 0 ${props => props.embedded ? 0 : 16}px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -119,7 +119,6 @@ const Wrapper = styled.div`
   ${props => props.embedded ? css`
     border: 0;
     width: calc(100% + 8px);
-    margin-left: -16px;
   ` : ''}
 
   #dropdown-arrow-image {stroke: ${props => getArrowColor(props)};}

--- a/src/components/molecules/PropertiesTable/PropertiesTable.jsx
+++ b/src/components/molecules/PropertiesTable/PropertiesTable.jsx
@@ -34,9 +34,9 @@ const Wrapper = styled.div`
   border-radius: ${StyleProps.borderRadius};
 `
 const Column = styled.div`
-  ${StyleProps.exactWidth('calc(50% - 32px)')}
+  ${StyleProps.exactWidth('calc(50% - 24px)')}
   height: 32px;
-  padding: 0 16px;
+  padding: 0 8px 0 16px;
   display: flex;
   align-items: center;
   ${props => props.header ? css`

--- a/src/components/organisms/EditReplica/EditReplica.jsx
+++ b/src/components/organisms/EditReplica/EditReplica.jsx
@@ -108,7 +108,12 @@ class EditReplica extends React.Component<Props, State> {
     })
 
     providerStore.loadDestinationSchema(this.props.destinationEndpoint.type, this.props.type || 'replica').then(() => {
-      return providerStore.getDestinationOptions(this.props.destinationEndpoint.id, this.props.destinationEndpoint.type, undefined, true)
+      return providerStore.getOptionsValues({
+        optionsType: 'destination',
+        endpointId: this.props.destinationEndpoint.id,
+        provider: this.props.destinationEndpoint.type,
+        useCache: true,
+      })
     }).then(() => {
       this.loadEnvDestinationOptions()
     })
@@ -167,7 +172,13 @@ class EditReplica extends React.Component<Props, State> {
     })
 
     if (envData) {
-      providerStore.getDestinationOptions(this.props.destinationEndpoint.id, this.props.destinationEndpoint.type, envData, true)
+      providerStore.getOptionsValues({
+        optionsType: 'destination',
+        endpointId: this.props.destinationEndpoint.id,
+        provider: this.props.destinationEndpoint.type,
+        useCache: true,
+        envData,
+      })
     }
   }
 

--- a/src/components/organisms/WizardPageContent/WizardPageContent.jsx
+++ b/src/components/organisms/WizardPageContent/WizardPageContent.jsx
@@ -335,7 +335,7 @@ class WizardPageContent extends React.Component<Props, State> {
       case 'source-options':
         body = (
           <WizardOptions
-            loading={this.props.providerStore.sourceSchemaLoading}
+            loading={this.props.providerStore.sourceSchemaLoading || this.props.providerStore.sourceOptionsLoading}
             fields={this.props.providerStore.sourceSchema}
             onChange={this.props.onSourceOptionsChange}
             data={this.props.wizardData.sourceOptions}

--- a/src/components/pages/AssessmentDetailsPage/AssessmentDetailsPage.jsx
+++ b/src/components/pages/AssessmentDetailsPage/AssessmentDetailsPage.jsx
@@ -314,7 +314,11 @@ class AssessmentDetailsPage extends React.Component<Props, State> {
 
   loadTargetOptions(): Promise<void> {
     let localData = this.getLocalData()
-    return providerStore.getDestinationOptions(localData.endpoint.id, localData.endpoint.type).then(options => {
+    return providerStore.getOptionsValues({
+      optionsType: 'destination',
+      endpointId: localData.endpoint.id,
+      provider: localData.endpoint.type,
+    }).then(options => {
       let locations = options.find(o => o.name === 'location')
       if (locations && locations.values) {
         let localDataFind = locations.values.find(l => l.id === localData.locationName)
@@ -338,9 +342,14 @@ class AssessmentDetailsPage extends React.Component<Props, State> {
   loadTargetVmSizes() {
     let localData = this.getLocalData()
     this.setState({ loadingTargetVmSizes: true })
-    providerStore.getDestinationOptions(localData.endpoint.id, localData.endpoint.type, {
-      location: localData.locationName,
-      resource_group: localData.resourceGroupName,
+    providerStore.getOptionsValues({
+      optionsType: 'destination',
+      endpointId: localData.endpoint.id,
+      provider: localData.endpoint.type,
+      envData: {
+        location: localData.locationName,
+        resource_group: localData.resourceGroupName,
+      },
     }).then(options => {
       let vmSizes = options.find(o => o.name === 'vm_size')
       if (vmSizes && vmSizes.values) {

--- a/src/plugins/endpoint/default/OptionsSchemaPlugin.js
+++ b/src/plugins/endpoint/default/OptionsSchemaPlugin.js
@@ -15,13 +15,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // @flow
 
 import type { Field } from '../../../types/Field'
-import type { DestinationOption, StorageMap } from '../../../types/Endpoint'
+import type { OptionValues, StorageMap } from '../../../types/Endpoint'
 import type { NetworkMap } from '../../../types/Network'
 import { executionOptions } from '../../../constants'
 
 const migrationImageOsTypes = ['windows', 'linux']
 
-export const defaultFillFieldValues = (field: Field, option: DestinationOption) => {
+export const defaultFillFieldValues = (field: Field, option: OptionValues) => {
   if (field.type === 'string') {
     field.enum = [...option.values]
     if (option.config_default) {
@@ -33,7 +33,7 @@ export const defaultFillFieldValues = (field: Field, option: DestinationOption) 
   }
 }
 
-export const defaultFillMigrationImageMapValues = (field: Field, option: DestinationOption): boolean => {
+export const defaultFillMigrationImageMapValues = (field: Field, option: OptionValues): boolean => {
   if (field.name === 'migr_image_map') {
     field.properties = migrationImageOsTypes.map(os => {
       let values = option.values
@@ -109,7 +109,7 @@ export const defaultGetMigrationImageMap = (options: ?{ [string]: mixed }) => {
 }
 
 export default class OptionsSchemaParser {
-  static fillFieldValues(field: Field, options: DestinationOption[]) {
+  static fillFieldValues(field: Field, options: OptionValues[]) {
     let option = options.find(f => f.name === field.name)
     if (!option) {
       return

--- a/src/sources/ProviderSource.js
+++ b/src/sources/ProviderSource.js
@@ -19,7 +19,7 @@ import { servicesUrl, providerTypes } from '../constants'
 import { SchemaParser } from './Schemas'
 import type { Field } from '../types/Field'
 import type { Providers } from '../types/Providers'
-import type { DestinationOption } from '../types/Endpoint'
+import type { OptionValues } from '../types/Endpoint'
 
 class ProviderSource {
   static getConnectionInfoSchema(providerName: string): Promise<Field[]> {
@@ -44,8 +44,8 @@ class ProviderSource {
     })
   }
 
-  static loadSourceSchema(providerName: string, isReplica: boolean): Promise<Field[]> {
-    let schemaTypeInt = isReplica ? providerTypes.SOURCE_REPLICA : providerTypes.SOURCE_MIGRATION
+  static loadSourceSchema(providerName: string, schemaType: string): Promise<Field[]> {
+    let schemaTypeInt = schemaType === 'replica' ? providerTypes.SOURCE_REPLICA : providerTypes.SOURCE_MIGRATION
 
     return Api.get(`${servicesUrl.coriolis}/${Api.projectId}/providers/${providerName}/schemas/${schemaTypeInt}`).then(response => {
       let schema = { oneOf: [response.data.schemas.source_environment_schema] }
@@ -54,14 +54,16 @@ class ProviderSource {
     })
   }
 
-  static getDestinationOptions(endpointId: string, envData: ?{ [string]: mixed }): Promise<DestinationOption[]> {
+  static getOptionsValues(optionsType: 'source' | 'destination', endpointId: string, envData: ?{ [string]: mixed }): Promise<OptionValues[]> {
     let envString = ''
     if (envData) {
       envString = `?env=${btoa(JSON.stringify(envData))}`
     }
+    let callName = optionsType === 'source' ? 'source-options' : 'destination-options'
+    let fieldName = optionsType === 'source' ? 'source_options' : 'destination_options'
 
-    return Api.get(`${servicesUrl.coriolis}/${Api.projectId}/endpoints/${endpointId}/destination-options${envString}`)
-      .then(response => response.data.destination_options)
+    return Api.get(`${servicesUrl.coriolis}/${Api.projectId}/endpoints/${endpointId}/${callName}${envString}`)
+      .then(response => response.data[fieldName])
   }
 }
 

--- a/src/types/Config.js
+++ b/src/types/Config.js
@@ -9,5 +9,6 @@ export type Config = {
   requestPollTimeout: number,
   sourceOptionsProviders: string[],
   instancesListBackgroundLoading: { default: number, [string]: number },
-  providersWithExtraOptions: Array<string | { name: string, envRequiredFields: string[] }>,
+  sourceProvidersWithExtraOptions: Array<string | { name: string, envRequiredFields: string[] }>,
+  destinationProvidersWithExtraOptions: Array<string | { name: string, envRequiredFields: string[] }>,
 }

--- a/src/types/Endpoint.js
+++ b/src/types/Endpoint.js
@@ -34,7 +34,7 @@ export type Endpoint = {
   },
 }
 
-export type DestinationOption = {
+export type OptionValues = {
   name: string,
   // $FlowIssue
   values: string[] | { name: string, id: string, [string]: mixed }[],


### PR DESCRIPTION
AWS supports source options schema and now it also supports
'source-options' API calls to populate the source options schema with
available values, similar to 'destination-options' API calls available
to other providers.

To add to the list of providers which support the 'source-options' API,
update the `sourceProvidersWithExtraOptions` property in `./config.js`
file.