### PR TITLE
Fix polling not clearing on Details pages

### DIFF
--- a/src/components/pages/MigrationDetailsPage/MigrationDetailsPage.jsx
+++ b/src/components/pages/MigrationDetailsPage/MigrationDetailsPage.jsx
@@ -61,7 +61,7 @@ class MigrationDetailsPage extends React.Component<Props, State> {
     showFromReplicaModal: false,
   }
 
-  pollTimeout: TimeoutID
+  stopPolling: ?boolean
 
   componentDidMount() {
     document.title = 'Migration Details'
@@ -82,7 +82,7 @@ class MigrationDetailsPage extends React.Component<Props, State> {
 
   componentWillUnmount() {
     migrationStore.clearDetails()
-    clearTimeout(this.pollTimeout)
+    this.stopPolling = true
   }
 
   loadMigrationWithInstances(migrationId: string, cache: boolean) {
@@ -178,11 +178,11 @@ class MigrationDetailsPage extends React.Component<Props, State> {
   }
 
   pollData() {
-    if (this.state.showEditModal) {
+    if (this.state.showEditModal || this.stopPolling) {
       return
     }
     migrationStore.getMigration(this.props.match.params.id, false).then(() => {
-      this.pollTimeout = setTimeout(() => { this.pollData() }, configLoader.config.requestPollTimeout)
+      setTimeout(() => { this.pollData() }, configLoader.config.requestPollTimeout)
     })
   }
 

--- a/src/components/pages/ReplicaDetailsPage/ReplicaDetailsPage.jsx
+++ b/src/components/pages/ReplicaDetailsPage/ReplicaDetailsPage.jsx
@@ -81,7 +81,7 @@ class ReplicaDetailsPage extends React.Component<Props, State> {
     isEditable: false,
   }
 
-  pollTimeout: TimeoutID
+  stopPolling: ?boolean
 
   componentDidMount() {
     document.title = 'Replica Details'
@@ -102,7 +102,7 @@ class ReplicaDetailsPage extends React.Component<Props, State> {
   componentWillUnmount() {
     replicaStore.clearDetails()
     scheduleStore.clearUnsavedSchedules()
-    clearTimeout(this.pollTimeout)
+    this.stopPolling = true
   }
 
   loadIsEditable(replicaDetails: MainItem) {
@@ -306,7 +306,7 @@ class ReplicaDetailsPage extends React.Component<Props, State> {
   }
 
   pollData(showLoading: boolean) {
-    if (this.state.showEditModal) {
+    if (this.state.showEditModal || this.stopPolling) {
       return
     }
 
@@ -315,7 +315,7 @@ class ReplicaDetailsPage extends React.Component<Props, State> {
     }
 
     replicaStore.getReplicaExecutions(this.props.match.params.id, showLoading).then(() => {
-      this.pollTimeout = setTimeout(() => { this.pollData(false) }, configLoader.config.requestPollTimeout)
+      setTimeout(() => { this.pollData(false) }, configLoader.config.requestPollTimeout)
     })
   }
 


### PR DESCRIPTION
Sometimes polling wouldn't get cleared after going from Details page to
another Details page, so the new Details page would show info from a
wrong page.