### PR TITLE
Fix OSMorphing minions shown for wrong platform

### DIFF
--- a/src/components/organisms/EditReplica/EditReplica.tsx
+++ b/src/components/organisms/EditReplica/EditReplica.tsx
@@ -558,9 +558,8 @@ class EditReplica extends React.Component<Props, State> {
     if (endpoint) {
       dictionaryKey = `${endpoint.type}-${type}`
     }
-    const minionPools = type === 'source'
-      ? minionPoolStore.minionPools.filter(m => m.endpoint_id === this.props.sourceEndpoint.id)
-      : minionPoolStore.minionPools.filter(m => m.endpoint_id === this.props.destinationEndpoint.id)
+    const minionPools = minionPoolStore.minionPools
+      .filter(m => m.pool_platform === type && m.endpoint_id === endpoint.id)
     return (
       <WizardOptions
         minionPools={minionPools}

--- a/src/components/pages/ReplicaDetailsPage/ReplicaDetailsPage.tsx
+++ b/src/components/pages/ReplicaDetailsPage/ReplicaDetailsPage.tsx
@@ -636,7 +636,7 @@ class ReplicaDetailsPage extends React.Component<Props, State> {
           >
             <ReplicaMigrationOptions
               transferItem={this.replica}
-              minionPools={minionPoolStore.minionPools}
+              minionPools={minionPoolStore.minionPools.filter(m => m.endpoint_id === this.replica?.destination_endpoint_id && m.pool_platform === 'destination')}
               loadingInstances={instanceStore.loadingInstancesDetails}
               instances={instanceStore.instancesDetails}
               onCancelClick={() => { this.handleCloseMigrationModal() }}


### PR DESCRIPTION
When Editing a replica, recreating a migration or migrating from a
replica, the instance OSMorphing Minion pool mappings are shown for
both platforms, source and destination, instead of showing only the
destination platform minion pools.