### PR TITLE
Remove extra '/' from dashboard activity path CORWEB-245

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,13 +4,6 @@
   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
-    {
-      "type": "chrome",
-      "request": "launch",
-      "name": "Launch Chrome against localhost",
-      "url": "http://localhost:3001",
-      "webRoot": "${workspaceFolder}"
-    },
     // Launch Chrome like this: "C:\Program Files (x86)\Google\Chrome\Application\chrome.exe" --remote-debugging-port=9222
     {
       "type": "chrome",
@@ -19,6 +12,13 @@
       "port": 9222,
       "urlFilter": "http://localhost:3001/*",
       "webRoot": "${workspaceFolder}"
-    }
+    },
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Launch Chrome against localhost",
+      "url": "http://localhost:3001",
+      "webRoot": "${workspaceFolder}"
+    },
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,10 +12,9 @@
   "[typescriptreact]": {
     "editor.formatOnSave": false,
   },
-  "debug.node.autoAttach": "on",
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },
-  "eslint.enable": true,
-  "files.eol": "\n"
+  "files.eol": "\n",
+  "debug.javascript.autoAttachFilter": "always"
 }

--- a/src/components/organisms/DashboardContent/modules/ActivityModule/ActivityModule.tsx
+++ b/src/components/organisms/DashboardContent/modules/ActivityModule/ActivityModule.tsx
@@ -106,7 +106,7 @@ class ActivityModule extends React.Component<Props> {
             return (
               <ListItem
                 key={item.id}
-                to={`/${item.type}s/${item.id}/${executionsHref}`}
+                to={`/${item.type}s/${item.id}${executionsHref}`}
                 style={{
                   width: `calc(${this.props.large ? 50 : 100}% - 32px)`,
                   paddingTop: (i === 0 || i === 5) ? '16px' : '8px',


### PR DESCRIPTION
If a replica or a migration was running and the user clicked the recent
activity notification item for it, the URL path would include an extra
'/' character.