### PR TITLE
Dynamically detect if a provider has env options

### DIFF
--- a/config.js
+++ b/config.js
@@ -37,24 +37,16 @@ const conf: Config = {
   // - `Infinity` value means no `limit` will be used, i.e. all VMs will be listed.
   instancesListBackgroundLoading: { default: 10, ovm: Infinity },
 
-  // A list of providers for which `source-options` API call(s) will be made
-  // If the item is just a string with the provider name, only one API call will be made
-  // If the item has `envRequiredFields`, an additional API call will be made once the specified fields are filled
-  sourceProvidersWithExtraOptions: ['aws'],
-
-  // A list of providers for which `destination-options` API call(s) will be made
-  // If the item is just a string with the provider name, only one API call will be made
-  // If the item has `envRequiredFields`, an additional API call will be made once the specified fields are filled
-  destinationProvidersWithExtraOptions: [
-    'openstack',
-    'oracle_vm',
-    'aws',
+  // The providers for which an extra `source` or `destination options` call can be made with a set of field values
+  providersWithEnvOptions: [
     {
       name: 'azure',
+      type: 'destination',
       envRequiredFields: ['location', 'resource_group'],
     },
     {
       name: 'oci',
+      type: 'destination',
       envRequiredFields: ['compartment', 'availability_domain'],
     },
   ],

--- a/src/components/pages/WizardPage/WizardPage.jsx
+++ b/src/components/pages/WizardPage/WizardPage.jsx
@@ -26,7 +26,7 @@ import Modal from '../../molecules/Modal'
 import Endpoint from '../../organisms/Endpoint'
 
 import userStore from '../../../stores/UserStore'
-import providerStore, { getFieldChangeDestOptions } from '../../../stores/ProviderStore'
+import providerStore, { getFieldChangeOptions } from '../../../stores/ProviderStore'
 import endpointStore from '../../../stores/EndpointStore'
 import wizardStore from '../../../stores/WizardStore'
 import instanceStore from '../../../stores/InstanceStore'
@@ -248,7 +248,11 @@ class WizardPage extends React.Component<Props, State> {
     // Preload destination options schema
     providerStore.loadDestinationSchema(target.type, this.state.type).then(() => {
       // Preload destination options values
-      providerStore.getOptionsValues({ optionsType: 'destination', endpointId: target.id, provider: target.type })
+      providerStore.getOptionsValues({
+        optionsType: 'destination',
+        endpointId: target.id,
+        provider: target.type,
+      })
     })
     if (this.pages.find(p => p.id === 'storage')) {
       endpointStore.loadStorage(target.id, {})
@@ -349,11 +353,12 @@ class WizardPage extends React.Component<Props, State> {
 
   loadEnvDestinationOptions(field?: Field) {
     let provider = wizardStore.data.target && wizardStore.data.target.type
-    let envData = getFieldChangeDestOptions({
+    let envData = getFieldChangeOptions({
       provider: wizardStore.data.target && wizardStore.data.target.type,
-      destSchema: providerStore.destinationSchema,
+      schema: providerStore.destinationSchema,
       data: wizardStore.data.destOptions,
       field,
+      type: 'destination',
     })
 
     if (provider && envData && wizardStore.data.target) {
@@ -381,7 +386,11 @@ class WizardPage extends React.Component<Props, State> {
           providerStore.loadSourceSchema(source.type, this.state.type).then(() => {
             // Preload source options if data is set from 'Permalink'
             if (providerStore.sourceOptions.length === 0 && source) {
-              providerStore.getOptionsValues({ optionsType: 'source', endpointId: source.id, provider: source.type })
+              providerStore.getOptionsValues({
+                optionsType: 'source',
+                endpointId: source.id,
+                provider: source.type,
+              })
             }
           })
         }

--- a/src/constants.js
+++ b/src/constants.js
@@ -43,20 +43,15 @@ export const navigationMenu = [
   { label: 'Users', value: 'users', requiresAdmin: true },
 ]
 
-/* https://github.com/cloudbase/coriolis/blob/master/coriolis/constants.py
-PROVIDER_TYPE_IMPORT = 1 // migration target schema
-PROVIDER_TYPE_EXPORT = 2 // migration source schema
-PROVIDER_TYPE_REPLICA_IMPORT = 4 // replica target schema
-PROVIDER_TYPE_REPLICA_EXPORT = 8 // replica source schema
-PROVIDER_TYPE_ENDPOINT_STORAGE = 32768
-PROVIDER_TYPE_SOURCE_REPLICA_UPDATE = 65536 // the replica can be updated if provider is source
-PROVIDER_TYPE_DESTINATION_REPLICA_UPDATE = 262144 // the replica can be updated if provider is source */
+// https://github.com/cloudbase/coriolis/blob/master/coriolis/constants.py
 export const providerTypes = {
   TARGET_MIGRATION: 1,
   SOURCE_MIGRATION: 2,
   TARGET_REPLICA: 4,
   SOURCE_REPLICA: 8,
   CONNECTION: 16,
+  DESTINATION_OPTIONS: 512,
+  SOURCE_OPTIONS: 131072,
   STORAGE: 32768,
   SOURCE_UPDATE: 65536,
   TARGET_UPDATE: 262144,

--- a/src/types/Config.js
+++ b/src/types/Config.js
@@ -9,8 +9,7 @@ export type Config = {
   requestPollTimeout: number,
   sourceOptionsProviders: string[],
   instancesListBackgroundLoading: { default: number, [string]: number },
-  sourceProvidersWithExtraOptions: Array<string | { name: string, envRequiredFields: string[] }>,
-  destinationProvidersWithExtraOptions: Array<string | { name: string, envRequiredFields: string[] }>,
+  providersWithEnvOptions: Array<{ name: string, type: 'source' | 'destination', envRequiredFields: string[] }>,
   providerSortPriority: { [providerName: string]: number },
   hiddenUsers: string[],
 }


### PR DESCRIPTION
Dynamically detect if a provider can make `destination-options` or
`source-options` API calls to fill the destination / source options
schema. For this, we use Coriolis API's `constants.py` info.

Previously, the list of providers which support these calls was stored
in `config.js`. Note that we still need to store the providers which can
make additional destination / source API calls with a set of field
values, in the config file.