### PR TITLE
Add support for required values for extra options

### DIFF
--- a/config.js
+++ b/config.js
@@ -38,12 +38,23 @@ const conf: Config = {
   // - `Infinity` value means no `limit` will be used, i.e. all VMs will be listed.
   instancesListBackgroundLoading: { default: 10, ovm: Infinity, 'hyper-v': Infinity },
 
-  // The providers for which an extra `source options` or `destination options` call can be made with a set of field values
+  /**
+   * The list of providers for which and extra source or destination options API call will be made,
+   * if the required fields have any value set.
+   * If `requiredValues` is provided, the field specified there needs to have a certain value (specified in values)
+   * in order to make the options API call.
+   */
   extraOptionsApiCalls: [
     {
       name: 'openstack',
       types: ['source'],
       requiredFields: ['replica_export_mechanism'],
+      requiredValues: [
+        {
+          field: 'replica_export_mechanism',
+          values: ['swift_backups', 'ceph_backups', 'coriolis_backups'],
+        },
+      ],
     },
     {
       name: 'azure',

--- a/src/stores/ProviderStore.js
+++ b/src/stores/ProviderStore.js
@@ -41,6 +41,7 @@ export const getFieldChangeOptions = (config: {
     return null
   }
   let requiredFields = providerWithEnvOptions.requiredFields
+  let requiredValues = providerWithEnvOptions.requiredValues
 
   let findFieldInSchema = (name: string) => schema.find(f => f.name === name)
 
@@ -50,8 +51,16 @@ export const getFieldChangeOptions = (config: {
       if (data[fn] === null) {
         return false
       }
-      if (data[fn] === undefined && schemaField && schemaField.default) {
+      let defaultValue = data[fn] === undefined && schemaField && schemaField.default
+      let requiredValue = requiredValues && requiredValues.find(f => f.field === fn)
+      if (defaultValue) {
+        if (requiredValue) {
+          return Boolean(requiredValue.values.find(v => v === defaultValue))
+        }
         return true
+      }
+      if (requiredValue) {
+        return Boolean(requiredValue.values.find(v => v === data[fn]))
       }
       return data[fn]
     }

--- a/src/types/Config.js
+++ b/src/types/Config.js
@@ -2,6 +2,16 @@
 
 type Type = 'source' | 'destination'
 
+type ExtraOption = {
+  name: string,
+  types: Type[],
+  requiredFields: string[],
+  requiredValues?: {
+    field: string,
+    values: string[],
+  }[]
+}
+
 export type Config = {
   disabledPages: string[],
   showUserDomainInput: boolean,
@@ -11,7 +21,7 @@ export type Config = {
   requestPollTimeout: number,
   sourceOptionsProviders: string[],
   instancesListBackgroundLoading: { default: number, [string]: number },
-  extraOptionsApiCalls: Array<{ name: string, types: Type[], requiredFields: string[] }>,
+  extraOptionsApiCalls: ExtraOption[],
   providerSortPriority: { [providerName: string]: number },
   hiddenUsers: string[],
   passwordFields: string[],


### PR DESCRIPTION
Previously, you could specify a list of providers for which an extra
source or destination options is made, as long as the `requiredFields`
have any value set before making the API calls.

Now, you can specify a set of required values for those fields, before
making the calls.

**Openstack example:**

Previously, `source-options` API call would have been made if
`replica_export_mechanism` had any value chosen from the list of values.

With this change, the API call is made only if `replica_export_mechanism`
is `swift_backups`, `ceph_backups` or `coriolis_backups`.

This is configurable in `./config.js`