### PR TITLE
Add pagination to lists (replicas, endpoints etc)

### DIFF
--- a/config.js
+++ b/config.js
@@ -93,6 +93,8 @@ const conf: Config = {
   // If the field doesn't contain `password` in its name, the following list will be used instead
   passwordFields: ['private_key_passphrase', 'secret_access_key'],
 
+  // The number of items per page applicable to main lists: replicas, migrations, endpoints, users etc.
+  mainListItemsPerPage: 20,
 }
 
 export const config = conf

--- a/src/components/atoms/Pagination/Pagination.jsx
+++ b/src/components/atoms/Pagination/Pagination.jsx
@@ -1,0 +1,109 @@
+/*
+Copyright (C) 2020  Cloudbase Solutions SRL
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// @flow
+
+import React from 'react'
+import { observer } from 'mobx-react'
+import styled, { css } from 'styled-components'
+
+import Arrow from '../../atoms/Arrow'
+import HorizontalLoading from '../../atoms/HorizontalLoading'
+
+import StyleProps from '../../styleUtils/StyleProps'
+import Palette from '../../styleUtils/Palette'
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  flex-shrink: 0;
+`
+const pageStyle = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: ${Palette.grayscale[1]};
+`
+const pageButtonStyle = css`
+  width: 32px;
+  height: 30px;
+  cursor: ${props => props.disabled ? 'default' : 'pointer'};
+  padding-top: 2px;
+`
+const PagePrevious = styled.div`
+  border-top-left-radius: ${StyleProps.borderRadius};
+  border-bottom-left-radius: ${StyleProps.borderRadius};
+  ${pageStyle}
+  ${pageButtonStyle}
+`
+const PageNext = styled.div`
+  border-top-right-radius: ${StyleProps.borderRadius};
+  border-bottom-right-radius: ${StyleProps.borderRadius};
+  ${pageStyle}
+  ${pageButtonStyle}
+`
+const PageNumber = styled.div`
+  width: 64px;
+  height: 29px;
+  flex-direction: column;
+  margin: 0 1px;
+  padding-top: 3px;
+  ${pageStyle}
+`
+
+type Props = {
+  className?: string,
+  style?: any,
+  previousDisabled: boolean,
+  onPreviousClick: () => void,
+  currentPage: number,
+  totalPages: number,
+  loading?: boolean,
+  nextDisabled: boolean,
+  onNextClick: () => void,
+}
+
+@observer
+class Pagination extends React.Component<Props> {
+  render() {
+    return (
+      <Wrapper
+        className={this.props.className}
+        style={this.props.style}
+        onMouseDown={e => { e.preventDefault() }}
+      >
+        <PagePrevious
+          disabled={this.props.previousDisabled}
+          onClick={() => { if (!this.props.previousDisabled) { this.props.onPreviousClick() } }}
+        >
+          <Arrow orientation="left" disabled={this.props.previousDisabled} color={Palette.black} thick />
+        </PagePrevious>
+        <PageNumber>
+          {this.props.currentPage} of {this.props.totalPages}
+          {this.props.loading ? (
+            <HorizontalLoading style={{ width: '100%', top: '3px' }} />
+          ) : null}
+        </PageNumber>
+        <PageNext
+          onClick={() => { if (!this.props.nextDisabled) { this.props.onNextClick() } }}
+          disabled={this.props.nextDisabled}
+        >
+          <Arrow disabled={this.props.nextDisabled} color={Palette.black} thick />
+        </PageNext>
+      </Wrapper>
+    )
+  }
+}
+
+export default Pagination

--- a/src/components/atoms/Pagination/package.json
+++ b/src/components/atoms/Pagination/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "Pagination",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./Pagination.jsx"
+}

--- a/src/components/organisms/WizardInstances/WizardInstances.jsx
+++ b/src/components/organisms/WizardInstances/WizardInstances.jsx
@@ -16,16 +16,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from 'react'
 import { observer } from 'mobx-react'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 
 import Checkbox from '../../atoms/Checkbox'
 import ReloadButton from '../../atoms/ReloadButton'
-import Arrow from '../../atoms/Arrow'
-import HorizontalLoading from '../../atoms/HorizontalLoading'
 import StatusImage from '../../atoms/StatusImage'
 import Button from '../../atoms/Button'
 import SearchInput from '../../molecules/SearchInput'
 import InfoIcon from '../../atoms/InfoIcon'
+import Pagination from '../../atoms/Pagination'
 
 import Palette from '../../styleUtils/Palette'
 import StyleProps from '../../styleUtils/StyleProps'
@@ -122,45 +121,6 @@ const FilterInfo = styled.div`
 const SelectionInfo = styled.div``
 const FilterSeparator = styled.div`
   margin: 0 14px 0 16px;
-`
-const Pagination = styled.div`
-  display: flex;
-  justify-content: center;
-  margin: 32px 0 16px 0;
-  flex-shrink: 0;
-`
-const pageStyle = css`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background: ${Palette.grayscale[1]};
-`
-const pageButtonStyle = css`
-  width: 32px;
-  height: 30px;
-  cursor: ${props => props.disabled ? 'default' : 'pointer'};
-  padding-top: 2px;
-`
-
-const PagePrevious = styled.div`
-  border-top-left-radius: ${StyleProps.borderRadius};
-  border-bottom-left-radius: ${StyleProps.borderRadius};
-  ${pageStyle}
-  ${pageButtonStyle}
-`
-const PageNext = styled.div`
-  border-top-right-radius: ${StyleProps.borderRadius};
-  border-bottom-right-radius: ${StyleProps.borderRadius};
-  ${pageStyle}
-  ${pageButtonStyle}
-`
-const PageNumber = styled.div`
-  width: 64px;
-  height: 29px;
-  flex-direction: column;
-  margin: 0 1px;
-  padding-top: 3px;
-  ${pageStyle}
 `
 const Reloading = styled.div`
   margin: 32px auto 0 auto;
@@ -402,28 +362,16 @@ class WizardInstances extends React.Component<Props, State> {
     let isNextDisabled = !hasNextPage || areAllDisabled
 
     return (
-      <Pagination onMouseDown={e => { e.preventDefault() }}>
-        <PagePrevious
-          disabled={isPreviousDisabled}
-          onClick={() => { if (!isPreviousDisabled) { this.handlePreviousPageClick() } }}
-          data-test-id="wInstances-prevPageButton"
-        >
-          <Arrow orientation="left" disabled={isPreviousDisabled} color={Palette.black} thick />
-        </PagePrevious>
-        <PageNumber data-test-id="wInstances-currentPage">
-          {this.props.currentPage} of {Math.ceil(this.props.instances.length / this.props.instancesPerPage)}
-          {this.props.chunksLoading ? (
-            <HorizontalLoading style={{ width: '100%', top: '3px' }} data-test-id="wInstances-loadingChunks" />
-          ) : null}
-        </PageNumber>
-        <PageNext
-          onClick={() => { if (!isNextDisabled) { this.handleNextPageClick() } }}
-          disabled={isNextDisabled}
-          data-test-id="wInstances-nextPageButton"
-        >
-          <Arrow disabled={isNextDisabled} color={Palette.black} thick />
-        </PageNext>
-      </Pagination>
+      <Pagination
+        style={{ margin: '32px 0 16px 0' }}
+        previousDisabled={isPreviousDisabled}
+        onPreviousClick={() => { this.handlePreviousPageClick() }}
+        currentPage={this.props.currentPage}
+        totalPages={Math.ceil(this.props.instances.length / this.props.instancesPerPage)}
+        loading={this.props.chunksLoading}
+        nextDisabled={isNextDisabled}
+        onNextClick={() => { this.handleNextPageClick() }}
+      />
     )
   }
 

--- a/src/types/Config.js
+++ b/src/types/Config.js
@@ -25,4 +25,5 @@ export type Config = {
   providerSortPriority: { [providerName: string]: number },
   hiddenUsers: string[],
   passwordFields: string[],
+  mainListItemsPerPage: number,
 }


### PR DESCRIPTION
All main lists (replicas, migrations, endpoints, users, projects) now
display pagination control IF the number of items exceeds a configurable
amount.

The configurable amount of items per page can be modified at
`mainListItemsPerPage` in [`config.js`](config.js).