### PR TITLE
Download logs notice text change

### DIFF
--- a/src/components/pages/LogsPage/DownloadsContent.tsx
+++ b/src/components/pages/LogsPage/DownloadsContent.tsx
@@ -208,7 +208,7 @@ class DownloadsContent extends React.Component<Props, State> {
           Optional time range for log download:
         </Info>
         {this.renderDates()}
-        <InfoUtc><StatusIcon status="UNSCHEDULED" />Start and End times must be set in UTC</InfoUtc>
+        <InfoUtc><StatusIcon status="UNSCHEDULED" />Start and End times must be set in server&apos;s timezone</InfoUtc>
         {this.renderLogs()}
       </Wrapper>
     )


### PR DESCRIPTION
Small text change indicating that download logs start and end times are
not necessarily in UTC.