### PR TITLE
Add security groups selection to network mapping

### DIFF
--- a/src/components/molecules/AutocompleteDropdown/AutocompleteDropdown.jsx
+++ b/src/components/molecules/AutocompleteDropdown/AutocompleteDropdown.jsx
@@ -62,6 +62,12 @@ const List = styled.div`
   border-radius: ${StyleProps.borderRadius};
   z-index: 1000;
 `
+const Separator = styled.div`
+  width: calc(100% - 32px);
+  height: 1px;
+  margin: 8px 16px;
+  background: ${Palette.grayscale[3]};
+`
 const ListItems = styled.div`
   max-height: 400px;
   overflow: auto;
@@ -352,6 +358,9 @@ class AutocompleteDropdown extends React.Component<Props, State> {
     return (
       <ListItems innerRef={ref => { this.listItemsRef = ref }}>
         {this.state.filteredItems.map((item, i) => {
+          if (item.separator === true) {
+            return <Separator key={`sep-${i}`} />
+          }
           let label = this.getLabel(item)
           let value = this.getValue(item)
           let duplicatedLabel = duplicatedLabels.find(l => l === label)

--- a/src/components/molecules/Dropdown/Dropdown.jsx
+++ b/src/components/molecules/Dropdown/Dropdown.jsx
@@ -199,7 +199,7 @@ type Props = {
   embedded?: boolean,
   dimFirstItem?: boolean,
   multipleSelection?: boolean,
-  selectedItems?: string[],
+  selectedItems?: ?any[],
   highlight?: boolean,
   required?: boolean,
 }
@@ -334,7 +334,8 @@ class Dropdown extends React.Component<Props, State> {
     if (!item || !checkmarkRef) {
       return
     }
-    let multipleSelected = this.props.selectedItems && this.props.selectedItems.find(i => i === this.getValue(item))
+    let multipleSelected = this.props.selectedItems && this.props.selectedItems.find(i =>
+      this.getValue(i) === this.getValue(item))
     let symbol = checkmarkRef.querySelector('#symbol')
     if (symbol) {
       symbol.style.animationName = multipleSelected ? 'dashOff' : 'dashOn'
@@ -404,13 +405,14 @@ class Dropdown extends React.Component<Props, State> {
         <ListItems innerRef={ref => { this.listItemsRef = ref }}>
           {this.props.items.map((item, i) => {
             if (item.separator === true) {
-              return <Separator />
+              return <Separator key={`sep-${i}`} />
             }
 
             let label = this.getLabel(item)
             let value = this.getValue(item)
             let duplicatedLabel = duplicatedLabels.find(l => l === label)
-            let multipleSelected = this.props.selectedItems && this.props.selectedItems.find(i => i === value)
+            let multipleSelected = this.props.selectedItems && this.props.selectedItems
+              .find(i => this.getValue(i) === value)
             let checkmarkRef
             let listItem = (
               <ListItem
@@ -454,7 +456,8 @@ class Dropdown extends React.Component<Props, State> {
     let buttonValue = () => {
       if (this.props.items && this.props.items.length) {
         if (this.props.multipleSelection && this.props.selectedItems && this.props.selectedItems.length > 0) {
-          return this.props.selectedItems.map(i => this.getLabel(this.props.items.find(item => this.getValue(item) === i))).join(', ')
+          return this.props.selectedItems.map(i => this.getLabel(this.props.items.find(item =>
+            this.getValue(item) === this.getValue(i)))).join(', ')
         }
         return this.getLabel(this.props.selectedItem)
       }

--- a/src/components/organisms/MainDetails/MainDetails.jsx
+++ b/src/components/organisms/MainDetails/MainDetails.jsx
@@ -162,36 +162,6 @@ class MainDetails extends React.Component<Props> {
     return vms.length === 0 ? 'Failed to read network configuration for the original instance' : vms.map(vm => <div data-test-id={`vm-${vm}`} style={{ marginBottom: '8px' }}>{vm}<br /></div>)
   }
 
-  getNetworks() {
-    let networkMap = this.props.item && this.props.item.network_map
-    if (!networkMap) {
-      return null
-    }
-    let networks = []
-    Object.keys(networkMap).forEach(key => {
-      let newItem
-      if (typeof networkMap[key] === 'string') {
-        newItem = [
-          key,
-          this.getConnectedVms(key),
-          networkMap[key],
-          'Existing network',
-        ]
-      } else {
-        newItem = [
-          networkMap[key].source_network,
-          this.getConnectedVms(key),
-          // $FlowIssue
-          networkMap[key].destination_network,
-          'Existing network',
-        ]
-      }
-      networks.push(newItem)
-    })
-
-    return networks
-  }
-
   renderLastExecutionTime() {
     let lastExecution = this.getLastExecution()
     let lastUpdate = lastExecution.updated_at || lastExecution.created_at

--- a/src/components/organisms/WizardPageContent/WizardPageContent.jsx
+++ b/src/components/organisms/WizardPageContent/WizardPageContent.jsx
@@ -37,7 +37,7 @@ import type { WizardData, WizardPage } from '../../../types/WizardData'
 import type { Endpoint, StorageBackend, StorageMap } from '../../../types/Endpoint'
 import type { Instance, Nic, Disk } from '../../../types/Instance'
 import type { Field } from '../../../types/Field'
-import type { Network } from '../../../types/Network'
+import type { Network, SecurityGroup } from '../../../types/Network'
 import type { Schedule as ScheduleType } from '../../../types/Schedule'
 import instanceStore from '../../../stores/InstanceStore'
 import providerStore from '../../../stores/ProviderStore'
@@ -154,7 +154,7 @@ type Props = {
   onInstancePageClick: (page: number) => void,
   onDestOptionsChange: (field: Field, value: any) => void,
   onSourceOptionsChange: (field: Field, value: any) => void,
-  onNetworkChange: (nic: Nic, network: Network) => void,
+  onNetworkChange: (nic: Nic, network: Network, secGroups: ?SecurityGroup[]) => void,
   onStorageChange: (sourceStorage: Disk, targetStorage: StorageBackend, type: 'backend' | 'disk') => void,
   onAddScheduleClick: (schedule: ScheduleType) => void,
   onScheduleChange: (scheduleId: string, schedule: ScheduleType) => void,

--- a/src/components/organisms/WizardSummary/WizardSummary.jsx
+++ b/src/components/organisms/WizardSummary/WizardSummary.jsx
@@ -112,12 +112,26 @@ const NetworkArrow = styled.div`
   height: 16px;
   background: url('${networkArrowImage}') center no-repeat;
 `
-const TargetNetwork = styled.div`
+const StorageTarget = styled.div`
   width: 50%;
   text-align: right;
   margin-left: 20px;
   text-overflow: ellipsis;
   overflow: hidden;
+`
+const TargetNetwork = styled.div`
+  width: 50%;
+  text-align: right;
+  margin-left: 20px;
+  display: flex;
+  flex-direction: column;
+  margin-top: -16px;
+`
+const TargetNetworkName = styled.div`
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  margin-top: 16px;
 `
 const OptionsList = styled.div``
 const Option = styled.div`
@@ -354,7 +368,7 @@ class WizardSummary extends React.Component<Props> {
               >
                 <SourceNetwork>{mapping.source[fieldName]}</SourceNetwork>
                 <NetworkArrow />
-                <TargetNetwork>{mapping.target ? mapping.target.name : 'Default'}</TargetNetwork>
+                <StorageTarget>{mapping.target ? mapping.target.name : 'Default'}</StorageTarget>
               </Row>
             )
           })}
@@ -379,7 +393,12 @@ class WizardSummary extends React.Component<Props> {
               <Row key={mapping.sourceNic.network_name} direction="row">
                 <SourceNetwork data-test-id="wSummary-networkSource">{mapping.sourceNic.network_name}</SourceNetwork>
                 <NetworkArrow />
-                <TargetNetwork data-test-id="wSummary-networkTarget">{mapping.targetNetwork.name}</TargetNetwork>
+                <TargetNetwork>
+                  <TargetNetworkName data-test-id="wSummary-networkTarget">{mapping.targetNetwork.name}</TargetNetworkName>
+                  {mapping.targetSecurityGroups && mapping.targetSecurityGroups.length ? (
+                    <TargetNetworkName>Security Groups: {mapping.targetSecurityGroups.map(s => s.name ? s.name : s).join(', ')}</TargetNetworkName>
+                  ) : null}
+                </TargetNetwork>
               </Row>
             )
           })}

--- a/src/components/pages/MigrationDetailsPage/MigrationDetailsPage.jsx
+++ b/src/components/pages/MigrationDetailsPage/MigrationDetailsPage.jsx
@@ -100,7 +100,7 @@ class MigrationDetailsPage extends React.Component<Props, State> {
       details.origin_endpoint_id,
       // $FlowIgnore
       details.instances.map(n => { return { instance_name: n } }),
-      false, cache
+      cache, false
     )
   }
 

--- a/src/components/pages/ReplicaDetailsPage/ReplicaDetailsPage.jsx
+++ b/src/components/pages/ReplicaDetailsPage/ReplicaDetailsPage.jsx
@@ -140,7 +140,7 @@ class ReplicaDetailsPage extends React.Component<Props, State> {
       details.origin_endpoint_id,
       // $FlowIgnore
       details.instances.map(n => { return { instance_name: n } }),
-      false, cache
+      cache, false
     )
   }
 

--- a/src/components/pages/WizardPage/WizardPage.jsx
+++ b/src/components/pages/WizardPage/WizardPage.jsx
@@ -42,7 +42,7 @@ import type { MainItem } from '../../../types/MainItem'
 import type { Endpoint as EndpointType, StorageBackend } from '../../../types/Endpoint'
 import type { Instance, Nic, Disk } from '../../../types/Instance'
 import type { Field } from '../../../types/Field'
-import type { Network } from '../../../types/Network'
+import type { Network, SecurityGroup } from '../../../types/Network'
 import type { Schedule } from '../../../types/Schedule'
 import type { WizardPage as WizardPageType } from '../../../types/WizardData'
 
@@ -333,8 +333,8 @@ class WizardPage extends React.Component<Props, State> {
     wizardStore.setPermalink(wizardStore.data)
   }
 
-  handleNetworkChange(sourceNic: Nic, targetNetwork: Network) {
-    wizardStore.updateNetworks({ sourceNic, targetNetwork })
+  handleNetworkChange(sourceNic: Nic, targetNetwork: Network, targetSecurityGroups: ?SecurityGroup[]) {
+    wizardStore.updateNetworks({ sourceNic, targetNetwork, targetSecurityGroups })
     wizardStore.setPermalink(wizardStore.data)
   }
 
@@ -577,7 +577,7 @@ class WizardPage extends React.Component<Props, State> {
             onInstancePageClick={page => { this.handleInstancePageClick(page) }}
             onDestOptionsChange={(field, value) => { this.handleDestOptionsChange(field, value) }}
             onSourceOptionsChange={(field, value) => { this.handleSourceOptionsChange(field, value) }}
-            onNetworkChange={(sourceNic, targetNetwork) => { this.handleNetworkChange(sourceNic, targetNetwork) }}
+            onNetworkChange={(sourceNic, targetNetwork, secGroups) => { this.handleNetworkChange(sourceNic, targetNetwork, secGroups) }}
             onStorageChange={(source, target, type) => { this.handleStorageChange(source, target, type) }}
             onAddScheduleClick={schedule => { this.handleAddScheduleClick(schedule) }}
             onScheduleChange={(scheduleId, data) => { this.handleScheduleChange(scheduleId, data) }}

--- a/src/plugins/endpoint/default/OptionsSchemaPlugin.js
+++ b/src/plugins/endpoint/default/OptionsSchemaPlugin.js
@@ -138,8 +138,18 @@ export default class OptionsSchemaParser {
   static getNetworkMap(networkMappings: ?NetworkMap[]) {
     let payload = {}
     if (networkMappings && networkMappings.length) {
+      let hasSecurityGroups = Boolean(networkMappings.find(nm => nm.targetNetwork.security_groups))
       networkMappings.forEach(mapping => {
-        payload[mapping.sourceNic.network_name] = mapping.targetNetwork.id
+        let target
+        if (hasSecurityGroups) {
+          target = {
+            id: mapping.targetNetwork.id,
+            security_groups: mapping.targetSecurityGroups ? mapping.targetSecurityGroups.map(s => s.id ? s.id : s) : [],
+          }
+        } else {
+          target = mapping.targetNetwork.id
+        }
+        payload[mapping.sourceNic.network_name] = target
       })
     }
     return payload

--- a/src/sources/NetworkSource.js
+++ b/src/sources/NetworkSource.js
@@ -28,7 +28,7 @@ class NetworkSource {
       url = `${url}?env=${btoa(JSON.stringify(environment))}`
     }
     let response = await Api.send({ url, quietError: options && options.quietError })
-    let networks = response.data.networks.filter(n => n.name.indexOf('coriolis-migrnet') === -1)
+    let networks: Network[] = response.data.networks.filter(n => n.name.indexOf('coriolis-migrnet') === -1)
     networks.sort((a, b) => a.name.localeCompare(b.name))
     return networks
   }

--- a/src/sources/ReplicaSource.js
+++ b/src/sources/ReplicaSource.js
@@ -208,11 +208,7 @@ class ReplicaSource {
     let payload = { replica: {} }
 
     if (updateData.network.length > 0) {
-      let networkMap = {}
-      updateData.network.forEach(mapping => {
-        networkMap[mapping.sourceNic.network_name] = mapping.targetNetwork.id
-      })
-      payload.replica.network_map = networkMap
+      payload.replica.network_map = parser.getNetworkMap(updateData.network)
     }
 
     if (Object.keys(updateData.destination).length > 0) {

--- a/src/types/MainItem.js
+++ b/src/types/MainItem.js
@@ -70,6 +70,6 @@ export type MainItem = {
     [string]: {
       source_network: string,
       destination_network: string,
-    } | string
+    } | string | { id: string, security_groups?: string[] }
   }
 }

--- a/src/types/Network.js
+++ b/src/types/Network.js
@@ -16,12 +16,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import type { Nic } from './Instance'
 
+export type SecurityGroup = string | {
+  id: string,
+  name: string,
+}
+
 export type Network = {
   name: string,
   id: string,
+  security_groups?: SecurityGroup[],
 }
 
 export type NetworkMap = {
   sourceNic: Nic,
   targetNetwork: Network,
+  targetSecurityGroups?: ?SecurityGroup[],
 }

--- a/src/utils/LabelDictionary.js
+++ b/src/utils/LabelDictionary.js
@@ -17,7 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import type { Field } from '../types/Field'
 
 // The word will be uppercased
-const acronyms = ['id', 'api', 'url', 'vm', 'os', 'dhcp', 'sql', 'oci', 'aws']
+const acronyms = ['id', 'api', 'url', 'vm', 'os', 'dhcp', 'sql', 'oci', 'aws', 'vcn']
 
 // The word will be replaced
 const abbreviations = {


### PR DESCRIPTION
OCI supports security groups selection for each network mapping.

This affects all the places in which network mapping is used: Wizard
Networks, Edit Replica and Recreate Migration.