### PR TITLE
Fix a crash in Projects Page caused by roles

### DIFF
--- a/src/components/organisms/ProjectDetailsContent/ProjectDetailsContent.jsx
+++ b/src/components/organisms/ProjectDetailsContent/ProjectDetailsContent.jsx
@@ -221,7 +221,7 @@ class ProjectDetailsContent extends React.Component<Props, State> {
     let getUserRoles = user => {
       let projectId = this.props.project ? this.props.project.id : ''
       let roles = this.props.roleAssignments
-        .filter(a => a.scope.project.id === projectId)
+        .filter(a => a.scope.project && a.scope.project.id === projectId)
         .filter(a => a.user.id === user.id)
         .map(a => { return { value: a.role.id, label: a.role.name } })
       return roles

--- a/src/components/pages/ProjectDetailsPage/ProjectDetailsPage.jsx
+++ b/src/components/pages/ProjectDetailsPage/ProjectDetailsPage.jsx
@@ -95,7 +95,7 @@ class ProjectDetailsPage extends React.Component<Props, State> {
 
   handleRemoveUser(user: User) {
     let roles = projectStore.roleAssignments
-      .filter(a => a.scope.project.id === this.props.match.params.id)
+      .filter(a => a.scope.project && a.scope.project.id === this.props.match.params.id)
       .filter(a => a.user.id === user.id)
       .map(ra => ra.role.id)
     projectStore.removeUser(this.props.match.params.id, user.id, roles)

--- a/src/components/pages/ProjectsPage/ProjectsPage.jsx
+++ b/src/components/pages/ProjectsPage/ProjectsPage.jsx
@@ -57,7 +57,7 @@ class ProjectsPage extends React.Component<{ history: any }, State> {
   }
 
   getMembers(projectId: string): number {
-    return projectStore.roleAssignments.filter(a => a.scope.project.id === projectId).length
+    return projectStore.roleAssignments.filter(a => a.scope.project && a.scope.project.id === projectId).length
   }
 
   isCurrentProject(projectId: string): boolean {

--- a/src/sources/ProjectSource.js
+++ b/src/sources/ProjectSource.js
@@ -53,7 +53,7 @@ class ProjectsSource {
   async getUsers(projectId: string): Promise<User[]> {
     let assignments = await this.getRoleAssignments()
     const userIds: string[] = assignments
-      .filter(a => a.scope.project.id === projectId)
+      .filter(a => a.scope.project && a.scope.project.id === projectId)
       .filter((a, i, arr) => arr.findIndex(e => a.user.id === e.user.id) === i)
       .map(a => a.user.id)
     let users: User[] = await Promise.all(userIds.map(async id => {

--- a/src/sources/UserSource.js
+++ b/src/sources/UserSource.js
@@ -320,7 +320,8 @@ class UserSource {
     let assignments: RoleAssignment[] = response.data.role_assignments
     let projects: $Shape<Project>[] = assignments
       .filter(a => a.user.id === userId)
-      .filter((a, i, arr) => arr.findIndex(e => e.scope.project.id === a.scope.project.id) === i)
+      .filter((a, i, arr) =>
+        arr.findIndex(e => e.scope.project && a.scope.project && e.scope.project.id === a.scope.project.id) === i)
       .map(a => a.scope.project)
 
     return projects

--- a/src/types/Project.js
+++ b/src/types/Project.js
@@ -28,7 +28,7 @@ export type Role = {
 
 export type RoleAssignment = {
   scope: {
-    project: {
+    project?: {
       id: string,
       name: string,
     },


### PR DESCRIPTION
The UI crashes in Projects Page if there's a role whose scope is not a
project, i.e. a system role.