### PR TITLE
Fix missing labels in some modals

### DIFF
--- a/src/components/organisms/EndpointDuplicateOptions/EndpointDuplicateOptions.jsx
+++ b/src/components/organisms/EndpointDuplicateOptions/EndpointDuplicateOptions.jsx
@@ -123,6 +123,7 @@ class EndpointDuplicateOptions extends React.Component<Props, State> {
           <FieldInputStyled
             data-test-id={`${testName}-field-project`}
             name="duplicate_to_project"
+            label="Duplicate To Project"
             type="string"
             enum={this.props.projects}
             value={this.state.selectedProjectId}

--- a/src/components/organisms/ProjectMemberModal/ProjectMemberModal.jsx
+++ b/src/components/organisms/ProjectMemberModal/ProjectMemberModal.jsx
@@ -26,11 +26,12 @@ import Modal from '../../molecules/Modal'
 import FieldInput from '../../molecules/FieldInput'
 import ToggleButtonBar from '../../atoms/ToggleButtonBar'
 import AutocompleteDropdown from '../../molecules/AutocompleteDropdown'
+
 import StyleProps from '../../styleUtils/StyleProps'
 import Palette from '../../styleUtils/Palette'
+import KeyboardManager from '../../../utils/KeyboardManager'
 
 import userImage from './images/user.svg'
-import KeyboardManager from '../../../utils/KeyboardManager'
 
 const Wrapper = styled.div`
   padding: 48px 0 32px 0;
@@ -230,6 +231,7 @@ class ProjectMemberModal extends React.Component<Props, State> {
         data-test-id={`${testName}-roles`}
         key="roles"
         name="role(s)"
+        label="Role(s)"
         type="array"
         onChange={roleId => {
           if (selectedRoles.find(id => id === roleId)) {

--- a/src/components/organisms/ProjectModal/ProjectModal.jsx
+++ b/src/components/organisms/ProjectModal/ProjectModal.jsx
@@ -25,6 +25,7 @@ import Modal from '../../molecules/Modal'
 import FieldInput from '../../molecules/FieldInput'
 
 import projectImage from './images/project.svg'
+import LabelDictionary from '../../../utils/LabelDictionary'
 import KeyboardManager from '../../../utils/KeyboardManager'
 import StyleProps from '../../styleUtils/StyleProps'
 
@@ -124,6 +125,7 @@ class ProjectModal extends React.Component<Props, State> {
         name={field.name}
         type={field.type || 'string'}
         value={value}
+        label={LabelDictionary.get(field.name)}
         onChange={onChange}
         width={StyleProps.inputSizes.large.width}
         disabled={this.props.loading}

--- a/src/components/organisms/UserModal/UserModal.jsx
+++ b/src/components/organisms/UserModal/UserModal.jsx
@@ -25,9 +25,11 @@ import Button from '../../atoms/Button'
 import Modal from '../../molecules/Modal'
 import FieldInput from '../../molecules/FieldInput'
 
-import userImage from './images/user.svg'
+import LabelDictionary from '../../../utils/LabelDictionary'
 import KeyboardManager from '../../../utils/KeyboardManager'
 import StyleProps from '../../styleUtils/StyleProps'
+
+import userImage from './images/user.svg'
 
 const Wrapper = styled.div`
   padding: 48px 0 32px 0;
@@ -179,6 +181,7 @@ class UserModal extends React.Component<Props, State> {
         data-test-id={`${testName}-field-${field.name}`}
         key={field.name}
         name={field.name}
+        label={LabelDictionary.get(field.name)}
         type={field.type || 'string'}
         value={value}
         onChange={onChange}


### PR DESCRIPTION
New Project, New User, Duplicate Endpoint and Add Project Member modals
had no labels for their inputs.

This is a regression bug caused by commit "Add dictionary support for
fields with same name" 1293baca57e29d7199622b209dd897c97861fdaf