### PR TITLE
Use correct replication count when recreat. migr. CORWEB-234

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,7 @@
 [ignore]
 <PROJECT_ROOT>/node_modules/*
 <PROJECT_ROOT>/dist/.*
+<PROJECT_ROOT>/private/.*
 
 [libs]
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "flow.useNPMPackagedFlow": true,
   "javascript.validate.enable": false,
+  "files.eol": "\n",
 }

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -80,7 +80,7 @@ const Wrapper = styled.div`
 type State = {
   isConfigReady: boolean,
 }
-const MIN_WAIT_MS = 2000
+const MIN_WAIT_MS = 0
 
 class App extends React.Component<{}, State> {
   state = {

--- a/src/components/organisms/EditReplica/EditReplica.jsx
+++ b/src/components/organisms/EditReplica/EditReplica.jsx
@@ -324,7 +324,15 @@ class EditReplica extends React.Component<Props, State> {
     } else {
       try {
         let replicaDefaultStorage = this.props.replica.storage_mappings && this.props.replica.storage_mappings.default
-        let migration: MainItem = await migrationStore.recreate(this.props.replica, this.props.sourceEndpoint, this.props.destinationEndpoint, updateData, replicaDefaultStorage, this.state.defaultStorage)
+        let migration: MainItem = await migrationStore.recreate(
+          this.props.replica,
+          this.props.sourceEndpoint,
+          this.props.destinationEndpoint,
+          updateData,
+          replicaDefaultStorage,
+          this.state.defaultStorage,
+          this.props.replica.replication_count
+        )
         migrationStore.clearDetails()
         this.props.onRequestClose()
         this.props.onUpdateComplete(`/migration/tasks/${migration.id}`)

--- a/src/sources/MigrationSource.js
+++ b/src/sources/MigrationSource.js
@@ -87,6 +87,7 @@ class MigrationSource {
     networkMappings: ?{ [string]: any },
     updatedNetworkMappings: ?NetworkMap[],
     defaultSkipOsMorphing: ?boolean,
+    replicationCount: ?number,
   }): Promise<MainItem> {
     const getValue = (fieldName: string): ?string => {
       let updatedDestEnv = opts.updatedDestEnv && opts.updatedDestEnv[fieldName]
@@ -106,7 +107,7 @@ class MigrationSource {
         ...destParser.getDestinationEnv(opts.updatedDestEnv),
       },
       shutdown_instances: Boolean(opts.updatedDestEnv && opts.updatedDestEnv.shutdown_instances),
-      replication_count: (opts.updatedDestEnv && opts.updatedDestEnv.replication_count) || 2,
+      replication_count: (opts.updatedDestEnv && opts.updatedDestEnv.replication_count) || opts.replicationCount || 2,
       instances: opts.instanceNames,
       notes: getValue('description') || '',
     }

--- a/src/stores/MigrationStore.js
+++ b/src/stores/MigrationStore.js
@@ -69,7 +69,8 @@ class MigrationStore {
     destEndpoint: Endpoint,
     updateData: UpdateData,
     defaultStorage: ?string,
-    updatedDefaultStorage: ?string
+    updatedDefaultStorage: ?string,
+    replicationCount: ?number
   ): Promise<MainItem> {
     let migrationResult = await MigrationSource.recreate({
       sourceEndpoint,
@@ -86,6 +87,7 @@ class MigrationStore {
       networkMappings: migration.network_map,
       updatedNetworkMappings: updateData.network,
       defaultSkipOsMorphing: this.getDefaultSkipOsMorphing(migration),
+      replicationCount,
     })
     return migrationResult
   }

--- a/src/types/MainItem.js
+++ b/src/types/MainItem.js
@@ -55,6 +55,7 @@ export type MainItem = {
   destination_environment: { [string]: mixed },
   source_environment: { [string]: mixed },
   transfer_result: ?{ [string]: Instance },
+  replication_count?: number,
   storage_mappings?: ?{
     backend_mappings: ?{
       destination: string,


### PR DESCRIPTION
Previously, if replication count value was already set when clicking
Recreate Migration, the value would appear in the Recreate Migration
modal, but it wouldn't have been sent to the API. You had to set it
again in order for it to be sent.

This fixes the issue.