### PR TITLE
Fix sync issues when going from details to list

### DIFF
--- a/src/stores/MigrationStore.js
+++ b/src/stores/MigrationStore.js
@@ -84,7 +84,10 @@ class MigrationStore {
 
     try {
       let migration = await MigrationSource.getMigration(migrationId, options && options.skipLog)
-      runInAction(() => { this.migrationDetails = migration })
+      runInAction(() => {
+        this.migrationDetails = migration
+        this.migrations = this.migrations.map(m => m.id === migration.id ? migration : m)
+      })
     } finally {
       runInAction(() => { this.detailsLoading = false })
     }

--- a/src/stores/ReplicaStore.js
+++ b/src/stores/ReplicaStore.js
@@ -105,7 +105,10 @@ class ReplicaStore {
 
     try {
       let replica = await ReplicaSource.getReplica(replicaId, options && options.skipLog)
-      runInAction(() => { this.replicaDetails = replica })
+      runInAction(() => {
+        this.replicaDetails = replica
+        this.replicas = this.replicas.map(r => r.id === replica.id ? replica : r)
+      })
     } finally {
       runInAction(() => { this.detailsLoading = false })
     }


### PR DESCRIPTION
When going from migration details page to migrations list page, the
migrations list page would briefly display an older status of the
migration from the details page.