### PR TITLE
Fix missing info in server error alerts

### DIFF
--- a/src/components/pages/MigrationDetailsPage/MigrationDetailsPage.jsx
+++ b/src/components/pages/MigrationDetailsPage/MigrationDetailsPage.jsx
@@ -188,11 +188,7 @@ class MigrationDetailsPage extends React.Component<Props, State> {
       return
     }
     await migrationStore.cancel(migrationStore.migrationDetails.id)
-    if (migrationStore.canceling === false) {
-      notificationStore.alert('Canceled', 'success')
-    } else {
-      notificationStore.alert('The migration couldn\'t be canceled', 'error')
-    }
+    notificationStore.alert('Canceled', 'success')
   }
 
   async recreateFromReplica(options: Field[]) {

--- a/src/components/pages/ProjectDetailsPage/ProjectDetailsPage.jsx
+++ b/src/components/pages/ProjectDetailsPage/ProjectDetailsPage.jsx
@@ -30,7 +30,6 @@ import AlertModal from '../../organisms/AlertModal'
 
 import projectStore from '../../../stores/ProjectStore'
 import userStore from '../../../stores/UserStore'
-import notificationStore from '../../../stores/NotificationStore'
 
 import Palette from '../../styleUtils/Palette'
 
@@ -138,16 +137,11 @@ class ProjectDetailsPage extends React.Component<Props, State> {
 
   async handleAddMember(user: User, isNew: boolean, roles: Role[]) {
     const assign = async (userId: string) => {
-      try {
-        await Promise.all(roles.map(async r => {
-          await userStore.assignUserToProjectWithRole(userId, this.props.match.params.id, r.id)
-        }))
-        this.loadData()
-        this.setState({ addingMember: false, showAddMemberModal: false })
-      } catch (err) {
-        notificationStore.alert('Error while assigning role to user', 'error')
-        console.error(err)
-      }
+      await Promise.all(roles.map(async r => {
+        await userStore.assignUserToProjectWithRole(userId, this.props.match.params.id, r.id)
+      }))
+      this.loadData()
+      this.setState({ addingMember: false, showAddMemberModal: false })
     }
 
     this.setState({ addingMember: true })

--- a/src/stores/MigrationStore.js
+++ b/src/stores/MigrationStore.js
@@ -25,7 +25,6 @@ class MigrationStore {
   @observable migrations: MainItem[] = []
   @observable migrationDetails: ?MainItem = null
   @observable loading: boolean = true
-  @observable canceling: boolean | { failed: boolean } = true
   @observable detailsLoading: boolean = true
 
   migrationsLoaded: boolean = false
@@ -94,13 +93,7 @@ class MigrationStore {
   }
 
   @action async cancel(migrationId: string) {
-    this.canceling = true
-    try {
-      await MigrationSource.cancel(migrationId)
-      runInAction(() => { this.canceling = false })
-    } catch (ex) {
-      runInAction(() => { this.canceling = { failed: true } })
-    }
+    await MigrationSource.cancel(migrationId)
   }
 
   @action async delete(migrationId: string) {


### PR DESCRIPTION
Some error alerts don't display server error details, because they are
custom handled with a custom message.

Fixed by handling them s using the default error handling system, thus
always displaying the full server error details.