### PR TITLE
Fix `yarn build` fail

### DIFF
--- a/src/components/atoms/StatusImage/StatusImage.jsx
+++ b/src/components/atoms/StatusImage/StatusImage.jsx
@@ -78,7 +78,6 @@ const dashAnimationStyle = css`
   }
 `
 const loadingAnimationStyle = css`
-  /* background: url(${loadingImage}) center no-repeat; */
   animation: rotate 1s linear infinite;
   @keyframes rotate {
     0% {transform: rotate(0deg);}


### PR DESCRIPTION
Production build fails because it tries to interpret CSS comments.