### PR TITLE
Update Edit Replica modal inputs style

### DIFF
--- a/src/components/organisms/EditReplica/EditReplica.jsx
+++ b/src/components/organisms/EditReplica/EditReplica.jsx
@@ -166,7 +166,7 @@ class EditReplica extends React.Component<Props, State> {
       return data
     }
     Object.keys(env).forEach(key => {
-      if (env[key] && typeof env[key] === 'object') {
+      if (env[key] && typeof env[key] === 'object' && !Array.isArray(JSON.parse(JSON.stringify(env[key])))) {
         Object.keys(env[key]).forEach(subkey => {
           let destParent: any = env[key]
           if (destParent[subkey]) {
@@ -397,6 +397,7 @@ class EditReplica extends React.Component<Props, State> {
         onScrollableRef={ref => { this.scrollableRef = ref }}
         availableHeight={384}
         useAdvancedOptions
+        layout="modal"
       />
     )
   }

--- a/src/components/organisms/WizardOptions/WizardOptions.jsx
+++ b/src/components/organisms/WizardOptions/WizardOptions.jsx
@@ -90,6 +90,7 @@ type Props = {
   fieldWidth?: number,
   onScrollableRef?: (ref: HTMLElement) => void,
   availableHeight?: number,
+  layout?: 'page' | 'modal',
 }
 @observer
 class WizardOptions extends React.Component<Props> {
@@ -178,7 +179,7 @@ class WizardOptions extends React.Component<Props> {
     }
     return (
       <FieldInputStyled
-        layout="page"
+        layout={this.props.layout || 'page'}
         key={field.name}
         name={field.name}
         type={field.type}


### PR DESCRIPTION
The Endpoint modal inputs style is now used in Edit Replica modal,
instead of the Wizard Options inputs style.