### PR TITLE
Fix some dest. / source options values missing

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,7 @@
 [ignore]
 <PROJECT_ROOT>/node_modules/*
 <PROJECT_ROOT>/dist/.*
+<PROJECT_ROOT>/private/.*
 
 [libs]
 

--- a/src/components/organisms/EditReplica/EditReplica.jsx
+++ b/src/components/organisms/EditReplica/EditReplica.jsx
@@ -135,9 +135,8 @@ class EditReplica extends React.Component<Props, State> {
 
     let loadAllOptions = async (type: 'source' | 'destination') => {
       let endpoint = type === 'source' ? this.props.sourceEndpoint : this.props.destinationEndpoint
-      let envData = type === 'source' ? this.props.replica.source_environment : this.props.replica.destination_environment
       try {
-        await this.loadOptions(endpoint, type, useCache, envData)
+        await this.loadOptions(endpoint, type, useCache)
         this.loadExtraOptions(null, type, useCache)
       } catch (err) {
         if (type === 'source') {
@@ -154,7 +153,7 @@ class EditReplica extends React.Component<Props, State> {
     loadAllOptions('destination')
   }
 
-  async loadOptions(endpoint: Endpoint, optionsType: 'source' | 'destination', useCache: boolean, envData: ?{ [string]: mixed }) {
+  async loadOptions(endpoint: Endpoint, optionsType: 'source' | 'destination', useCache: boolean) {
     try {
       await providerStore.loadOptionsSchema({
         providerName: endpoint.type,
@@ -176,7 +175,6 @@ class EditReplica extends React.Component<Props, State> {
       endpointId: endpoint.id,
       providerName: endpoint.type,
       useCache,
-      envData,
     })
   }
 

--- a/src/components/pages/MigrationDetailsPage/MigrationDetailsPage.jsx
+++ b/src/components/pages/MigrationDetailsPage/MigrationDetailsPage.jsx
@@ -92,13 +92,21 @@ class MigrationDetailsPage extends React.Component<Props, State> {
         useCache: true,
         quietError: true,
       })
-      await providerStore.getOptionsValues({
+      let getOptionsValuesConfig = {
         optionsType: 'destination',
         endpointId: details.destination_endpoint_id,
         providerName: endpoint.type,
-        envData: details.destination_environment,
         useCache: true,
         quietError: true,
+        allowMultiple: true,
+      }
+      // For some providers, the API doesn't return the required fields values
+      // if those required fields are sent in env data,
+      // so to retrieve those values a request without env data must be made
+      await providerStore.getOptionsValues(getOptionsValuesConfig)
+      await providerStore.getOptionsValues({
+        ...getOptionsValuesConfig,
+        envData: details.destination_environment,
       })
     }
     loadMigration()

--- a/src/components/pages/ReplicaDetailsPage/ReplicaDetailsPage.jsx
+++ b/src/components/pages/ReplicaDetailsPage/ReplicaDetailsPage.jsx
@@ -109,13 +109,21 @@ class ReplicaDetailsPage extends React.Component<Props, State> {
         useCache: true,
         quietError: true,
       })
-      await providerStore.getOptionsValues({
+      let getOptionsValuesConfig = {
         optionsType: 'destination',
         endpointId: details.destination_endpoint_id,
         providerName: endpoint.type,
-        envData: details.destination_environment,
         useCache: true,
         quietError: true,
+        allowMultiple: true,
+      }
+      // For some providers, the API doesn't return the required fields values
+      // if those required fields are sent in env data,
+      // so to retrieve those values a request without env data must be made
+      await providerStore.getOptionsValues(getOptionsValuesConfig)
+      await providerStore.getOptionsValues({
+        ...getOptionsValuesConfig,
+        envData: details.destination_environment,
       })
     }
     loadReplica()

--- a/src/stores/ProviderStore.js
+++ b/src/stores/ProviderStore.js
@@ -205,8 +205,9 @@ class ProviderStore {
     envData?: ?{ [string]: mixed },
     useCache?: boolean,
     quietError?: boolean,
+    allowMultiple?: boolean,
   }): Promise<OptionValues[]> {
-    let { providerName, optionsType, endpointId, envData, useCache, quietError } = config
+    let { providerName, optionsType, endpointId, envData, useCache, quietError, allowMultiple } = config
     let providerType = optionsType === 'source' ? providerTypes.SOURCE_OPTIONS : providerTypes.DESTINATION_OPTIONS
 
     await this.loadProviders()
@@ -219,7 +220,9 @@ class ProviderStore {
     }
 
     let canceled = false
-    apiCaller.cancelRequests(endpointId)
+    if (!allowMultiple) {
+      apiCaller.cancelRequests(endpointId)
+    }
     this.getOptionsValuesStart(optionsType, !envData)
 
     try {


### PR DESCRIPTION
Fixes an issues where, for some providers, the API may not return the
values for fields sent in a previous dest. / source options call.

For example, when requesting destination options for Azure, while
sending the location and resource group as parameters, the list of
locations and resource groups are no longer returned. As opposed to
making the destination options call for Azure the first time, with no
parameters, in which case, the list of locations and resource groups are
returned.

This means that 2 calls must be made each time to retrieve the full list
of options.