### PR TITLE
Add ability to unset minion pool mappings

### DIFF
--- a/src/plugins/endpoint/default/OptionsSchemaPlugin.ts
+++ b/src/plugins/endpoint/default/OptionsSchemaPlugin.ts
@@ -92,19 +92,24 @@ export const defaultGetDestinationEnv = (
   }
 
   Object.keys(options).forEach(optionName => {
-    if (specialOptions.find(o => o === optionName) || !options || options[optionName] == null || options[optionName] === '') {
+    const value = options[optionName]
+    if (specialOptions.find(o => o === optionName) || value == null || value === '') {
       return
     }
-    if (Array.isArray(options[optionName])) {
-      env[optionName] = options[optionName]
-    } else if (typeof options[optionName] === 'object') {
-      const oldOption = oldOptions?.[optionName] || {}
-      env[optionName] = {
-        ...oldOption,
-        ...options[optionName],
-      }
+    if (Array.isArray(value)) {
+      env[optionName] = value
+    } else if (typeof value === 'object') {
+      const oldValue = oldOptions?.[optionName] || {}
+      const mergedValue: any = { ...oldValue, ...value }
+      const newValue: any = {}
+      Object.keys(mergedValue).forEach(k => {
+        if (mergedValue[k] !== null) {
+          newValue[k] = mergedValue[k]
+        }
+      })
+      env[optionName] = newValue
     } else {
-      env[optionName] = options ? Utils.trim(optionName, options[optionName]) : null
+      env[optionName] = options ? Utils.trim(optionName, value) : null
     }
   })
   return env

--- a/src/sources/MigrationSource.ts
+++ b/src/sources/MigrationSource.ts
@@ -205,8 +205,14 @@ class MigrationSource {
 
     const updatedDestEnvMappings = updatedDestEnv[INSTANCE_OSMORPHING_MINION_POOL_MAPPINGS] || {}
     const oldMappings = migration[INSTANCE_OSMORPHING_MINION_POOL_MAPPINGS] || {}
-    const newMappings = { ...oldMappings, ...updatedDestEnvMappings }
-    if (Object.keys(newMappings).length) {
+    const mergedMappings = { ...oldMappings, ...updatedDestEnvMappings }
+    if (Object.keys(mergedMappings).length) {
+      const newMappings: any = {}
+      Object.keys(mergedMappings).forEach(k => {
+        if (mergedMappings[k] !== null) {
+          newMappings[k] = mergedMappings[k]
+        }
+      })
       payload.migration[INSTANCE_OSMORPHING_MINION_POOL_MAPPINGS] = newMappings
     }
 
@@ -266,7 +272,13 @@ class MigrationSource {
     }
 
     if (Object.keys(minionPoolMappings).length) {
-      payload.migration[INSTANCE_OSMORPHING_MINION_POOL_MAPPINGS] = minionPoolMappings
+      const newMappings: any = {}
+      Object.keys(minionPoolMappings).forEach(k => {
+        if (minionPoolMappings[k] !== null) {
+          newMappings[k] = minionPoolMappings[k]
+        }
+      })
+      payload.migration[INSTANCE_OSMORPHING_MINION_POOL_MAPPINGS] = newMappings
     } else {
       payload.migration[INSTANCE_OSMORPHING_MINION_POOL_MAPPINGS] = null
     }

--- a/src/sources/ReplicaSource.ts
+++ b/src/sources/ReplicaSource.ts
@@ -243,17 +243,13 @@ class ReplicaSource {
 
     if (Object.keys(updateData.destination).length > 0) {
       const destEnv = parser.getDestinationEnv(updateData.destination,
-        replica.destination_environment)
+        { ...replica, ...replica.destination_environment })
 
       const newMinionMappings = destEnv[INSTANCE_OSMORPHING_MINION_POOL_MAPPINGS]
       if (newMinionMappings) {
-        const oldMinionMappings = replica[INSTANCE_OSMORPHING_MINION_POOL_MAPPINGS] || {}
         payload.replica[
           INSTANCE_OSMORPHING_MINION_POOL_MAPPINGS
-        ] = {
-          ...oldMinionMappings,
-          ...newMinionMappings,
-        }
+        ] = newMinionMappings
       }
       delete destEnv[INSTANCE_OSMORPHING_MINION_POOL_MAPPINGS]
 


### PR DESCRIPTION
This applies to Editing a replica, Recreating a migration or Creating a
migration from a replica