### PR TITLE
Break notification item name if it doesn't fit CORWEB-219

### DIFF
--- a/src/components/molecules/NotificationDropdown/NotificationDropdown.jsx
+++ b/src/components/molecules/NotificationDropdown/NotificationDropdown.jsx
@@ -148,7 +148,7 @@ export const ItemReplicaBadge = styled.div`
   border: 1px solid #7F8795;
 `
 export const ItemTitle = styled.div`
-  ${props => props.nowrap ? 'white-space: nowrap;' : ''}
+  ${props => props.nowrap ? 'white-space: nowrap;' : 'word-break: break-word;'}
   overflow: hidden;
   text-overflow: ellipsis;
 `


### PR DESCRIPTION
If the notification item's name is too long, break it on the next line,
so it doesn't overflow the items list.