### PR TITLE
Improve Replica / Migration source options support

### DIFF
--- a/config.js
+++ b/config.js
@@ -30,7 +30,7 @@ const conf: Config = {
   requestPollTimeout: 5000,
 
   // The list of providers which offer source options
-  sourceOptionsProviders: ['aws'],
+  sourceOptionsProviders: ['aws', 'azure', 'openstack'],
 
   // - Specifies the `limit` for each provider when listing all its VMs for pagination.
   // - If the provider is not in this list, the 'default' value will be used.
@@ -38,17 +38,17 @@ const conf: Config = {
   // - `Infinity` value means no `limit` will be used, i.e. all VMs will be listed.
   instancesListBackgroundLoading: { default: 10, ovm: Infinity, 'hyper-v': Infinity },
 
-  // The providers for which an extra `source` or `destination options` call can be made with a set of field values
-  providersWithEnvOptions: [
+  // The providers for which an extra `source options` or `destination options` call can be made with a set of field values
+  extraOptionsApiCalls: [
     {
       name: 'azure',
-      type: 'destination',
-      envRequiredFields: ['location', 'resource_group'],
+      types: ['source', 'destination'],
+      requiredFields: ['location', 'resource_group'],
     },
     {
       name: 'oci',
-      type: 'destination',
-      envRequiredFields: ['compartment', 'availability_domain', 'vcn_compartment'],
+      types: ['destination'],
+      requiredFields: ['compartment', 'availability_domain', 'vcn_compartment'],
     },
   ],
 

--- a/src/components/molecules/Dropdown/Dropdown.jsx
+++ b/src/components/molecules/Dropdown/Dropdown.jsx
@@ -48,6 +48,7 @@ const Required = styled.div`
   right: -16px;
   top: 12px;
   background: url('${requiredImage}') center no-repeat;
+  ${props => props.disabledLoading ? StyleProps.animations.disabledLoading : ''}
 `
 const List = styled.div`
   position: absolute;
@@ -483,7 +484,7 @@ class Dropdown extends React.Component<Props, State> {
           value={buttonValue()}
           onClick={() => this.handleButtonClick()}
         />
-        {this.props.required ? <Required /> : null}
+        {this.props.required ? <Required disabledLoading={this.props.disabledLoading} /> : null}
         {this.renderList()}
       </Wrapper>
     )

--- a/src/components/molecules/FieldInput/FieldInput.jsx
+++ b/src/components/molecules/FieldInput/FieldInput.jsx
@@ -181,7 +181,7 @@ class FieldInput extends React.Component<Props> {
         placeholder={LabelDictionary.get(this.props.name)}
         disabled={this.props.disabled}
         disabledLoading={this.props.disabledLoading}
-        required={this.props.required}
+        required={this.props.layout === 'page' ? false : this.props.required}
       />
     )
   }
@@ -208,6 +208,7 @@ class FieldInput extends React.Component<Props> {
     let selectedItem = items.find(i => i.value === this.props.value)
     let commonProps = {
       width: this.props.width,
+      required: this.props.layout === 'page' ? false : this.props.required,
       selectedItem,
       items,
       disabledLoading: this.props.disabledLoading,
@@ -283,7 +284,7 @@ class FieldInput extends React.Component<Props> {
         disabled={this.props.disabled}
         disabledLoading={this.props.disabledLoading}
         highlight={this.props.highlight}
-        required={this.props.required}
+        required={this.props.layout === 'page' ? false : this.props.required}
       />
     )
   }
@@ -324,7 +325,7 @@ class FieldInput extends React.Component<Props> {
         highlight={this.props.highlight}
         disabled={this.props.disabled}
         disabledLoading={this.props.disabledLoading}
-        required={this.props.required}
+        required={this.props.layout === 'page' ? false : this.props.required}
       />
     )
   }

--- a/src/components/molecules/MainDetailsTable/MainDetailsTable.jsx
+++ b/src/components/molecules/MainDetailsTable/MainDetailsTable.jsx
@@ -262,7 +262,7 @@ class MainDetailsTable extends React.Component<Props, State> {
       }
 
       rows.push(this.renderRow(
-        `${instance.instance_name}-${sourceName}-${destinationName}`,
+        `${instance.instance_name || instance.name}-${sourceName}-${destinationName}`,
         'storage',
         sourceName,
         destinationName,
@@ -332,7 +332,7 @@ class MainDetailsTable extends React.Component<Props, State> {
         }
 
         rows.push(this.renderRow(
-          `${instance.instance_name}-${nic.network_name}`,
+          `${instance.instance_name || instance.name}-${nic.network_name}`,
           'network',
           nic.mac_address,
           destinationNetworkName,
@@ -358,16 +358,16 @@ class MainDetailsTable extends React.Component<Props, State> {
     let destinationName: string = ''
     let transferResult = this.getTransferResult(instance)
     if (transferResult) {
-      destinationName = transferResult.instance_name
+      destinationName = transferResult.instance_name || transferResult.name
       destinationBody = getBody(transferResult)
     } else if (this.props.item && this.props.item.status === 'RUNNING' && this.props.item.type === 'migration') {
       destinationName = 'Waiting for migration to finish'
     }
-
+    let instanceName = instance.instance_name || instance.name
     return this.renderRow(
-      instance.instance_name,
+      instanceName,
       'instance',
-      instance.instance_name,
+      instanceName,
       destinationName,
       sourceBody,
       destinationBody

--- a/src/components/organisms/MainDetails/MainDetails.jsx
+++ b/src/components/organisms/MainDetails/MainDetails.jsx
@@ -155,7 +155,7 @@ class MainDetails extends React.Component<Props> {
         instanceDet.devices && instanceDet.devices.nics && instanceDet.devices.nics.find &&
         instanceDet.devices.nics.find(n => n.network_name === networkId)
       ) {
-        vms.push(instanceDet.instance_name)
+        vms.push(instanceDet.instance_name || instanceDet.name)
       }
     })
 

--- a/src/components/organisms/WizardInstances/WizardInstances.jsx
+++ b/src/components/organisms/WizardInstances/WizardInstances.jsx
@@ -314,7 +314,7 @@ class WizardInstances extends React.Component<Props, State> {
               <CheckboxStyled checked={selected} onChange={() => { }} />
               <InstanceContent data-test-id="wInstances-instanceItem">
                 <Image />
-                <Label data-test-id="wInstances-itemName">{instance.instance_name}</Label>
+                <Label data-test-id="wInstances-itemName">{instance.instance_name || instance.name}</Label>
                 <Details data-test-id="wInstances-itemDetails">{`${instance.num_cpu} vCPU | ${instance.memory_mb} MB RAM${flavorName}`}</Details>
               </InstanceContent>
             </Instance>

--- a/src/components/organisms/WizardNetworks/WizardNetworks.jsx
+++ b/src/components/organisms/WizardNetworks/WizardNetworks.jsx
@@ -240,7 +240,7 @@ class WizardNetworks extends React.Component<Props> {
               return true
             }
             return false
-          }).map(i => i.instance_name)
+          }).map(i => i.instance_name || i.name)
           let selectedNetwork = this.props.selectedNetworks && this.props.selectedNetworks.find(n => n.sourceNic.network_name === nic.network_name)
           return (
             <Nic key={nic.id} data-test-id="networkItem">

--- a/src/components/organisms/WizardOptions/WizardOptions.jsx
+++ b/src/components/organisms/WizardOptions/WizardOptions.jsx
@@ -41,6 +41,7 @@ const Options = styled.div`
   min-height: 0;
 `
 const Fields = styled.div`
+  ${props => props.padding ? `padding: ${props.padding}px;` : ''}
   display: flex;
   overflow: auto;
   justify-content: space-between;
@@ -236,7 +237,7 @@ class WizardOptions extends React.Component<Props> {
 
     if (fields.length * 96 < availableHeight) {
       return (
-        <Fields>
+        <Fields padding={this.props.layout === 'page' ? null : 32}>
           <OneColumn style={this.props.oneColumnStyle}>
             {fields.map(f => f.component)}
           </OneColumn>
@@ -245,7 +246,7 @@ class WizardOptions extends React.Component<Props> {
     }
 
     return (
-      <Fields innerRef={this.props.onScrollableRef}>
+      <Fields innerRef={this.props.onScrollableRef} padding={this.props.layout === 'page' ? null : 32}>
         <Column left style={this.props.columnStyle}>
           {fields.map(f => f.column === 'left' && f.component)}
         </Column>

--- a/src/components/organisms/WizardPageContent/WizardPageContent.jsx
+++ b/src/components/organisms/WizardPageContent/WizardPageContent.jsx
@@ -246,6 +246,8 @@ class WizardPageContent extends React.Component<Props, State> {
         return !this.props.wizardData.target
       case 'vms':
         return !this.props.wizardData.selectedInstances || !this.props.wizardData.selectedInstances.length
+      case 'source-options':
+        return !isOptionsPageValid(this.props.wizardData.sourceOptions, this.props.providerStore.sourceSchema)
       case 'dest-options':
         return !isOptionsPageValid(this.props.wizardData.destOptions, this.props.providerStore.destinationSchema)
       case 'networks':

--- a/src/components/organisms/WizardStorage/WizardStorage.jsx
+++ b/src/components/organisms/WizardStorage/WizardStorage.jsx
@@ -182,7 +182,7 @@ class WizardStorage extends React.Component<Props> {
                 return true
               }
               return false
-            }).map(i => i.instance_name)
+            }).map(i => i.instance_name || i.name)
             let selectedItem = storageMap && storageMap.find(s => s.type === type && String(s.source[diskFieldName]) === String(disk[diskFieldName]))
             selectedItem = selectedItem ? selectedItem.target : null
             return (

--- a/src/components/pages/AssessmentDetailsPage/AssessmentDetailsPage.jsx
+++ b/src/components/pages/AssessmentDetailsPage/AssessmentDetailsPage.jsx
@@ -398,10 +398,19 @@ class AssessmentDetailsPage extends React.Component<Props, State> {
   }
 
   loadInstancesDetails() {
-    let selectedVms = this.getLocalData().selectedVms
-    let instances = instanceStore.instances.filter(i => selectedVms.find(m => i.id === m))
+    let localData = this.getLocalData()
+    let selectedVms = localData.selectedVms
+    let instancesInfo = instanceStore.instances.filter(i => selectedVms.find(m => i.id === m))
     instanceStore.clearInstancesDetails()
-    instanceStore.loadInstancesDetails(this.getSourceEndpointId(), instances, true)
+    instanceStore.loadInstancesDetails({
+      endpointId: this.getSourceEndpointId(),
+      instancesInfo,
+      useLocalStorage: true,
+      env: {
+        location: localData.locationName,
+        resource_group: localData.resourceGroupName,
+      },
+    })
   }
 
   handleMigrationExecute(fieldValues: { [string]: any }) {
@@ -413,7 +422,7 @@ class AssessmentDetailsPage extends React.Component<Props, State> {
       let vm = selectedVms.find(m => i.id === m)
       let selectedVmSize = localData.selectedVmSizes[i.id]
       if (vm && azureStore.vmSizes.find(s => s === selectedVmSize)) {
-        vmSizes[i.instance_name] = selectedVmSize
+        vmSizes[i.instance_name || i.name] = selectedVmSize
       }
     })
 

--- a/src/components/pages/MigrationDetailsPage/MigrationDetailsPage.jsx
+++ b/src/components/pages/MigrationDetailsPage/MigrationDetailsPage.jsx
@@ -96,12 +96,14 @@ class MigrationDetailsPage extends React.Component<Props, State> {
       quietError: true,
       useLocalStorage: cache,
     })
-    instanceStore.loadInstancesDetails(
-      details.origin_endpoint_id,
+    instanceStore.loadInstancesDetails({
+      endpointId: details.origin_endpoint_id,
       // $FlowIgnore
-      details.instances.map(n => { return { instance_name: n } }),
-      cache, false
-    )
+      instancesInfo: details.instances.map(n => ({ instance_name: n })),
+      useLocalStorage: cache,
+      quietError: false,
+      env: details.source_environment,
+    })
   }
 
   handleUserItemClick(item: { value: string }) {

--- a/src/components/pages/ReplicaDetailsPage/ReplicaDetailsPage.jsx
+++ b/src/components/pages/ReplicaDetailsPage/ReplicaDetailsPage.jsx
@@ -136,12 +136,14 @@ class ReplicaDetailsPage extends React.Component<Props, State> {
       quietError: true,
       useLocalStorage: cache,
     })
-    instanceStore.loadInstancesDetails(
-      details.origin_endpoint_id,
+    instanceStore.loadInstancesDetails({
+      endpointId: details.origin_endpoint_id,
       // $FlowIgnore
-      details.instances.map(n => { return { instance_name: n } }),
-      cache, false
-    )
+      instancesInfo: details.instances.map(n => ({ instance_name: n })),
+      useLocalStorage: cache,
+      quietError: false,
+      env: details.source_environment,
+    })
   }
 
   getLastExecution() {

--- a/src/sources/InstanceSource.js
+++ b/src/sources/InstanceSource.js
@@ -25,7 +25,8 @@ class InstanceSource {
     chunkSize: number,
     lastInstanceId?: string,
     cancelId?: string,
-    searchText?: string
+    searchText?: string,
+    env?: any,
   ): Promise<Instance[]> {
     let url = `${servicesUrl.coriolis}/${Api.projectId}/endpoints/${endpointId}/instances`
     let queryParams: { [string]: string | number } = {}
@@ -50,6 +51,13 @@ class InstanceSource {
       }
     }
 
+    if (env) {
+      queryParams = {
+        ...queryParams,
+        env: btoa(JSON.stringify(env)),
+      }
+    }
+
     let keys = Object.keys(queryParams)
     url = `${url}${keys.length > 0 ? '?' : ''}${keys.map(p => `${p}=${queryParams[p]}`).join('&')}`
 
@@ -64,9 +72,19 @@ class InstanceSource {
     return response.data.instances
   }
 
-  async loadInstanceDetails(endpointId: string, instanceName: string, reqId: number, quietError?: boolean): Promise<{ instance: Instance, reqId: number }> {
+  async loadInstanceDetails(
+    endpointId: string,
+    instanceName: string,
+    reqId: number,
+    quietError?: boolean,
+    env?: any
+  ): Promise<{ instance: Instance, reqId: number }> {
+    let url = `${servicesUrl.coriolis}/${Api.projectId}/endpoints/${endpointId}/instances/${btoa(instanceName)}`
+    if (env) {
+      url += `?env=${btoa(JSON.stringify(env))}`
+    }
     let response = await Api.send({
-      url: `${servicesUrl.coriolis}/${Api.projectId}/endpoints/${endpointId}/instances/${btoa(instanceName)}`,
+      url,
       cancelId: `instanceDetail-${reqId}`,
       quietError,
     })

--- a/src/sources/ProviderSource.js
+++ b/src/sources/ProviderSource.js
@@ -40,8 +40,7 @@ class ProviderSource {
       optionsType === 'source' ? providerTypes.SOURCE_REPLICA : providerTypes.TARGET_REPLICA
 
     let response = await Api.get(`${servicesUrl.coriolis}/${Api.projectId}/providers/${providerName}/schemas/${schemaTypeInt}`)
-    let schema = optionsType === 'source' ?
-      { oneOf: [response.data.schemas.source_environment_schema] } : response.data.schemas.destination_environment_schema
+    let schema = optionsType === 'source' ? response.data.schemas.source_environment_schema : response.data.schemas.destination_environment_schema
     let fields = SchemaParser.optionsSchemaToFields(providerName, schema)
     return fields
   }

--- a/src/sources/WizardSource.js
+++ b/src/sources/WizardSource.js
@@ -34,7 +34,7 @@ class WizardSource {
       destination_endpoint_id: data.target ? data.target.id : 'null',
       destination_environment: destParser.getDestinationEnv(data.destOptions),
       network_map: destParser.getNetworkMap(data.networks),
-      instances: data.selectedInstances ? data.selectedInstances.map(i => i.instance_name) : 'null',
+      instances: data.selectedInstances ? data.selectedInstances.map(i => i.instance_name || i.name) : 'null',
       storage_mappings: destParser.getStorageMap(defaultStorage, storageMap),
       notes: data.destOptions ? data.destOptions.description || '' : '',
     }

--- a/src/stores/ProviderStore.js
+++ b/src/stores/ProviderStore.js
@@ -32,16 +32,17 @@ export const getFieldChangeOptions = (config: {
   type: 'source' | 'destination',
 }) => {
   let { providerName, schema, data, field, type } = config
-  let providerWithEnvOptions = configLoader.config.providersWithEnvOptions.find(p => p.name === providerName && p.type === type)
+  let providerWithEnvOptions = configLoader.config.extraOptionsApiCalls
+    .find(p => p.name === providerName && p.types.find(t => t === type))
 
   if (!providerName || !providerWithEnvOptions) {
     return null
   }
-  let envRequiredFields = providerWithEnvOptions.envRequiredFields
+  let requiredFields = providerWithEnvOptions.requiredFields
 
   let findFieldInSchema = (name: string) => schema.find(f => f.name === name)
 
-  let validFields = envRequiredFields.filter(fn => {
+  let validFields = requiredFields.filter(fn => {
     let schemaField = findFieldInSchema(fn)
     if (data) {
       if (data[fn] === null) {
@@ -56,7 +57,7 @@ export const getFieldChangeOptions = (config: {
   })
 
   let isCurrentFieldValid = field ? validFields.find(fn => field ? fn === field.name : false) : true
-  if (validFields.length !== envRequiredFields.length || !isCurrentFieldValid) {
+  if (validFields.length !== requiredFields.length || !isCurrentFieldValid) {
     return null
   }
 

--- a/src/types/Config.js
+++ b/src/types/Config.js
@@ -1,5 +1,7 @@
 // @flow
 
+type Type = 'source' | 'destination'
+
 export type Config = {
   disabledPages: string[],
   showUserDomainInput: boolean,
@@ -9,7 +11,7 @@ export type Config = {
   requestPollTimeout: number,
   sourceOptionsProviders: string[],
   instancesListBackgroundLoading: { default: number, [string]: number },
-  providersWithEnvOptions: Array<{ name: string, type: 'source' | 'destination', envRequiredFields: string[] }>,
+  extraOptionsApiCalls: Array<{ name: string, types: Type[], requiredFields: string[] }>,
   providerSortPriority: { [providerName: string]: number },
   hiddenUsers: string[],
 }

--- a/src/types/Instance.js
+++ b/src/types/Instance.js
@@ -35,7 +35,7 @@ export type Instance = {
   id: string,
   name: string,
   flavor_name: string,
-  instance_name: string,
+  instance_name?: ?string,
   num_cpu: number,
   memory_mb: number,
   os_type: string,


### PR DESCRIPTION
Added new providers to the list of providers which support source
options: aws, openstack, azure.

Send the source options when listing an endpoint's instances.

Use `name` instead of `instance_name`, if an endpoint's instance doesn't
have the `instance_name` field.