### PR TITLE
Fill wizard data current value with default value

### DIFF
--- a/src/stores/WizardStore.js
+++ b/src/stores/WizardStore.js
@@ -68,6 +68,41 @@ class WizardStore {
     this.data = { ...this.data, ...data }
   }
 
+  @action fillWithDefaultValues(direction: 'source' | 'destination', schema: Field[]) {
+    let data: { [string]: any } = (direction === 'source' ? this.data.sourceOptions : this.data.destOptions) || {}
+
+    schema.forEach(field => {
+      if (data[field.name] !== undefined) {
+        return
+      }
+      let fieldDefault = field.default
+      if (fieldDefault == null) {
+        return
+      }
+      if (field.enum) {
+        let isDefaultInEnum = field.enum.find(enumItem => {
+          if (fieldDefault.id != null) {
+            return enumItem.id != null ? enumItem.id === fieldDefault.id : enumItem === fieldDefault.id
+          }
+          return enumItem.id != null ? (enumItem.id === fieldDefault || enumItem.name === fieldDefault) : enumItem === fieldDefault
+        })
+
+        // Don't use the default if it can't be found in the enum list.
+        if (isDefaultInEnum) {
+          data[field.name] = field.default
+        }
+      } else {
+        data[field.name] = field.default
+      }
+    })
+
+    if (direction === 'source') {
+      this.data.sourceOptions = data
+    } else {
+      this.data.destOptions = data
+    }
+  }
+
   @action toggleInstanceSelection(instance: Instance) {
     if (!this.data.selectedInstances) {
       this.data.selectedInstances = [instance]


### PR DESCRIPTION
When using the wizard, after the source or destination schema is loaded,
or after the source or destination options are loaded, set the current
value of the fields to their corresponding default values, if those
fields don't already have a value.

In the case of fields with enums, don't set their value to the default
value if the default value can't be found in the list.