### PR TITLE
Add support for schemas without `oneOf` as root

### DIFF
--- a/src/plugins/endpoint/default/ConnectionSchemaPlugin.js
+++ b/src/plugins/endpoint/default/ConnectionSchemaPlugin.js
@@ -122,13 +122,14 @@ export default class ConnectionSchemaParser {
     return fields
   }
 
-  static parseFieldsToPayload(data: { [string]: mixed }, schema: Schema) {
+  static parseFieldsToPayload(data: { [string]: mixed }, schema: any) {
     let payload = {}
 
     payload.name = data.name
     payload.description = data.description
 
-    payload.connection_info = fieldsToPayload(data, schema.oneOf[0])
+    let schemaRoot = schema.oneOf ? schema.oneOf[0] : schema
+    payload.connection_info = fieldsToPayload(data, schemaRoot)
 
     if (data.secret_ref) {
       payload.connection_info.secret_ref = data.secret_ref

--- a/src/sources/Schemas.js
+++ b/src/sources/Schemas.js
@@ -32,9 +32,10 @@ class SchemaParser {
     return fields
   }
 
-  static optionsSchemaToFields(provider: string, schema: Schema) {
+  static optionsSchemaToFields(provider: string, schema: any) {
     let parser = OptionsSchemaPlugin[provider] || OptionsSchemaPlugin.default
-    let fields = parser.parseSchemaToFields(schema.oneOf[0], schema.definitions)
+    let schemaRoot = schema.oneOf ? schema.oneOf[0] : schema
+    let fields = parser.parseSchemaToFields(schemaRoot, schemaRoot.definitions)
     fields.sort((a, b) => {
       if (a.required && !b.required) {
         return -1


### PR DESCRIPTION
Most schemas come from the API with `oneOf` as their root property.
However, some schemas (ex.: VMWare's source schema) don't have `oneOf`,
but instead may have schema properties directly in the root.