### PR TITLE
Make the admin role name configurable

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -17,6 +17,10 @@ const conf: Config = {
   // The default user domain name used for logging in
   defaultUserDomain: 'default',
 
+  // The name of the admin role, used for checking
+  // if a user is allowed to do certain admin operations
+  adminRoleName: 'admin',
+
   // Shows the 'Use Current User/Project/Domain for Authentification' switch
   // when creating a new openstack endpoint
   showOpenstackCurrentUserSwitch: false,

--- a/src/@types/Config.ts
+++ b/src/@types/Config.ts
@@ -23,6 +23,7 @@ export type Config = {
   disabledPages: string[],
   showUserDomainInput: boolean,
   defaultUserDomain: string,
+  adminRoleName: string,
   showOpenstackCurrentUserSwitch: boolean,
   useBarbicanSecrets: boolean,
   requestPollTimeout: number,

--- a/src/sources/UserSource.ts
+++ b/src/sources/UserSource.ts
@@ -295,7 +295,7 @@ class UserSource {
 
   async getAdminRoleId(): Promise<string> {
     const roles: { id: string, name: string }[] = await this.getRoles()
-    const role = roles.find(r => r.name.toLowerCase() === 'admin')
+    const role = roles.find(r => r.name.toLowerCase() === configLoader.config.adminRoleName)
     const roleId = role ? role.id : ''
     return roleId
   }
@@ -330,7 +330,9 @@ class UserSource {
     const roleAssignments: RoleAssignment[] = response.data.role_assignments
     return roleAssignments
       .filter(a => a && a.user && a.user.id === userId)
-      .filter(a => a && a.role && a.role.name && a.role.name.toLowerCase() === 'admin').length > 0
+      .filter(a => a && a.role && a.role.name
+        && a.role.name.toLowerCase() === configLoader.config.adminRoleName)
+      .length > 0
   }
 }
 


### PR DESCRIPTION
The name of the admin role is now configurable. As a reminder, the admin
role name is used to check if a user is allowed to do certain admin
operations (Projects, Users pages among others).