### PR TITLE
Render field integers even without min and max

### DIFF
--- a/src/components/organisms/WizardOptions/WizardOptions.jsx
+++ b/src/components/organisms/WizardOptions/WizardOptions.jsx
@@ -94,7 +94,6 @@ const LoadingText = styled.div`
 
 export const shouldRenderField = (field: Field) => {
   return (field.type !== 'array' || (field.enum && field.enum.length && field.enum.length > 0)) &&
-    (field.type !== 'integer' || (field.minimum && field.maximum)) &&
     (field.type !== 'object' || field.properties)
 }
 type FieldRender = {


### PR DESCRIPTION
Allow integer fields to get render if they don't have a minimum and a
maximum value.