### PR TITLE
Send null values when editing a replica

### DIFF
--- a/src/plugins/endpoint/openstack/OptionsSchemaPlugin.ts
+++ b/src/plugins/endpoint/openstack/OptionsSchemaPlugin.ts
@@ -81,13 +81,23 @@ export default class OptionsSchemaParser {
     }
   }
 
-  static getDestinationEnv(options: { [prop: string]: any } | null, oldOptions?: any) {
+  static getDestinationEnv(
+    options: { [prop: string]: any } | null,
+    oldOptions?: any,
+    useNullValues?: boolean,
+  ) {
     const env = {
-      ...defaultGetDestinationEnv(options, oldOptions, this.imageSuffix),
+      ...defaultGetDestinationEnv(
+        options,
+        oldOptions,
+        this.imageSuffix,
+        useNullValues,
+      ),
       ...defaultGetMigrationImageMap(
         options,
         oldOptions,
-        this.migrationImageMapFieldName, this.imageSuffix,
+        this.migrationImageMapFieldName,
+        this.imageSuffix,
       ),
     }
     return env

--- a/src/plugins/endpoint/ovm/OptionsSchemaPlugin.ts
+++ b/src/plugins/endpoint/ovm/OptionsSchemaPlugin.ts
@@ -78,9 +78,18 @@ export default class OptionsSchemaParser {
     }
   }
 
-  static getDestinationEnv(options: { [prop: string]: any } | null, oldOptions?: any) {
+  static getDestinationEnv(
+    options: { [prop: string]: any } | null,
+    oldOptions?: any,
+    useNullValues?: boolean,
+  ) {
     const env = {
-      ...defaultGetDestinationEnv(options, oldOptions, this.imageSuffix),
+      ...defaultGetDestinationEnv(
+        options,
+        oldOptions,
+        this.imageSuffix,
+        useNullValues,
+      ),
       ...defaultGetMigrationImageMap(
         options,
         oldOptions,

--- a/src/sources/ReplicaSource.ts
+++ b/src/sources/ReplicaSource.ts
@@ -231,8 +231,12 @@ class ReplicaSource {
       payload.replica.network_map = parser.getNetworkMap(updateData.network)
     }
     if (Object.keys(updateData.source).length > 0) {
-      const sourceEnv = parser.getDestinationEnv(updateData.source, replica.source_environment)
-      if (sourceEnv.minion_pool_id) {
+      const sourceEnv = parser.getDestinationEnv(
+        updateData.source,
+        replica.source_environment,
+        true,
+      )
+      if (sourceEnv.minion_pool_id !== undefined) {
         payload.replica.origin_minion_pool_id = sourceEnv.minion_pool_id
         delete sourceEnv.minion_pool_id
       }
@@ -242,8 +246,11 @@ class ReplicaSource {
     }
 
     if (Object.keys(updateData.destination).length > 0) {
-      const destEnv = parser.getDestinationEnv(updateData.destination,
-        replica.destination_environment)
+      const destEnv = parser.getDestinationEnv(
+        updateData.destination,
+        replica.destination_environment,
+        true,
+      )
 
       const newMinionMappings = destEnv[INSTANCE_OSMORPHING_MINION_POOL_MAPPINGS]
       if (newMinionMappings) {
@@ -257,7 +264,7 @@ class ReplicaSource {
       }
       delete destEnv[INSTANCE_OSMORPHING_MINION_POOL_MAPPINGS]
 
-      if (destEnv.minion_pool_id) {
+      if (destEnv.minion_pool_id !== undefined) {
         payload.replica.destination_minion_pool_id = destEnv.minion_pool_id
         delete destEnv.minion_pool_id
       }


### PR DESCRIPTION
Sending a null value when editing a replica should essentially reset
that value.

Previously, null values weren't sent at all, just like when creating a
replica using the wizard.

NOTE: this PR should be merged only after the API is confirmed to accept null values.