### PR TITLE
Disable editing if provider doesn't support it

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -48,6 +48,7 @@ export const navigationMenu = [
 // PROVIDER_TYPE_EXPORT = 2 // migration source schema
 // PROVIDER_TYPE_REPLICA_IMPORT = 4 // replica target schema
 // PROVIDER_TYPE_REPLICA_EXPORT = 8 // replica source schema
+// PROVIDER_TYPE_REPLICA_UPDATE = 65536 // the replica can be updated if provider is target
 export const providerTypes = {
   TARGET_MIGRATION: 1,
   SOURCE_MIGRATION: 2,
@@ -55,6 +56,7 @@ export const providerTypes = {
   SOURCE_REPLICA: 8,
   CONNECTION: 16,
   STORAGE: 32768,
+  UPDATE: 65536,
 }
 
 export const loginButtons = [

--- a/src/types/Providers.js
+++ b/src/types/Providers.js
@@ -15,7 +15,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // @flow
 
 export type Providers = {
-  [string]: {
+  [provider: string]: {
     types: number[],
   },
 }

--- a/src/utils/ObjectUtils.js
+++ b/src/utils/ObjectUtils.js
@@ -54,6 +54,19 @@ class ObjectUtils {
 
     return result
   }
+
+  static waitFor(predicate: () => boolean): Promise<void> {
+    let test = () => new Promise((resolve) => {
+      if (predicate()) {
+        resolve()
+        return
+      }
+      setTimeout(() => {
+        test()
+      }, 1000)
+    })
+    return test()
+  }
 }
 
 export default ObjectUtils


### PR DESCRIPTION
Replica editing is disabled if target provider doesn't support replica
update.