### PR TITLE
Fix details pg. sometimes showing missing endpoint

### DIFF
--- a/src/components/pages/MigrationDetailsPage/MigrationDetailsPage.jsx
+++ b/src/components/pages/MigrationDetailsPage/MigrationDetailsPage.jsx
@@ -63,10 +63,10 @@ class MigrationDetailsPage extends React.Component<Props, State> {
 
   stopPolling: ?boolean
 
-  componentDidMount() {
+  componentWillMount() {
     document.title = 'Migration Details'
 
-    endpointStore.getEndpoints()
+    endpointStore.getEndpoints({ showLoading: true })
     this.loadMigrationWithInstances(this.props.match.params.id, true)
     this.pollData()
   }

--- a/src/components/pages/ReplicaDetailsPage/ReplicaDetailsPage.jsx
+++ b/src/components/pages/ReplicaDetailsPage/ReplicaDetailsPage.jsx
@@ -83,11 +83,11 @@ class ReplicaDetailsPage extends React.Component<Props, State> {
 
   stopPolling: ?boolean
 
-  componentDidMount() {
+  componentWillMount() {
     document.title = 'Replica Details'
 
     this.loadReplicaWithInstances(this.props.match.params.id, true)
-    endpointStore.getEndpoints()
+    endpointStore.getEndpoints({ showLoading: true })
     scheduleStore.getSchedules(this.props.match.params.id)
     this.pollData(true)
   }

--- a/src/stores/MigrationStore.js
+++ b/src/stores/MigrationStore.js
@@ -78,7 +78,9 @@ class MigrationStore {
   }
 
   @action async getMigration(migrationId: string, options?: { showLoading?: boolean, skipLog?: boolean }) {
-    this.detailsLoading = Boolean(options && options.showLoading)
+    if (options && options.showLoading) {
+      this.detailsLoading = true
+    }
 
     try {
       let migration = await MigrationSource.getMigration(migrationId, options && options.skipLog)


### PR DESCRIPTION
Sometimes (slow connection) missing endpoint is show in replica /
migration details page, while the page is still being loaded.