### PR TITLE
Use correct reload options label for migration CORWEB-230

### DIFF
--- a/src/components/molecules/Panel/Panel.jsx
+++ b/src/components/molecules/Panel/Panel.jsx
@@ -75,6 +75,7 @@ export type Props = {
   selectedValue: ?string,
   onChange: (item: NavigationItem) => void,
   style?: any,
+  reloadLabel: string,
   onReloadClick: () => void,
 }
 
@@ -107,7 +108,9 @@ class Panel extends React.Component<Props> {
           ))}
         </Navigation>
         <Content data-test-id={`${TEST_ID}-content`}>{this.props.content}</Content>
-        <ReloadButton onClick={() => { this.props.onReloadClick() }}>Reload All Replica Options</ReloadButton>
+        <ReloadButton onClick={() => { this.props.onReloadClick() }}>
+          {this.props.reloadLabel}
+        </ReloadButton>
       </Wrapper>
     )
   }

--- a/src/components/molecules/Panel/story.jsx
+++ b/src/components/molecules/Panel/story.jsx
@@ -33,6 +33,7 @@ storiesOf('Panel', module)
         selectedValue="network"
         onChange={item => console.log(item, 'clicked')}
         onReloadClick={() => { }}
+        reloadLabel=""
       />
     </div>
   ))

--- a/src/components/molecules/Panel/test.jsx
+++ b/src/components/molecules/Panel/test.jsx
@@ -38,6 +38,7 @@ describe('Panel Component', () => {
     let wrapper = wrap({
       navigationItems,
       content,
+      reloadLabel: '',
       onChange: () => { },
       selectedValue: 'navigation2',
       onReloadClick: () => { },
@@ -51,6 +52,7 @@ describe('Panel Component', () => {
     let wrapper = wrap({
       navigationItems,
       content,
+      reloadLabel: '',
       onChange: () => { },
       selectedValue: 'navigation2',
       onReloadClick: () => { },
@@ -66,6 +68,7 @@ describe('Panel Component', () => {
       navigationItems,
       content,
       onChange,
+      reloadLabel: '',
       selectedValue: 'navigation2',
       onReloadClick: () => { },
     })
@@ -77,6 +80,7 @@ describe('Panel Component', () => {
     let wrapper = wrap({
       navigationItems,
       content,
+      reloadLabel: '',
       onChange: () => { },
       selectedValue: 'navigation2',
       onReloadClick: () => { },

--- a/src/components/organisms/EditReplica/EditReplica.jsx
+++ b/src/components/organisms/EditReplica/EditReplica.jsx
@@ -630,6 +630,7 @@ class EditReplica extends React.Component<Props, State> {
           onChange={navItem => { this.handlePanelChange(navItem.value) }}
           selectedValue={this.state.selectedPanel}
           onReloadClick={() => { this.handleReload() }}
+          reloadLabel={this.props.type === 'replica' ? 'Reload All Replica Options' : 'Reload All Migration Options'}
         />
       </Modal>
     )


### PR DESCRIPTION
When showing 'Recreate Replica from Migration' modal, use the correct
reload button label instead of showing 'Reload All Replica Options'.