### PR TITLE
Preserve skip_os_morphing when recreating migr. CORWEB-229

### DIFF
--- a/src/components/organisms/EditReplica/EditReplica.jsx
+++ b/src/components/organisms/EditReplica/EditReplica.jsx
@@ -376,6 +376,9 @@ class EditReplica extends React.Component<Props, State> {
     if (migrationFields.find(f => f.name === fieldName) && this.props.replica[fieldName]) {
       return this.props.replica[fieldName]
     }
+    if (fieldName === 'skip_os_morphing' && this.props.type === 'migration') {
+      return migrationStore.getDefaultSkipOsMorphing(this.props.replica)
+    }
     return defaultValue
   }
 

--- a/src/components/organisms/ReplicaMigrationOptions/ReplicaMigrationOptions.jsx
+++ b/src/components/organisms/ReplicaMigrationOptions/ReplicaMigrationOptions.jsx
@@ -78,6 +78,7 @@ const FieldInputStyled = styled(FieldInput)`
 type Props = {
   instances: Instance[],
   loadingInstances: boolean,
+  defaultSkipOsMorphing?: ?boolean,
   onCancelClick: () => void,
   onMigrateClick: (fields: Field[], uploadedScripts: InstanceScript[]) => void,
   onResizeUpdate?: (scrollableRef: HTMLElement, scrollOffset?: number) => void,
@@ -105,12 +106,20 @@ let defaultFields: Field[] = [
 @observer
 class ReplicaMigrationOptions extends React.Component<Props, State> {
   state = {
-    fields: [...defaultFields],
+    fields: [],
     selectedBarButton: 'options',
     uploadedScripts: [],
   }
 
   scrollableRef: HTMLElement
+
+  componentWillMount() {
+    this.setState({
+      fields: defaultFields.map(f => f.name === 'skip_os_morphing' ? (
+        { ...f, value: this.props.defaultSkipOsMorphing || null }
+      ) : f),
+    })
+  }
 
   componentDidMount() {
     KeyboardManager.onEnter('migration-options', () => { this.migrate() }, 2)

--- a/src/components/organisms/ReplicaMigrationOptions/test.jsx
+++ b/src/components/organisms/ReplicaMigrationOptions/test.jsx
@@ -25,6 +25,7 @@ const wrap = props => new TW(shallow(
     instances={[]}
     onMigrateClick={() => { }}
     loadingInstances={false}
+    defaultSkipOsMorphing={false}
     {...props}
   />), 'rmOptions')
 

--- a/src/components/organisms/WizardOptions/WizardOptions.jsx
+++ b/src/components/organisms/WizardOptions/WizardOptions.jsx
@@ -173,7 +173,7 @@ class WizardOptions extends React.Component<Props> {
       fieldsSchema.push({ name: 'description', type: 'string' })
     }
 
-    if (this.props.wizardType === 'migration') {
+    if (this.props.wizardType === 'migration' || this.props.wizardType === 'migration-destination-options-edit') {
       fieldsSchema.unshift({ name: 'skip_os_morphing', type: 'boolean', default: false })
     }
 

--- a/src/components/pages/MigrationDetailsPage/MigrationDetailsPage.jsx
+++ b/src/components/pages/MigrationDetailsPage/MigrationDetailsPage.jsx
@@ -336,6 +336,7 @@ class MigrationDetailsPage extends React.Component<Props, State> {
               onMigrateClick={(o, s) => { this.recreateFromReplica(o, s) }}
               instances={instanceStore.instancesDetails}
               loadingInstances={instanceStore.loadingInstancesDetails}
+              defaultSkipOsMorphing={migrationStore.getDefaultSkipOsMorphing(migrationStore.migrationDetails)}
             />
           </Modal>
         ) : null}

--- a/src/sources/MigrationSource.js
+++ b/src/sources/MigrationSource.js
@@ -86,9 +86,11 @@ class MigrationSource {
     updatedDefaultStorage: ?string,
     networkMappings: ?{ [string]: any },
     updatedNetworkMappings: ?NetworkMap[],
+    defaultSkipOsMorphing: ?boolean,
   }): Promise<MainItem> {
     const getValue = (fieldName: string): ?string => {
-      return (opts.updatedDestEnv && opts.updatedDestEnv[fieldName]) ||
+      let updatedDestEnv = opts.updatedDestEnv && opts.updatedDestEnv[fieldName]
+      return updatedDestEnv != null ? updatedDestEnv :
         (opts.destEnv && opts.destEnv[fieldName])
     }
 
@@ -109,8 +111,11 @@ class MigrationSource {
       notes: getValue('description') || '',
     }
 
-    if (getValue('skip_os_morphing') != null) {
-      payload.migration.skip_os_morphing = getValue('skip_os_morphing')
+    let skipOsMorphingValue = getValue('skip_os_morphing')
+    if (skipOsMorphingValue != null) {
+      payload.migration.skip_os_morphing = skipOsMorphingValue
+    } else if (opts.defaultSkipOsMorphing != null) {
+      payload.migration.skip_os_morphing = opts.defaultSkipOsMorphing
     }
 
     if (opts.networkMappings || (opts.updatedNetworkMappings && opts.updatedNetworkMappings.length)) {

--- a/src/stores/MigrationStore.js
+++ b/src/stores/MigrationStore.js
@@ -55,6 +55,14 @@ class MigrationStore {
     }
   }
 
+  getDefaultSkipOsMorphing(migration: ?MainItem) {
+    let tasks = migration && migration.tasks
+    if (tasks && !tasks.find(t => t.task_type === 'OS_MORPHING')) {
+      return true
+    }
+    return null
+  }
+
   @action async recreate(
     migration: MainItem,
     sourceEndpoint: Endpoint,
@@ -77,6 +85,7 @@ class MigrationStore {
       updatedDefaultStorage,
       networkMappings: migration.network_map,
       updatedNetworkMappings: updateData.network,
+      defaultSkipOsMorphing: this.getDefaultSkipOsMorphing(migration),
     })
     return migrationResult
   }


### PR DESCRIPTION
The `skip_os_morphing` field is now shown when recreating a migration
created from scratch.

The default value of the skip os morphing field is deduced by finding a
migration task of type 'OS_MORPHING'.

This default value is used for recreating a migration created from
scratch and for recreating a migration created from a replica.