### PR TITLE
Recreate migrations in bulk in migrations list CORWEB-238

### DIFF
--- a/src/components/organisms/ReplicaMigrationOptions/ReplicaMigrationOptions.tsx
+++ b/src/components/organisms/ReplicaMigrationOptions/ReplicaMigrationOptions.tsx
@@ -26,6 +26,7 @@ import KeyboardManager from '../../../utils/KeyboardManager'
 import StyleProps from '../../styleUtils/StyleProps'
 
 import replicaMigrationImage from './images/replica-migration.svg'
+import replicaMigrationFields from './replicaMigrationFields'
 
 import type { Field } from '../../../@types/Field'
 import type { Instance, InstanceScript } from '../../../@types/Instance'
@@ -86,21 +87,7 @@ type State = {
   selectedBarButton: string,
   uploadedScripts: InstanceScript[],
 }
-const defaultFields: Field[] = [
-  {
-    name: 'clone_disks',
-    type: 'boolean',
-    value: true,
-  },
-  {
-    name: 'force',
-    type: 'boolean',
-  },
-  {
-    name: 'skip_os_morphing',
-    type: 'boolean',
-  },
-]
+
 @observer
 class ReplicaMigrationOptions extends React.Component<Props, State> {
   state: State = {
@@ -113,7 +100,7 @@ class ReplicaMigrationOptions extends React.Component<Props, State> {
 
   UNSAFE_componentWillMount() {
     this.setState({
-      fields: defaultFields.map(f => (f.name === 'skip_os_morphing' ? (
+      fields: replicaMigrationFields.map(f => (f.name === 'skip_os_morphing' ? (
         { ...f, value: this.props.defaultSkipOsMorphing || null }
       ) : f)),
     })

--- a/src/components/organisms/ReplicaMigrationOptions/replicaMigrationFields.ts
+++ b/src/components/organisms/ReplicaMigrationOptions/replicaMigrationFields.ts
@@ -1,0 +1,33 @@
+/*
+Copyright (C) 2020  Cloudbase Solutions SRL
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { Field } from '../../../@types/Field'
+
+const replicaMigrationFields: Field[] = [
+  {
+    name: 'clone_disks',
+    type: 'boolean',
+    value: true,
+  },
+  {
+    name: 'force',
+    type: 'boolean',
+  },
+  {
+    name: 'skip_os_morphing',
+    type: 'boolean',
+  },
+]
+
+export default replicaMigrationFields

--- a/src/components/pages/MigrationDetailsPage/MigrationDetailsPage.tsx
+++ b/src/components/pages/MigrationDetailsPage/MigrationDetailsPage.tsx
@@ -310,6 +310,7 @@ class MigrationDetailsPage extends React.Component<Props, State> {
       },
       {
         label: 'Recreate Migration',
+        color: Palette.primary,
         action: () => { this.handleRecreateClick() },
       },
       {

--- a/src/sources/MigrationSource.ts
+++ b/src/sources/MigrationSource.ts
@@ -72,6 +72,43 @@ class MigrationSource {
     return migration
   }
 
+  async recreateFullCopy(migration: MainItem): Promise<MainItem> {
+    const {
+      origin_endpoint_id, destination_endpoint_id, destination_environment,
+      network_map, instances, storage_mappings, notes,
+    } = migration
+
+    const payload: any = {
+      migration: {
+        origin_endpoint_id,
+        destination_endpoint_id,
+        destination_environment,
+        network_map,
+        instances,
+        storage_mappings,
+        notes,
+      },
+    }
+
+    if (migration.skip_os_morphing != null) {
+      payload.migration.skip_os_morphing = migration.skip_os_morphing
+    }
+
+    if (migration.source_environment) {
+      payload.migration.source_environment = migration.source_environment
+    }
+
+    payload.migration.shutdown_instances = Boolean(migration.shutdown_instances)
+    payload.migration.replication_count = migration.replication_count || 2
+
+    const response = await Api.send({
+      url: `${configLoader.config.servicesUrls.coriolis}/${Api.projectId}/migrations`,
+      method: 'POST',
+      data: payload,
+    })
+    return response.data.migration
+  }
+
   async recreate(opts: {
     sourceEndpoint: Endpoint,
     destEndpoint: Endpoint,

--- a/src/stores/MigrationStore.ts
+++ b/src/stores/MigrationStore.ts
@@ -65,6 +65,10 @@ class MigrationStore {
     return null
   }
 
+  @action async recreateFullCopy(migration: MainItem) {
+    return MigrationSource.recreateFullCopy(migration)
+  }
+
   @action async recreate(
     migration: MainItem,
     sourceEndpoint: Endpoint,


### PR DESCRIPTION
Migrations can now be recreated in bulk in the Migrations List page.

If a migration has 'replica_id', then the Create Migration from Replica
default fields are used.

If a migration is a 'regular' migration (created using the Wizard), the
original fields are used.