### PR TITLE
Send full migration image map body when updating

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,7 @@
 [ignore]
 <PROJECT_ROOT>/node_modules/*
 <PROJECT_ROOT>/dist/.*
+<PROJECT_ROOT>/private/.*
 
 [libs]
 

--- a/src/plugins/endpoint/ovm/OptionsSchemaPlugin.js
+++ b/src/plugins/endpoint/ovm/OptionsSchemaPlugin.js
@@ -70,7 +70,7 @@ export default class OptionsSchemaParser {
   static getDestinationEnv(options: ?{ [string]: mixed }, oldOptions?: any) {
     let env = {
       ...defaultGetDestinationEnv(options, oldOptions),
-      ...defaultGetMigrationImageMap(options, this.migrationImageMapFieldName),
+      ...defaultGetMigrationImageMap(options, oldOptions, this.migrationImageMapFieldName),
     }
     return env
   }


### PR DESCRIPTION
When editing a replica, send the migration full image map body, even if
only one OS image map was updated.