### PR TITLE
Fix dropdown click not registering correctly

### DIFF
--- a/src/components/molecules/Dropdown/Dropdown.tsx
+++ b/src/components/molecules/Dropdown/Dropdown.tsx
@@ -400,7 +400,7 @@ class Dropdown extends React.Component<Props, State> {
 
     this.justFocused = true
     this.toggleDropdownList(true)
-    setTimeout(() => { this.justFocused = false }, 100)
+    setTimeout(() => { this.justFocused = false }, 1000)
   }
 
   handleBlur() {


### PR DESCRIPTION
Fixes an issue where the time between mouse button down and up had to be
less than 100ms. Time was increased to 1s.

The timing is required in order to be able to open the dropdown list
when the dropdown button is focused using the TAB key.