### PR TITLE
Break storage name into lines if it is too long

### DIFF
--- a/src/components/organisms/WizardStorage/WizardStorage.jsx
+++ b/src/components/organisms/WizardStorage/WizardStorage.jsx
@@ -83,6 +83,7 @@ const StorageTitle = styled.div`
 `
 const StorageName = styled.div`
   font-size: 16px;
+  word-break: break-word;
 `
 const StorageSubtitle = styled.div`
   font-size: 12px;


### PR DESCRIPTION
Applies `word-break: break-word;` CSS style to the storage name, thus
breaking its name into multiple lines if it doesn't fit into one.