### PR TITLE
Fix a log streaming memory leak

### DIFF
--- a/src/stores/LogStore.js
+++ b/src/stores/LogStore.js
@@ -99,7 +99,7 @@ class LogStore {
   @action addToLiveFeed(feed: { message: string }) {
     this.liveFeed = [...this.liveFeed, feed.message]
     if (this.liveFeed.length > MAX_STREAM_LINES) {
-      this.liveFeed = this.liveFeed.filter((f, i) => i > this.liveFeed.length - MAX_STREAM_LINES)
+      this.liveFeed = [...this.liveFeed.filter((f, i) => i > this.liveFeed.length - MAX_STREAM_LINES)]
     }
   }
 


### PR DESCRIPTION
Fixes a memory leak caused by not reinitialising the JS array object
when adding new lines to the stream after the stream maximum lines have
been reached.