### PR TITLE
Improve Edit Replica options loading

### DIFF
--- a/src/components/organisms/EditReplica/EditReplica.jsx
+++ b/src/components/organisms/EditReplica/EditReplica.jsx
@@ -120,8 +120,9 @@ class EditReplica extends React.Component<Props, State> {
 
     let loadAllOptions = async (type: 'source' | 'destination') => {
       let endpoint = type === 'source' ? this.props.sourceEndpoint : this.props.destinationEndpoint
+      let envData = type === 'source' ? this.props.replica.source_environment : this.props.replica.destination_environment
       try {
-        await this.loadOptions(endpoint, type, useCache)
+        await this.loadOptions(endpoint, type, useCache, envData)
         this.loadExtraOptions(null, type, useCache)
       } catch (err) {
         if (type === 'source') {
@@ -139,7 +140,7 @@ class EditReplica extends React.Component<Props, State> {
     loadAllOptions('destination')
   }
 
-  async loadOptions(endpoint: Endpoint, optionsType: 'source' | 'destination', useCache: boolean) {
+  async loadOptions(endpoint: Endpoint, optionsType: 'source' | 'destination', useCache: boolean, envData: ?{ [string]: mixed }) {
     await providerStore.loadOptionsSchema({
       providerName: endpoint.type,
       schemaType: this.props.type || 'replica',
@@ -151,6 +152,7 @@ class EditReplica extends React.Component<Props, State> {
       endpointId: endpoint.id,
       providerName: endpoint.type,
       useCache,
+      envData,
     })
   }
 

--- a/src/stores/ProviderStore.js
+++ b/src/stores/ProviderStore.js
@@ -194,7 +194,7 @@ class ProviderStore {
     optionsType: 'source' | 'destination',
     endpointId: string,
     providerName: string,
-    envData?: { [string]: mixed },
+    envData?: ?{ [string]: mixed },
     useCache?: boolean,
     quietError?: boolean,
   }): Promise<OptionValues[]> {


### PR DESCRIPTION
Fixes an issue where destination options would not load if Edit Replica
is opened while destination options call is already made in Replica
Details Page.