### PR TITLE
Fix an issue where "Not Set" was not an option CO-176

### DIFF
--- a/src/components/organisms/WizardOptions/WizardOptions.tsx
+++ b/src/components/organisms/WizardOptions/WizardOptions.tsx
@@ -339,7 +339,7 @@ class WizardOptions extends React.Component<Props> {
 
       return {
         column,
-        component: this.renderOptionsField(field),
+        component: this.renderOptionsField(usableField),
         field: usableField,
       }
     })


### PR DESCRIPTION
In Wizard Options, boolean switches didn't have "Not Set" as an option.