### PR TITLE
Refactor and improve API calls caching process

### DIFF
--- a/src/components/organisms/EditReplica/EditReplica.jsx
+++ b/src/components/organisms/EditReplica/EditReplica.jsx
@@ -119,7 +119,7 @@ class EditReplica extends React.Component<Props, State> {
     let loadAllOptions = async (type: 'source' | 'destination') => {
       let endpoint = type === 'source' ? this.props.sourceEndpoint : this.props.destinationEndpoint
       await this.loadOptions(endpoint, type, useCache)
-      this.loadExtraOptions(null, type)
+      this.loadExtraOptions(null, type, useCache)
     }
     if (this.hasSourceOptions()) {
       loadAllOptions('source')
@@ -142,7 +142,7 @@ class EditReplica extends React.Component<Props, State> {
     })
   }
 
-  loadExtraOptions(field?: ?Field, type: 'source' | 'destination') {
+  loadExtraOptions(field?: ?Field, type: 'source' | 'destination', useCache?: boolean) {
     let endpoint = type === 'source' ? this.props.sourceEndpoint : this.props.destinationEndpoint
     let env = type === 'source' ? this.props.replica.source_environment : this.props.replica.destination_environment
     let stateEnv = type === 'source' ? this.state.sourceData : this.state.destinationData
@@ -165,7 +165,7 @@ class EditReplica extends React.Component<Props, State> {
       optionsType: type,
       endpointId: endpoint.id,
       providerName: endpoint.type,
-      useCache: true,
+      useCache,
       envData,
     })
   }

--- a/src/sources/InstanceSource.js
+++ b/src/sources/InstanceSource.js
@@ -65,10 +65,10 @@ class InstanceSource {
     return response.data.instances
   }
 
-  async loadInstances(endpointId: string): Promise<Instance[]> {
+  async loadInstances(endpointId: string, cache?: ?boolean): Promise<Instance[]> {
     Api.cancelRequests(endpointId)
     let url = `${servicesUrl.coriolis}/${Api.projectId}/endpoints/${endpointId}/instances`
-    let response = await Api.send({ url, cancelId: endpointId })
+    let response = await Api.send({ url, cancelId: endpointId, cache })
     return response.data.instances
   }
 
@@ -77,7 +77,8 @@ class InstanceSource {
     instanceName: string,
     reqId: number,
     quietError?: boolean,
-    env?: any
+    env?: any,
+    cache?: ?boolean,
   ): Promise<{ instance: Instance, reqId: number }> {
     let url = `${servicesUrl.coriolis}/${Api.projectId}/endpoints/${endpointId}/instances/${btoa(instanceName)}`
     if (env) {
@@ -87,6 +88,7 @@ class InstanceSource {
       url,
       cancelId: `instanceDetail-${reqId}`,
       quietError,
+      cache,
     })
     return { instance: response.data.instance, reqId }
   }

--- a/src/sources/NetworkSource.js
+++ b/src/sources/NetworkSource.js
@@ -22,12 +22,17 @@ import { servicesUrl } from '../constants'
 class NetworkSource {
   async loadNetworks(enpointId: string, environment: ?{ [string]: mixed }, options?: {
     quietError?: boolean,
+    useLocalStorage?: boolean,
   }): Promise<Network[]> {
     let url = `${servicesUrl.coriolis}/${Api.projectId}/endpoints/${enpointId}/networks`
     if (environment) {
       url = `${url}?env=${btoa(JSON.stringify(environment))}`
     }
-    let response = await Api.send({ url, quietError: options && options.quietError })
+    let response = await Api.send({
+      url,
+      quietError: options && options.quietError,
+      cache: options && options.useLocalStorage,
+    })
     let networks: Network[] = response.data.networks.filter(n => n.name.indexOf('coriolis-migrnet') === -1)
     networks.sort((a, b) => a.name.localeCompare(b.name))
     return networks

--- a/src/sources/ProviderSource.js
+++ b/src/sources/ProviderSource.js
@@ -34,18 +34,21 @@ class ProviderSource {
     return response.data.providers
   }
 
-  async loadOptionsSchema(providerName: string, schemaType: 'migration' | 'replica', optionsType: 'source' | 'destination'): Promise<Field[]> {
+  async loadOptionsSchema(providerName: string, schemaType: 'migration' | 'replica', optionsType: 'source' | 'destination', useCache?: ?boolean): Promise<Field[]> {
     let schemaTypeInt = schemaType === 'migration' ?
       optionsType === 'source' ? providerTypes.SOURCE_MIGRATION : providerTypes.TARGET_MIGRATION :
       optionsType === 'source' ? providerTypes.SOURCE_REPLICA : providerTypes.TARGET_REPLICA
 
-    let response = await Api.get(`${servicesUrl.coriolis}/${Api.projectId}/providers/${providerName}/schemas/${schemaTypeInt}`)
+    let response = await Api.send({
+      url: `${servicesUrl.coriolis}/${Api.projectId}/providers/${providerName}/schemas/${schemaTypeInt}`,
+      cache: useCache,
+    })
     let schema = optionsType === 'source' ? response.data.schemas.source_environment_schema : response.data.schemas.destination_environment_schema
     let fields = SchemaParser.optionsSchemaToFields(providerName, schema)
     return fields
   }
 
-  async getOptionsValues(optionsType: 'source' | 'destination', endpointId: string, envData: ?{ [string]: mixed }): Promise<OptionValues[]> {
+  async getOptionsValues(optionsType: 'source' | 'destination', endpointId: string, envData: ?{ [string]: mixed }, cache?: ?boolean): Promise<OptionValues[]> {
     let envString = ''
     if (envData) {
       envString = `?env=${btoa(JSON.stringify(envData))}`
@@ -53,7 +56,10 @@ class ProviderSource {
     let callName = optionsType === 'source' ? 'source-options' : 'destination-options'
     let fieldName = optionsType === 'source' ? 'source_options' : 'destination_options'
 
-    let response = await Api.get(`${servicesUrl.coriolis}/${Api.projectId}/endpoints/${endpointId}/${callName}${envString}`)
+    let response = await Api.send({
+      url: `${servicesUrl.coriolis}/${Api.projectId}/endpoints/${endpointId}/${callName}${envString}`,
+      cache,
+    })
     return response.data[fieldName]
   }
 }

--- a/src/types/Cache.js
+++ b/src/types/Cache.js
@@ -1,0 +1,8 @@
+// @flow
+
+export type Cache = {
+  [key: string]: {
+    data: any,
+    createdAt: string,
+  }
+}

--- a/src/utils/Cacher.js
+++ b/src/utils/Cacher.js
@@ -1,0 +1,44 @@
+// @flow
+
+import type { Cache } from '../types/Cache'
+
+const DEFAULT_MAX_AGE = 15 * 60 * 1000 // 15 minutes
+const STORE = 'api-cacher'
+
+class Cacher {
+  load(options: {
+    key: string,
+    maxAge?: ?number,
+  }): ?any {
+    let { key, maxAge } = options
+    let storage: Cache = JSON.parse(localStorage.getItem(STORE) || '{}')
+    let item = storage[key]
+    if (!item) {
+      return null
+    }
+    let createdAt = new Date(item.createdAt).getTime()
+    let actualMaxAge = (maxAge || DEFAULT_MAX_AGE)
+    if (new Date().getTime() - createdAt > actualMaxAge) {
+      delete storage[key]
+      localStorage.setItem(STORE, JSON.stringify(storage))
+      return null
+    }
+    console.log(`%cFrom cache ${key}`, 'color: #777A8B', item.data)
+    return item.data
+  }
+
+  save(options: {
+    key: string,
+    data: any,
+  }) {
+    let { key, data } = options
+    let storage: Cache = JSON.parse(localStorage.getItem(STORE) || '{}')
+    storage[key] = {
+      data,
+      createdAt: new Date().toISOString(),
+    }
+    localStorage.setItem(STORE, JSON.stringify(storage))
+  }
+}
+
+export default new Cacher()


### PR DESCRIPTION
There's now only one place where API calls are cached in the source code
and in the local storage.

A 15 minute default caching age is used for all cached API calls.

If a call is loaded from cache, a `console.log` appears stating that.