### PR TITLE
Fix CEPH options not working properly

### DIFF
--- a/src/plugins/endpoint/openstack/ConnectionSchemaPlugin.ts
+++ b/src/plugins/endpoint/openstack/ConnectionSchemaPlugin.ts
@@ -56,6 +56,8 @@ export default class ConnectionSchemaParser {
       identityField.default = identityField.minimum
     }
 
+    fields.find(f => f.name === 'ceph_options')?.properties?.forEach(f => { f.name = `ceph_options/${f.name}` })
+
     const createInputChoice = (name: string, field1Name: string, field2Name: string) => {
       const field1 = fields.find(f => f.name === field1Name)
       const field2 = fields.find(f => f.name === field2Name)


### PR DESCRIPTION
The CEPH options fields weren't rendered correctly when creating a new
Openstack endpoint.

The CEPH options weren't displayed when editing an Openstack endpoint
with CEPH options.