### PR TITLE
Remove the '/details' path component

### DIFF
--- a/src/sources/MigrationSource.js
+++ b/src/sources/MigrationSource.js
@@ -54,7 +54,7 @@ class MigrationSourceUtils {
 class MigrationSource {
   async getMigrations(skipLog?: boolean): Promise<MainItem[]> {
     let response = await Api.send({
-      url: `${configLoader.config.servicesUrls.coriolis}/${Api.projectId}/migrations/detail`,
+      url: `${configLoader.config.servicesUrls.coriolis}/${Api.projectId}/migrations`,
       skipLog,
     })
     let migrations = response.data.migrations

--- a/src/sources/NotificationSource.js
+++ b/src/sources/NotificationSource.js
@@ -116,7 +116,7 @@ class NotificationSource {
   async loadData(): Promise<NotificationItemData[]> {
     let [migrationsResponse, replicasResponse] = await Promise.all([
       Api.send({ url: `${configLoader.config.servicesUrls.coriolis}/${Api.projectId}/migrations`, skipLog: true, quietError: true }),
-      Api.send({ url: `${configLoader.config.servicesUrls.coriolis}/${Api.projectId}/replicas/detail`, skipLog: true, quietError: true }),
+      Api.send({ url: `${configLoader.config.servicesUrls.coriolis}/${Api.projectId}/replicas`, skipLog: true, quietError: true }),
     ])
 
     let migrations = migrationsResponse.data.migrations

--- a/src/sources/ReplicaSource.js
+++ b/src/sources/ReplicaSource.js
@@ -118,7 +118,7 @@ class ReplicaSourceUtils {
 class ReplicaSource {
   async getReplicas(skipLog?: boolean, quietError?: boolean): Promise<MainItem[]> {
     let response = await Api.send({
-      url: `${configLoader.config.servicesUrls.coriolis}/${Api.projectId}/replicas/detail`,
+      url: `${configLoader.config.servicesUrls.coriolis}/${Api.projectId}/replicas`,
       skipLog,
       quietError,
     })

--- a/src/stores/LogStore.js
+++ b/src/stores/LogStore.js
@@ -71,8 +71,8 @@ class LogStore {
     let baseUrl = `${configLoader.config.servicesUrls.coriolis}/${apiCaller.projectId}`
     let [diagnosticsResp, replicasResp, migrationsResp] = await Promise.all([
       apiCaller.send({ url: `${baseUrl}/diagnostics` }),
-      apiCaller.send({ url: `${baseUrl}/replicas/detail?show_deleted=true` }),
-      apiCaller.send({ url: `${baseUrl}/migrations/detail?show_deleted=true` }),
+      apiCaller.send({ url: `${baseUrl}/replicas?show_deleted=true` }),
+      apiCaller.send({ url: `${baseUrl}/migrations?show_deleted=true` }),
     ])
 
     const zip = new JSZip()


### PR DESCRIPTION
The '/details' path component is redundant as it sends the same output
as skipping it when listing replicas or migrations.