### PR TITLE
Add Flow VSCode settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 dist
 *.log
 node_modules
-.vscode
 flow-typed/npm/*
 !flow-typed/npm/module_vx.x.x.js
 private/cypress/config.js

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "flow.useNPMPackagedFlow": true,
+  "javascript.validate.enable": false,
+}


### PR DESCRIPTION
These VSCode settings allow using the node modules version of Flow and
disables VSCode's Typescript validation (interferes with Flow's
validation).