### PR TITLE
Fix missing labels when creating a new endpoint

### DIFF
--- a/src/plugins/endpoint/azure/ContentPlugin.jsx
+++ b/src/plugins/endpoint/azure/ContentPlugin.jsx
@@ -22,6 +22,7 @@ import ToggleButtonBar from '../../../components/atoms/ToggleButtonBar'
 import type { Field } from '../../../types/Field'
 
 import configLoader from '../../../utils/Config'
+import LabelDictionary from '../../../utils/LabelDictionary'
 import Palette from '../../../components/styleUtils/Palette'
 import StyleProps from '../../../components/styleUtils/StyleProps'
 import KeyboardManager from '../../../utils/KeyboardManager'
@@ -231,6 +232,7 @@ class ContentPlugin extends React.Component<Props, State> {
     return (
       <FieldStyled
         {...field}
+        label={field.title || LabelDictionary.get(field.name)}
         width={StyleProps.inputSizes.large.width}
         disabled={this.props.disabled}
         key={field.name}

--- a/src/plugins/endpoint/default/ContentPlugin.jsx
+++ b/src/plugins/endpoint/default/ContentPlugin.jsx
@@ -18,6 +18,7 @@ import * as React from 'react'
 import styled from 'styled-components'
 
 import configLoader from '../../../utils/Config'
+import LabelDictionary from '../../../utils/LabelDictionary'
 
 import FieldInput from '../../../components/molecules/FieldInput'
 import type { Field } from '../../../types/Field'
@@ -89,6 +90,7 @@ class ContentPlugin extends React.Component<Props> {
       const currentField = (
         <FieldStyled
           {...field}
+          label={field.title || LabelDictionary.get(field.name)}
           width={StyleProps.inputSizes.large.width}
           disabled={this.props.disabled}
           password={isPassword}

--- a/src/plugins/endpoint/openstack/ContentPlugin.jsx
+++ b/src/plugins/endpoint/openstack/ContentPlugin.jsx
@@ -18,6 +18,7 @@ import * as React from 'react'
 import styled from 'styled-components'
 
 import configLoader from '../../../utils/Config'
+import LabelDictionary from '../../../utils/LabelDictionary'
 
 import ToggleButtonBar from '../../../components/atoms/ToggleButtonBar'
 import type { Field } from '../../../types/Field'
@@ -262,6 +263,7 @@ class ContentPlugin extends React.Component<Props, State> {
       return (
         <FieldStyled
           {...field}
+          label={field.title || LabelDictionary.get(field.name)}
           required={required}
           password={isPassword}
           width={StyleProps.inputSizes.large.width}


### PR DESCRIPTION
Fixes an issue where no labels were shown when showing the new endpoint
modal.