### PR TITLE
Fix Edit Replica modal layout issues

### DIFF
--- a/src/components/molecules/PropertiesTable/PropertiesTable.jsx
+++ b/src/components/molecules/PropertiesTable/PropertiesTable.jsx
@@ -63,6 +63,7 @@ type Props = {
   properties: Field[],
   onChange: (property: Field, value: any) => void,
   valueCallback: (property: Field) => any,
+  hideRequiredSymbol?: boolean,
 }
 @observer
 class PropertiesTable extends React.Component<Props> {
@@ -95,7 +96,7 @@ class PropertiesTable extends React.Component<Props> {
         value={this.props.valueCallback(prop)}
         onChange={e => { this.props.onChange(prop, e.target.value) }}
         placeholder={this.getName(prop.name)}
-        required={typeof prop.required === 'boolean' ? prop.required : false}
+        required={typeof prop.required === 'boolean' && !this.props.hideRequiredSymbol ? prop.required : false}
       />
     )
   }
@@ -135,6 +136,7 @@ class PropertiesTable extends React.Component<Props> {
         selectedItem={selectedItem}
         items={items}
         onChange={item => this.props.onChange(prop, item.value)}
+        required={typeof prop.required === 'boolean' && !this.props.hideRequiredSymbol ? prop.required : false}
       />
     )
   }

--- a/src/components/molecules/WizardOptionsField/WizardOptionsField.jsx
+++ b/src/components/molecules/WizardOptionsField/WizardOptionsField.jsx
@@ -115,6 +115,7 @@ class WizardOptionsField extends React.Component<Props> {
         properties={this.props.properties}
         valueCallback={this.props.valueCallback}
         onChange={this.props.onChange}
+        hideRequiredSymbol
         data-test-id="wOptionsField-propertiesTable"
       />
     )

--- a/src/utils/LabelDictionary.js
+++ b/src/utils/LabelDictionary.js
@@ -51,6 +51,8 @@ const dictionary = {
   storage_endpoint: 'Storage Endpoint Suffix',
   preserve_nic_ips: 'Preserve NIC IPs',
   openstack_use_current_user: 'Use Current User/Project/Domain for Authentification',
+  windows_os_image: 'Windows OS',
+  linux_os_image: 'Linux OS',
 }
 
 const cache: { name: string, label: ?string, description: ?string }[] = []


### PR DESCRIPTION
The AWS source options should look a little better since the
PropertiesTable labels are shorter.

Remove the PropertiesTable required symbols from Edit Replica modal,
visible for Azure target endpoint.