### PR TITLE
Add replica and migration force cancel support CORWEB-228

### DIFF
--- a/src/components/organisms/Executions/Executions.jsx
+++ b/src/components/organisms/Executions/Executions.jsx
@@ -89,7 +89,7 @@ const NoExecutionText = styled.div`
 type Props = {
   item: ?MainItem,
   loading: boolean,
-  onCancelExecutionClick: (execution: ?Execution) => void,
+  onCancelExecutionClick: (execution: ?Execution, force?: boolean) => void,
   onDeleteExecutionClick: (execution: ?Execution) => void,
   onExecuteClick: () => void,
 }
@@ -192,6 +192,10 @@ class Executions extends React.Component<Props, State> {
     this.props.onCancelExecutionClick(this.state.selectedExecution)
   }
 
+  handleForceCancelExecutionClick() {
+    this.props.onCancelExecutionClick(this.state.selectedExecution, true)
+  }
+
   renderLoading() {
     if (!this.props.loading) {
       return null
@@ -234,7 +238,18 @@ class Executions extends React.Component<Props, State> {
           hollow
           onClick={() => { this.handleCancelExecutionClick() }}
           data-test-id="executions-cancelButton"
-        >Cancel Execution</Button>)
+        >Cancel Execution</Button>
+      )
+    }
+
+    if (this.state.selectedExecution.status === 'CANCELLING') {
+      return (
+        <Button
+          secondary
+          hollow
+          onClick={() => { this.handleForceCancelExecutionClick() }}
+        >Force Cancel Execution</Button>
+      )
     }
 
     return (

--- a/src/components/organisms/ReplicaDetailsContent/ReplicaDetailsContent.jsx
+++ b/src/components/organisms/ReplicaDetailsContent/ReplicaDetailsContent.jsx
@@ -83,7 +83,7 @@ type Props = {
   page: string,
   detailsLoading: boolean,
   executionsLoading: boolean,
-  onCancelExecutionClick: (execution: ?Execution) => void,
+  onCancelExecutionClick: (execution: ?Execution, force?: boolean) => void,
   onDeleteExecutionClick: (execution: ?Execution) => void,
   onExecuteClick: () => void,
   onCreateMigrationClick: () => void,

--- a/src/sources/MigrationSource.js
+++ b/src/sources/MigrationSource.js
@@ -143,11 +143,15 @@ class MigrationSource {
     return response.data.migration
   }
 
-  async cancel(migrationId: string): Promise<string> {
+  async cancel(migrationId: string, force: ?boolean): Promise<string> {
+    let data: any = { cancel: null }
+    if (force) {
+      data.cancel = { force: true }
+    }
     await Api.send({
       url: `${servicesUrl.coriolis}/${Api.projectId}/migrations/${migrationId}/actions`,
       method: 'POST',
-      data: { cancel: null },
+      data,
     })
     return migrationId
   }

--- a/src/sources/ReplicaSource.js
+++ b/src/sources/ReplicaSource.js
@@ -169,11 +169,15 @@ class ReplicaSource {
     return execution
   }
 
-  async cancelExecution(replicaId: string, executionId: string): Promise<string> {
+  async cancelExecution(replicaId: string, executionId: string, force: ?boolean): Promise<string> {
+    let data: any = { cancel: null }
+    if (force) {
+      data.cancel = { force: true }
+    }
     await Api.send({
       url: `${servicesUrl.coriolis}/${Api.projectId}/replicas/${replicaId}/executions/${executionId}/actions`,
       method: 'POST',
-      data: { cancel: null },
+      data,
     })
     return replicaId
   }

--- a/src/stores/MigrationStore.js
+++ b/src/stores/MigrationStore.js
@@ -97,8 +97,8 @@ class MigrationStore {
     }
   }
 
-  @action async cancel(migrationId: string) {
-    await MigrationSource.cancel(migrationId)
+  @action async cancel(migrationId: string, force: ?boolean) {
+    await MigrationSource.cancel(migrationId, force)
   }
 
   @action async delete(migrationId: string) {

--- a/src/stores/ReplicaStore.js
+++ b/src/stores/ReplicaStore.js
@@ -132,9 +132,13 @@ class ReplicaStore {
     }
   }
 
-  async cancelExecution(replicaId: string, executionId: string): Promise<void> {
-    await ReplicaSource.cancelExecution(replicaId, executionId)
-    notificationStore.alert('Cancelled', 'success')
+  async cancelExecution(replicaId: string, executionId: string, force: ?boolean): Promise<void> {
+    await ReplicaSource.cancelExecution(replicaId, executionId, force)
+    if (force) {
+      notificationStore.alert('Force cancelled', 'success')
+    } else {
+      notificationStore.alert('Cancelled', 'success')
+    }
   }
 
   async deleteExecution(replicaId: string, executionId: string): Promise<void> {


### PR DESCRIPTION
If a replica execution (or migration) is in 'CANCELLING' state, a
'Force Cancel' option will be presented. This will send the`force: true`
message to the API.