### PR TITLE
Fix Options fields changing in a confusing way

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "react-notification-system": "^0.4.0",
     "react-router-dom": "^5.1.2",
     "react-tooltip": "^4.2.7",
+    "react-transition-group": "1.x",
     "request": "^2.88.0",
     "require-without-cache": "^0.0.6",
     "rimraf": "^2.6.2",

--- a/src/@types/Field.ts
+++ b/src/@types/Field.ts
@@ -31,6 +31,7 @@ export type Field = {
   enum?: EnumItem[],
   default?: any,
   password?: boolean,
+  disabled?: boolean,
   nullableBoolean?: boolean,
   items?: Field[],
   fields?: Field[],

--- a/src/@types/declarations.d.ts
+++ b/src/@types/declarations.d.ts
@@ -8,6 +8,7 @@ declare module '*.woff'
 declare module 'ansi-to-html'
 
 declare module 'require-without-cache'
+declare module 'react-transition-group'
 
 interface Window {
   /**

--- a/src/components/molecules/FieldInput/FieldInput.tsx
+++ b/src/components/molecules/FieldInput/FieldInput.tsx
@@ -59,6 +59,9 @@ const Label = styled.div<any>`
     align-items: center;
   `)}
   ${props => (props.disabledLoading ? StyleProps.animations.disabledLoading : '')}
+  ${props => (props.disabled ? css`
+    opacity: 0.5;
+  ` : '')}
 `
 const LabelText = styled.span``
 const Asterisk = styled.div<any>`
@@ -186,13 +189,14 @@ class FieldInput extends React.Component<Props> {
         properties={this.props.properties}
         valueCallback={field => this.props.valueCallback && this.props.valueCallback(field)}
         onChange={(field, value) => {
-          if (this.props.onChange) {
+          if (!this.props.disabled && this.props.onChange) {
             this.props.onChange(value, field)
           }
         }}
         labelRenderer={this.props.labelRenderer}
         hideRequiredSymbol={this.props.layout === 'page'}
         disabledLoading={this.props.disabledLoading}
+        disabled={this.props.disabled}
       />
     )
   }
@@ -374,6 +378,7 @@ class FieldInput extends React.Component<Props> {
         layout={this.props.layout}
         disabledLoading={this.props.disabledLoading}
         width={this.props.width}
+        disabled={this.props.disabled}
       >
         <LabelText style={{ marginRight }}>
           {this.props.label}

--- a/src/components/molecules/PropertiesTable/PropertiesTable.tsx
+++ b/src/components/molecules/PropertiesTable/PropertiesTable.tsx
@@ -32,6 +32,9 @@ const Wrapper = styled.div<any>`
   flex-direction: column;
   border: 1px solid ${Palette.grayscale[2]};
   border-radius: ${StyleProps.borderRadius};
+  ${props => (props.disabled ? css`
+    opacity: 0.5;
+  ` : '')}
   ${props => (props.disabledLoading ? StyleProps.animations.disabledLoading : '')}
 `
 const Column = styled.div<any>`
@@ -72,6 +75,7 @@ type Props = {
   onChange: (property: Field, value: any) => void,
   valueCallback: (property: Field) => any,
   hideRequiredSymbol?: boolean,
+  disabled?: boolean,
   disabledLoading?: boolean,
   labelRenderer?: ((propName: string) => string) | null,
   width?: number,
@@ -195,7 +199,11 @@ class PropertiesTable extends React.Component<Props> {
 
   render() {
     return (
-      <Wrapper disabledLoading={this.props.disabledLoading} width={this.props.width}>
+      <Wrapper
+        disabled={this.props.disabled}
+        disabledLoading={this.props.disabledLoading}
+        width={this.props.width}
+      >
         {this.props.properties.map(prop => (
           <Row key={prop.name} data-test-id={`${baseId}-row-${prop.name}`}>
             <Column header data-test-id={`${baseId}-header`}><span title={this.getName(prop.name)}>{this.getName(prop.name)}</span></Column>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3551,6 +3551,11 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
+chain-function@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/chain-function/-/chain-function-1.0.1.tgz#c63045e5b4b663fb86f1c6e186adaf1de402a1cc"
+  integrity sha512-SxltgMwL9uCko5/ZCLiyG2B7R9fY4pDZUw7hJ4MhirdjBLosoDqkWABi3XMucddHdLiFJMb7PD2MZifZriuMTg==
+
 chalk@2.4.2, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -4829,6 +4834,13 @@ dom-converter@~0.1:
   resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.1.4.tgz#a45ef5727b890c9bffe6d7c876e7b19cb0e17f3b"
   dependencies:
     utila "~0.3"
+
+dom-helpers@^3.2.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
+  integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
 
 dom-serializer@0:
   version "0.1.0"
@@ -10712,6 +10724,17 @@ react-tooltip@*, react-tooltip@^4.2.7:
     prop-types "^15.7.2"
     uuid "^7.0.3"
 
+react-transition-group@1.x:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-1.2.1.tgz#e11f72b257f921b213229a774df46612346c7ca6"
+  integrity sha512-CWaL3laCmgAFdxdKbhhps+c0HRGF4c+hdM4H23+FI1QBNUyx/AMeIJGWorehPNSaKnQNOAxL7PQmqMu78CDj3Q==
+  dependencies:
+    chain-function "^1.0.0"
+    dom-helpers "^3.2.0"
+    loose-envify "^1.3.1"
+    prop-types "^15.5.6"
+    warning "^3.0.0"
+
 react@^16.13.1, react@^16.8.3:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
@@ -12943,6 +12966,13 @@ vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
+
+warning@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  integrity sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=
+  dependencies:
+    loose-envify "^1.0.0"
 
 warning@^4.0.2, warning@^4.0.3:
   version "4.0.3"


### PR DESCRIPTION
This issue is visible when changing the Openstack source 'Replica
Transfer Mechanism' field, which causes other fields to appear /
disappear, which is confusing, especially since the layout of the fields
also changes from vertical to horizontal.

As a UX hot fix, the layout of the options will always be horizontal and
a small animation will highlight the appearance of new fields.