### PR TITLE
Update the "is replica editable" function

### DIFF
--- a/src/components/pages/ReplicaDetailsPage/ReplicaDetailsPage.jsx
+++ b/src/components/pages/ReplicaDetailsPage/ReplicaDetailsPage.jsx
@@ -107,16 +107,22 @@ class ReplicaDetailsPage extends React.Component<Props, State> {
 
   loadIsEditable(replicaDetails: MainItem) {
     let targetEndpointId = replicaDetails.destination_endpoint_id
+    let sourceEndpointId = replicaDetails.origin_endpoint_id
     providerStore.loadProviders()
       .then(() => utils.waitFor(() => endpointStore.endpoints.length > 0))
       .then(() => {
-        let endpoint = endpointStore.endpoints.find(e => e.id === targetEndpointId)
-        if (!endpoint) {
+        let sourceEndpoint = endpointStore.endpoints.find(e => e.id === sourceEndpointId)
+        let targetEndpoint = endpointStore.endpoints.find(e => e.id === targetEndpointId)
+        if (!sourceEndpoint || !targetEndpoint || !providerStore.providers) {
           return
         }
-        let isEditable = providerStore.providers && providerStore.providers[endpoint.type] ?
-          !!providerStore.providers[endpoint.type].types.find(t => t === providerTypes.UPDATE)
+        let sourceProviderTypes = providerStore.providers[sourceEndpoint.type]
+        let targetProviderTypes = providerStore.providers[targetEndpoint.type]
+        let isEditable = sourceProviderTypes && targetProviderTypes ?
+          !!sourceProviderTypes.types.find(t => t === providerTypes.SOURCE_UPDATE)
+          && !!targetProviderTypes.types.find(t => t === providerTypes.TARGET_UPDATE)
           : false
+
         this.setState({ isEditable })
       })
   }

--- a/src/constants.js
+++ b/src/constants.js
@@ -49,7 +49,8 @@ PROVIDER_TYPE_EXPORT = 2 // migration source schema
 PROVIDER_TYPE_REPLICA_IMPORT = 4 // replica target schema
 PROVIDER_TYPE_REPLICA_EXPORT = 8 // replica source schema
 PROVIDER_TYPE_ENDPOINT_STORAGE = 32768
-PROVIDER_TYPE_REPLICA_UPDATE = 65536 // the replica can be updated if provider is target */
+PROVIDER_TYPE_SOURCE_REPLICA_UPDATE = 65536 // the replica can be updated if provider is source
+PROVIDER_TYPE_DESTINATION_REPLICA_UPDATE = 262144 // the replica can be updated if provider is source */
 export const providerTypes = {
   TARGET_MIGRATION: 1,
   SOURCE_MIGRATION: 2,
@@ -57,7 +58,8 @@ export const providerTypes = {
   SOURCE_REPLICA: 8,
   CONNECTION: 16,
   STORAGE: 32768,
-  UPDATE: 65536,
+  SOURCE_UPDATE: 65536,
+  TARGET_UPDATE: 262144,
 }
 
 export const loginButtons = [


### PR DESCRIPTION
The Coriolis `constants.py` has been updated: a replica should be
editable if both the target and the source provider have update
capabilities.