### PR TITLE
Fix Safari password save prompt issue in Wizard

### DIFF
--- a/src/sources/WizardSource.js
+++ b/src/sources/WizardSource.js
@@ -19,6 +19,8 @@ import notificationStore from '../stores/NotificationStore'
 import { OptionsSchemaPlugin } from '../plugins/endpoint'
 
 import { servicesUrl } from '../constants'
+import DomUtils from '../utils/DomUtils'
+
 import type { WizardData } from '../types/WizardData'
 import type { StorageMap } from '../types/Endpoint'
 import type { MainItem } from '../types/MainItem'
@@ -95,7 +97,7 @@ class WizardSource {
 
   setUrlState(data: any) {
     let locationExp = /.*?(?:\?|$)/.exec(window.location.href)
-    if (!locationExp) {
+    if (!locationExp || DomUtils.isSafari()) {
       return
     }
     let location = locationExp[0].replace('?', '')

--- a/src/utils/DomUtils.js
+++ b/src/utils/DomUtils.js
@@ -150,6 +150,10 @@ class DomUtils {
       return `<span class="${cls}">${match}</span>`
     })
   }
+
+  static isSafari() {
+    return navigator.userAgent.indexOf('Chrome') === -1 && navigator.userAgent.indexOf('Safari') > -1
+  }
 }
 
 export default DomUtils


### PR DESCRIPTION
If there's a filled-in password field in the Wizard, Safari prompts the
user to store it in keychain every time any input is changed, due to the
Wizard's URL changing on each input change.

As a temporary workaround, the Wizard URL no longer changes for Safari,
meaning the Wizard page can no longer be refreshed while keeping all the
filled values and can no longer be bookmarked.