### PR TITLE
Group options inputs by `migr_*` field names

### DIFF
--- a/src/components/atoms/InfoIcon/InfoIcon.jsx
+++ b/src/components/atoms/InfoIcon/InfoIcon.jsx
@@ -18,13 +18,14 @@ import React from 'react'
 import { observer } from 'mobx-react'
 import styled from 'styled-components'
 
+import StyleProps from '../../styleUtils/StyleProps'
+
 import questionImage from './images/question.svg'
 import warningImage from './images/warning.svg'
 import questionFilledImage from './images/question-filled.svg'
 
 const Wrapper = styled.div`
-  width: 16px;
-  height: 16px;
+  ${StyleProps.exactSize('16px')}
   background: url('${props => props.warning ? warningImage : props.filled ? questionFilledImage : questionImage}') center no-repeat;
   display: inline-block;
   margin-left: ${props => props.marginLeft != null ? `${props.marginLeft}px` : '4px'};

--- a/src/components/molecules/FieldInput/FieldInput.jsx
+++ b/src/components/molecules/FieldInput/FieldInput.jsx
@@ -46,6 +46,7 @@ const Wrapper = styled.div`
 
 const Label = styled.div`
   font-weight: ${StyleProps.fontWeights.medium};
+  flex-grow: 1;
   ${props => props.layout === 'page' ? css`
     margin-bottom: 8px;
   ` : css`


### PR DESCRIPTION
If there is more than one field name starting with `migr_*`, put them in
a separate group, thus uncluterring the UI when there are a lot of
fields.