### PR TITLE
Skip empty string fields when creating replica

### DIFF
--- a/src/components/organisms/WizardSummary/WizardSummary.jsx
+++ b/src/components/organisms/WizardSummary/WizardSummary.jsx
@@ -248,7 +248,7 @@ class WizardSummary extends React.Component<Props> {
         <SectionTitle>{type} Source Options</SectionTitle>
         <OptionsList>
           {data.sourceOptions ? Object.keys(data.sourceOptions).map(optionName => {
-            if (!data.sourceOptions || data.sourceOptions[optionName] == null) {
+            if (!data.sourceOptions || data.sourceOptions[optionName] == null || data.sourceOptions[optionName] === '') {
               return null
             }
 
@@ -296,7 +296,7 @@ class WizardSummary extends React.Component<Props> {
             if (
               optionName === 'execute_now' ||
               optionName === 'separate_vm' ||
-              !data.destOptions || data.destOptions[optionName] == null
+              !data.destOptions || data.destOptions[optionName] == null || data.destOptions[optionName] === ''
             ) {
               return null
             }

--- a/src/plugins/endpoint/default/OptionsSchemaPlugin.js
+++ b/src/plugins/endpoint/default/OptionsSchemaPlugin.js
@@ -34,32 +34,32 @@ export const defaultFillFieldValues = (field: Field, option: OptionValues) => {
 }
 
 export const defaultFillMigrationImageMapValues = (field: Field, option: OptionValues): boolean => {
-  if (field.name === 'migr_image_map') {
-    field.properties = migrationImageOsTypes.map(os => {
-      let values = option.values
-        .filter(v => v.os_type === os || v.os_type === 'unknown')
-        .sort((v1, v2) => {
-          if (v1.os_type === 'unknown' && v2.os_type !== 'unknown') {
-            return 1
-          } else if (v1.os_type !== 'unknown' && v2.os_type === 'unknown') {
-            return -1
-          }
-          return 0
-        })
-      let unknownIndex = values.findIndex(v => v.os_type === 'unknown')
-      if (unknownIndex > -1 && values.filter(v => v.os_type === 'unknown').length < values.length) {
-        values.splice(unknownIndex, 0, { separator: true })
-      }
-
-      return {
-        name: `${os}_os_image`,
-        type: 'string',
-        enum: values,
-      }
-    })
-    return true
+  if (field.name !== 'migr_image_map') {
+    return false
   }
-  return false
+  field.properties = migrationImageOsTypes.map(os => {
+    let values = option.values
+      .filter(v => v.os_type === os || v.os_type === 'unknown')
+      .sort((v1, v2) => {
+        if (v1.os_type === 'unknown' && v2.os_type !== 'unknown') {
+          return 1
+        } else if (v1.os_type !== 'unknown' && v2.os_type === 'unknown') {
+          return -1
+        }
+        return 0
+      })
+    let unknownIndex = values.findIndex(v => v.os_type === 'unknown')
+    if (unknownIndex > -1 && values.filter(v => v.os_type === 'unknown').length < values.length) {
+      values.splice(unknownIndex, 0, { separator: true })
+    }
+
+    return {
+      name: `${os}_os_image`,
+      type: 'string',
+      enum: values,
+    }
+  })
+  return true
 }
 
 export const defaultGetDestinationEnv = (options: ?{ [string]: mixed }, oldOptions?: ?{ [string]: mixed }): any => {
@@ -68,12 +68,12 @@ export const defaultGetDestinationEnv = (options: ?{ [string]: mixed }, oldOptio
     .concat(executionOptions.map(o => o.name))
     .concat(migrationImageOsTypes.map(o => `${o}_os_image`))
 
-
   if (!options) {
     return env
   }
+
   Object.keys(options).forEach(optionName => {
-    if (specialOptions.find(o => o === optionName) || !options || options[optionName] == null) {
+    if (specialOptions.find(o => o === optionName) || !options || options[optionName] == null || options[optionName] === '') {
       return
     }
 
@@ -92,18 +92,19 @@ export const defaultGetDestinationEnv = (options: ?{ [string]: mixed }, oldOptio
 
 export const defaultGetMigrationImageMap = (options: ?{ [string]: mixed }) => {
   let env = {}
-  if (options) {
-    migrationImageOsTypes.forEach(os => {
-      if (!options || !options[`${os}_os_image`]) {
-        return
-      }
-      if (!env.migr_image_map) {
-        env.migr_image_map = {}
-      }
-
-      env.migr_image_map[os] = options[`${os}_os_image`]
-    })
+  if (!options) {
+    return env
   }
+  migrationImageOsTypes.forEach(os => {
+    if (!options || !options[`${os}_os_image`]) {
+      return
+    }
+    if (!env.migr_image_map) {
+      env.migr_image_map = {}
+    }
+
+    env.migr_image_map[os] = options[`${os}_os_image`]
+  })
 
   return env
 }


### PR DESCRIPTION
If a text field is an empty string, skip it completely, don't send it at
all to the server. This also applies to object type fields which have text
fields as properties.

The change is also reflected in Wizard Summary page.