### PR TITLE
Show tooltip if edit replica button is disabled

### DIFF
--- a/src/components/molecules/ActionDropdown/ActionDropdown.jsx
+++ b/src/components/molecules/ActionDropdown/ActionDropdown.jsx
@@ -62,6 +62,7 @@ export type Action = {
   action: () => void,
   disabled?: boolean,
   hidden?: boolean,
+  title?: ?string,
 }
 export type Props = {
   label: string,
@@ -168,6 +169,7 @@ class ActionDropdown extends React.Component<Props, State> {
             color={action.color}
             disabled={action.disabled}
             data-test-id={`${TEST_ID}-listItem-${action.label}`}
+            title={action.title}
           >
             {action.label}
           </ListItem>

--- a/src/components/pages/ReplicaDetailsPage/ReplicaDetailsPage.jsx
+++ b/src/components/pages/ReplicaDetailsPage/ReplicaDetailsPage.jsx
@@ -387,6 +387,7 @@ class ReplicaDetailsPage extends React.Component<Props, State> {
       action: () => { this.handleCreateMigrationClick() },
     }, {
       label: 'Edit',
+      title: !this.state.isEditable ? 'At least one of the providers doesn\'t support editing' : null,
       action: () => { this.handleReplicaEditClick() },
       disabled: !this.state.isEditable,
     }, {


### PR DESCRIPTION
Show a message informing the user that editing the replica is disabled
because one of the providers doesn't support editing.