### PR TITLE
Fix array type fields using label dictionary

### DIFF
--- a/src/components/molecules/FieldInput/FieldInput.jsx
+++ b/src/components/molecules/FieldInput/FieldInput.jsx
@@ -242,7 +242,7 @@ class FieldInput extends React.Component<Props> {
       }
 
       return {
-        label: typeof e === 'string' ? LabelDictionary.get(e) : e.name || e.label,
+        label: typeof e === 'string' ? e : e.name || e.label,
         value: typeof e === 'string' ? e : e.id || e.value,
       }
     })


### PR DESCRIPTION
Fields of type array should not use label dictionary for their values,
consistent with other type of fields that are represented with a
dropdown (i.e. type 'string' with 'enum' property).