### PR TITLE
Add support for 'CANCELED_FOR_DEBUGGING' status

### DIFF
--- a/src/components/atoms/StatusIcon/StatusIcon.jsx
+++ b/src/components/atoms/StatusIcon/StatusIcon.jsx
@@ -83,8 +83,12 @@ const Wrapper = styled.div`
 @observer
 class StatusIcon extends React.Component<Props> {
   render() {
+    let status = this.props.status
+    if (status === 'CANCELED_FOR_DEBUGGING') {
+      status = 'ERROR'
+    }
     return (
-      <Wrapper {...this.props} />
+      <Wrapper {...this.props} status={status} />
     )
   }
 }

--- a/src/components/atoms/StatusPill/StatusPill.jsx
+++ b/src/components/atoms/StatusPill/StatusPill.jsx
@@ -112,18 +112,25 @@ class StatusPill extends React.Component<Props> {
 
   render() {
     const dataTestId = this.props['data-test-id'] ? this.props['data-test-id'] : `statusPill-${this.props.status || 'null'}`
+    let label = this.props.label || this.props.status
+    let status = this.props.status
+
+    if (status === 'CANCELED_FOR_DEBUGGING') {
+      status = 'ERROR'
+      label = 'DEBUG'
+    }
 
     return (
       <Wrapper
         {...this.props}
-        status={this.props.status}
+        status={status}
         primary={this.props.primary}
         secondary={this.props.secondary}
         alert={this.props.alert}
         small={this.props.small}
         data-test-id={dataTestId}
       >
-        {this.props.label || this.props.status}
+        {label}
       </Wrapper>
     )
   }


### PR DESCRIPTION
'ERROR' icon and 'DEBUG' label is used to represent the
'CANCELED_FOR_DEBUGGING' status.