### PR TITLE
Fix scroll show in field of type properties table

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,6 +10,15 @@
       "name": "Launch Chrome against localhost",
       "url": "http://localhost:3001",
       "webRoot": "${workspaceFolder}"
+    },
+    // Launch Chrome like this: "C:\Program Files (x86)\Google\Chrome\Application\chrome.exe" --remote-debugging-port=9222
+    {
+      "type": "chrome",
+      "request": "attach",
+      "name": "Attach to Chrome",
+      "port": 9222,
+      "urlFilter": "http://localhost:3001/*",
+      "webRoot": "${workspaceFolder}"
     }
   ]
 }

--- a/src/components/molecules/PropertiesTable/PropertiesTable.tsx
+++ b/src/components/molecules/PropertiesTable/PropertiesTable.tsx
@@ -28,7 +28,7 @@ import { Field, EnumItem, isEnumSeparator } from '../../../@types/Field'
 
 const Wrapper = styled.div<any>`
   display: flex;
-  ${props => (props.width ? `width: ${props.width}px;` : '')}
+  ${props => (props.width ? `width: ${props.width - 2}px;` : '')}
   flex-direction: column;
   border: 1px solid ${Palette.grayscale[2]};
   border-radius: ${StyleProps.borderRadius};


### PR DESCRIPTION
Horizontal scroll appears in Wizard Options when showing field of type
'Properties Table', like the 'Execute Now Options' field.

Also, includes ability to attach the vscode debugger to an already
running Chrome process.