### PR TITLE
Add ability to debug the project from VS Code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Launch Chrome against localhost",
+      "url": "http://localhost:3001",
+      "webRoot": "${workspaceFolder}"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Your server will be running at `http://localhost:3000/` (the port is configurabl
 - run `yarn ui-dev` to start local development server (starts on port 3001)
 - run `yarn server-dev` to start the express server in development mode
 
+To debug the client code using VS Code, simply run the project's launch configuration from the 'Run' menu (Ctrl+Shift+D).
+The last 2 `yarn ...` commands must be running in the background.
+
+To debug the Node server using VS Code, run `yarn server-debug` instead of `yarn server-dev`.
+
 You can view some of the UIs components in the [Storybook](https://github.com/storybooks/storybook) by running `yarn storybook`
 
 ## Modding


### PR DESCRIPTION
Using the provided launch configuration, a Chrome instance is launched
against the localhost dev server and debugging is enabled in VS Code.

Further instructions about the client and node server debugging is added
in the README.md file.