### PR TITLE
Remove '_os_image' suffix from migr. image fields

### DIFF
--- a/src/@types/Field.ts
+++ b/src/@types/Field.ts
@@ -100,7 +100,7 @@ class FieldHelper {
       return value.map((v: any) => findInEnum(v)).join(', ')
     }
 
-    const isImageMapField = migrationImageOsTypes.find(os => `${os}${plugin?.imageSuffix}` === name)
+    const isImageMapField = migrationImageOsTypes.find(os => os === name)
     if (isImageMapField) {
       const migrImageField = plugin && fields
         .find(f => f.name === plugin.migrationImageMapFieldName)

--- a/src/components/organisms/EditReplica/EditReplica.tsx
+++ b/src/components/organisms/EditReplica/EditReplica.tsx
@@ -250,7 +250,7 @@ class EditReplica extends React.Component<Props, State> {
     const endpoint = type === 'source' ? this.props.sourceEndpoint : this.props.destinationEndpoint
     const plugin = OptionsSchemaPlugin.for(endpoint.type)
 
-    const osMapping = new RegExp(`^(windows|linux)${plugin.imageSuffix}`).exec(fieldName)
+    const osMapping = new RegExp('^(windows|linux)').exec(fieldName)
     if (osMapping) {
       const osData = replicaData[`${plugin.migrationImageMapFieldName}/${osMapping[0]}`]
       return osData

--- a/src/components/organisms/MainDetails/MainDetails.tsx
+++ b/src/components/organisms/MainDetails/MainDetails.tsx
@@ -237,7 +237,7 @@ class MainDetails extends React.Component<Props, State> {
           }
           let fieldName = pn
           if (migrationImageMapFieldName && fieldName === migrationImageMapFieldName) {
-            fieldName = `${p}${plugin?.imageSuffix}`
+            fieldName = p
           }
           return {
             label: `${label} - ${LabelDictionary.get(p)}`,

--- a/src/components/organisms/MinionPoolDetailsContent/MinionPoolMainDetails.tsx
+++ b/src/components/organisms/MinionPoolDetailsContent/MinionPoolMainDetails.tsx
@@ -187,7 +187,7 @@ class MinionPoolMainDetails extends React.Component<Props> {
           }
           let fieldName = pn
           if (migrationImageMapFieldName && fieldName === migrationImageMapFieldName) {
-            fieldName = `${p}${plugin?.imageSuffix}`
+            fieldName = p
           }
           return {
             label: `${label} - ${LabelDictionary.get(p)}`,

--- a/src/components/organisms/WizardSummary/WizardSummary.tsx
+++ b/src/components/organisms/WizardSummary/WizardSummary.tsx
@@ -321,9 +321,14 @@ class WizardSummary extends React.Component<Props> {
             return null
           }
 
-          const optionValue = fieldHelper.getValueAlias(propertyName,
-            value,
-            schema, provider)
+          let optionValue
+          if (key.indexOf('password') > -1 || propertyName.indexOf('password') > -1) {
+            optionValue = '•••••••••'
+          } else {
+            optionValue = fieldHelper.getValueAlias(propertyName,
+              value,
+              schema, provider)
+          }
 
           return (
             <Option key={propertyName}>

--- a/src/plugins/endpoint/default/OptionsSchemaPlugin.ts
+++ b/src/plugins/endpoint/default/OptionsSchemaPlugin.ts
@@ -46,7 +46,6 @@ export const defaultFillMigrationImageMapValues = (
   field: Field,
   option: OptionValues,
   migrationImageMapFieldName: string,
-  imageSuffix: string,
 ): boolean => {
   if (field.name !== migrationImageMapFieldName) {
     return false
@@ -68,7 +67,7 @@ export const defaultFillMigrationImageMapValues = (
     }
 
     return {
-      name: `${os}${imageSuffix}`,
+      name: os,
       type: 'string',
       enum: values,
     }
@@ -79,13 +78,12 @@ export const defaultFillMigrationImageMapValues = (
 export const defaultGetDestinationEnv = (
   options?: { [prop: string]: any } | null,
   oldOptions?: { [prop: string]: any } | null,
-  imageSuffix?: string,
 ): any => {
   const env: any = {}
   const specialOptions = ['execute_now', 'separate_vm', 'skip_os_morphing', 'description']
     .concat(migrationFields.map(f => f.name))
     .concat(executionOptions.map(o => o.name))
-    .concat(migrationImageOsTypes.map(o => `${o}${imageSuffix}`))
+    .concat(migrationImageOsTypes)
 
   if (!options) {
     return env
@@ -119,7 +117,6 @@ export const defaultGetMigrationImageMap = (
   options: { [prop: string]: any } | null | undefined,
   oldOptions: any,
   migrationImageMapFieldName: string,
-  imageSuffix: string,
 ) => {
   const env: any = {}
   const usableOptions = options
@@ -132,13 +129,13 @@ export const defaultGetMigrationImageMap = (
     return env
   }
   migrationImageOsTypes.forEach(os => {
-    let value = usableOptions[migrationImageMapFieldName][`${os}${imageSuffix}`]
+    let value = usableOptions[migrationImageMapFieldName][os]
 
     // Make sure the migr. image mapping has all the OSes filled,
     // even if only one OS mapping was updated,
     // ie. don't send just the updated OS map to the server, send them all if one was updated.
     if (!value) {
-      value = oldOptions?.[migrationImageMapFieldName]?.[`${os}${imageSuffix}`]
+      value = oldOptions?.[migrationImageMapFieldName]?.[os]
       if (!value) {
         return
       }
@@ -148,7 +145,7 @@ export const defaultGetMigrationImageMap = (
       env[migrationImageMapFieldName] = {}
     }
 
-    env[migrationImageMapFieldName][`${os}${imageSuffix}`] = value
+    env[migrationImageMapFieldName][os] = value
   })
 
   return env
@@ -156,8 +153,6 @@ export const defaultGetMigrationImageMap = (
 
 export default class OptionsSchemaParser {
   static migrationImageMapFieldName = 'migr_image_map'
-
-  static imageSuffix = '_os_image'
 
   static parseSchemaToFields(
     schema: SchemaProperties, schemaDefinitions?: SchemaDefinitions | null, dictionaryKey?: string,
@@ -175,7 +170,6 @@ export default class OptionsSchemaParser {
       field,
       option,
       this.migrationImageMapFieldName,
-      this.imageSuffix,
     )) {
       defaultFillFieldValues(field, option)
     }
@@ -186,13 +180,11 @@ export default class OptionsSchemaParser {
       ...defaultGetDestinationEnv(
         options,
         oldOptions,
-        this.imageSuffix,
       ),
       ...defaultGetMigrationImageMap(
         options,
         oldOptions,
         this.migrationImageMapFieldName,
-        this.imageSuffix,
       ),
     }
     return env

--- a/src/plugins/endpoint/openstack/OptionsSchemaPlugin.ts
+++ b/src/plugins/endpoint/openstack/OptionsSchemaPlugin.ts
@@ -28,8 +28,6 @@ import type { NetworkMap } from '../../../@types/Network'
 export default class OptionsSchemaParser {
   static migrationImageMapFieldName = DefaultOptionsSchemaPlugin.migrationImageMapFieldName
 
-  static imageSuffix = ''
-
   static parseSchemaToFields(
     schema: SchemaProperties,
     schemaDefinitions: SchemaDefinitions | null | undefined,
@@ -74,7 +72,6 @@ export default class OptionsSchemaParser {
         field,
         option,
         this.migrationImageMapFieldName,
-        this.imageSuffix,
       )) {
         defaultFillFieldValues(field, option)
       }
@@ -83,11 +80,11 @@ export default class OptionsSchemaParser {
 
   static getDestinationEnv(options: { [prop: string]: any } | null, oldOptions?: any) {
     const env = {
-      ...defaultGetDestinationEnv(options, oldOptions, this.imageSuffix),
+      ...defaultGetDestinationEnv(options, oldOptions),
       ...defaultGetMigrationImageMap(
         options,
         oldOptions,
-        this.migrationImageMapFieldName, this.imageSuffix,
+        this.migrationImageMapFieldName,
       ),
     }
     return env

--- a/src/plugins/endpoint/ovm/OptionsSchemaPlugin.ts
+++ b/src/plugins/endpoint/ovm/OptionsSchemaPlugin.ts
@@ -28,8 +28,6 @@ import type { NetworkMap } from '../../../@types/Network'
 export default class OptionsSchemaParser {
   static migrationImageMapFieldName = 'migr_template_map'
 
-  static imageSuffix = '_os_image'
-
   static parseSchemaToFields(
     schema: SchemaProperties,
     schemaDefinitions: SchemaDefinitions | null | undefined,
@@ -45,17 +43,18 @@ export default class OptionsSchemaParser {
       ) {
         return
       }
-      // eslint-disable-next-line no-param-reassign
+
+      const password = f.name === 'migr_template_password_map'
       f.properties = [
         {
           type: 'string',
-          name: `${f.name}/windows`,
-          password: f.name === 'migr_template_password_map',
+          name: 'windows',
+          password,
         },
         {
           type: 'string',
-          name: `${f.name}/linux`,
-          password: f.name === 'migr_template_password_map',
+          name: 'linux',
+          password,
         },
       ]
     })
@@ -72,7 +71,6 @@ export default class OptionsSchemaParser {
       field,
       option,
       this.migrationImageMapFieldName,
-      this.imageSuffix,
     )) {
       defaultFillFieldValues(field, option)
     }
@@ -80,12 +78,11 @@ export default class OptionsSchemaParser {
 
   static getDestinationEnv(options: { [prop: string]: any } | null, oldOptions?: any) {
     const env = {
-      ...defaultGetDestinationEnv(options, oldOptions, this.imageSuffix),
+      ...defaultGetDestinationEnv(options, oldOptions),
       ...defaultGetMigrationImageMap(
         options,
         oldOptions,
         this.migrationImageMapFieldName,
-        this.imageSuffix,
       ),
     }
     return env


### PR DESCRIPTION
The 'migr_image_map' field now only uses 'linux' and 'windows' as
sub-properties instead of 'linux_os_image' and 'windows_os_image'.

Previously, only Openstack used the field without the '_os_image'
suffix.