### PR TITLE
Create OVM plugin to handle `migr_template` fields

### DIFF
--- a/src/components/molecules/PropertiesTable/PropertiesTable.jsx
+++ b/src/components/molecules/PropertiesTable/PropertiesTable.jsx
@@ -94,6 +94,7 @@ class PropertiesTable extends React.Component<Props> {
         data-test-id={`${baseId}-textInput-${prop.name}`}
         width="100%"
         embedded
+        type={prop.password ? 'password' : 'text'}
         value={this.props.valueCallback(prop)}
         onChange={e => { this.props.onChange(prop, e.target.value) }}
         placeholder={this.getName(prop.name)}

--- a/src/components/organisms/Endpoint/Endpoint.jsx
+++ b/src/components/organisms/Endpoint/Endpoint.jsx
@@ -69,7 +69,7 @@ const ShowErrorButton = styled.span`
 `
 const StatusError = styled.div`
   max-width: 100%;
-  margin-top: 16px;
+  margin: 16px 16px 0 16px;
   max-height: 140px;
   overflow: auto;
   cursor: pointer;

--- a/src/plugins/endpoint/default/OptionsSchemaPlugin.js
+++ b/src/plugins/endpoint/default/OptionsSchemaPlugin.js
@@ -14,8 +14,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // @flow
 
+import { defaultSchemaToFields } from './ConnectionSchemaPlugin'
+
 import type { Field } from '../../../types/Field'
 import type { OptionValues, StorageMap } from '../../../types/Endpoint'
+import type { SchemaProperties, SchemaDefinitions } from '../../../types/Schema'
 import type { NetworkMap } from '../../../types/Network'
 import { executionOptions } from '../../../constants'
 
@@ -110,6 +113,10 @@ export const defaultGetMigrationImageMap = (options: ?{ [string]: mixed }) => {
 }
 
 export default class OptionsSchemaParser {
+  static parseSchemaToFields(schema: SchemaProperties, schemaDefinitions?: ?SchemaDefinitions) {
+    return defaultSchemaToFields(schema, schemaDefinitions)
+  }
+
   static fillFieldValues(field: Field, options: OptionValues[]) {
     let option = options.find(f => f.name === field.name)
     if (!option) {

--- a/src/plugins/endpoint/index.js
+++ b/src/plugins/endpoint/index.js
@@ -23,6 +23,7 @@ import AzureContentPlugin from './azure/ContentPlugin'
 import OpenstackContentPlugin from './openstack/ContentPlugin'
 
 import DefaultOptionsSchemaPlugin from './default/OptionsSchemaPlugin'
+import OvmOptionsSchemaPlugin from './ovm/OptionsSchemaPlugin'
 
 export const ConnectionSchemaPlugin = {
   default: DefaultConnectionSchemaPlugin,
@@ -33,6 +34,7 @@ export const ConnectionSchemaPlugin = {
 
 export const OptionsSchemaPlugin = {
   default: DefaultOptionsSchemaPlugin,
+  oracle_vm: OvmOptionsSchemaPlugin,
 }
 
 export const ContentPlugin = {

--- a/src/plugins/endpoint/ovm/OptionsSchemaPlugin.js
+++ b/src/plugins/endpoint/ovm/OptionsSchemaPlugin.js
@@ -1,0 +1,64 @@
+/*
+Copyright (C) 2017  Cloudbase Solutions SRL
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// @flow
+
+import DefaultOptionsSchemaPlugin from '../default/OptionsSchemaPlugin'
+
+import type { Field } from '../../../types/Field'
+import type { OptionValues, StorageMap } from '../../../types/Endpoint'
+import type { SchemaProperties, SchemaDefinitions } from '../../../types/Schema'
+import type { NetworkMap } from '../../../types/Network'
+
+export default class OptionsSchemaParser {
+  static parseSchemaToFields(schema: SchemaProperties, schemaDefinitions?: ?SchemaDefinitions) {
+    let fields = DefaultOptionsSchemaPlugin.parseSchemaToFields(schema, schemaDefinitions)
+    fields.forEach(f => {
+      if (f.name !== 'migr_template_username_map' && f.name !== 'migr_template_password_map') {
+        return
+      }
+      f.properties = [
+        {
+          type: 'string',
+          name: `${f.name}/windows`,
+          password: f.name === 'migr_template_password_map',
+        },
+        {
+          type: 'string',
+          name: `${f.name}/linux`,
+          password: f.name === 'migr_template_password_map',
+        },
+      ]
+    })
+
+    return fields
+  }
+
+  static fillFieldValues(field: Field, options: OptionValues[]) {
+    DefaultOptionsSchemaPlugin.fillFieldValues(field, options)
+  }
+
+  static getDestinationEnv(options: ?{ [string]: mixed }, oldOptions?: any) {
+    return DefaultOptionsSchemaPlugin.getDestinationEnv(options, oldOptions)
+  }
+
+  static getNetworkMap(networkMappings: ?NetworkMap[]) {
+    return DefaultOptionsSchemaPlugin.getNetworkMap(networkMappings)
+  }
+
+  static getStorageMap(defaultStorage: ?string, storageMap: ?StorageMap[], configDefault?: ?string) {
+    return DefaultOptionsSchemaPlugin.getStorageMap(defaultStorage, storageMap, configDefault)
+  }
+}
+

--- a/src/sources/Schemas.js
+++ b/src/sources/Schemas.js
@@ -14,8 +14,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // @flow
 
-import { ConnectionSchemaPlugin } from '../plugins/endpoint'
-import { defaultSchemaToFields } from '../plugins/endpoint/default/ConnectionSchemaPlugin'
+import { ConnectionSchemaPlugin, OptionsSchemaPlugin } from '../plugins/endpoint'
 import type { Schema } from '../types/Schema'
 import type { Endpoint } from '../types/Endpoint'
 
@@ -34,7 +33,8 @@ class SchemaParser {
   }
 
   static optionsSchemaToFields(provider: string, schema: Schema) {
-    let fields = defaultSchemaToFields(schema.oneOf[0], schema.definitions)
+    let parser = OptionsSchemaPlugin[provider] || OptionsSchemaPlugin.default
+    let fields = parser.parseSchemaToFields(schema.oneOf[0], schema.definitions)
     fields.sort((a, b) => {
       if (a.required && !b.required) {
         return -1

--- a/src/types/Field.js
+++ b/src/types/Field.js
@@ -22,6 +22,7 @@ export type Field = {
   // $FlowIssue
   enum?: string[] | { id: string, name: string, [string]: mixed }[],
   default?: any,
+  password?: boolean,
   nullableBoolean?: boolean,
   items?: Field[],
   fields?: Field[],


### PR DESCRIPTION
Use UI object table component in Wizard Options to render OVM
`migr_template_username_map` and `migr_template_password_map` fields.

The fields for `migr_template_password_map` are also shown as password
fields.