### PR TITLE
Fix a Safari CSS error

### DIFF
--- a/src/components/organisms/WizardOptions/WizardOptions.jsx
+++ b/src/components/organisms/WizardOptions/WizardOptions.jsx
@@ -52,6 +52,7 @@ const Fields = styled.div`
 const Group = styled.div`
   display: flex;
   flex-direction: column;
+  flex-shrink: 0;
 `
 const GroupName = styled.div`
   display: flex;


### PR DESCRIPTION
Wizard options gets collapsed when temporary migration options field
group is shown.