### PR TITLE
Fix an issue where execute options were incorrect

### DIFF
--- a/src/components/pages/WizardPage/WizardPage.tsx
+++ b/src/components/pages/WizardPage/WizardPage.tsx
@@ -620,8 +620,9 @@ class WizardPage extends React.Component<Props, State> {
     }
 
     const executeNowOptions = executionOptions.map(field => {
-      if (options && options[field.name] != null) {
-        return { name: field.name, value: options[field.name] }
+      const value = options?.execute_now_options?.[field.name]
+      if (value != null) {
+        return { name: field.name, value }
       }
       return field
     })

--- a/src/plugins/endpoint/default/OptionsSchemaPlugin.ts
+++ b/src/plugins/endpoint/default/OptionsSchemaPlugin.ts
@@ -80,7 +80,7 @@ export const defaultGetDestinationEnv = (
   oldOptions?: { [prop: string]: any } | null,
 ): any => {
   const env: any = {}
-  const specialOptions = ['execute_now', 'separate_vm', 'skip_os_morphing', 'description']
+  const specialOptions = ['execute_now', 'execute_now_options', 'separate_vm', 'skip_os_morphing', 'description']
     .concat(migrationFields.map(f => f.name))
     .concat(executionOptions.map(o => o.name))
     .concat(migrationImageOsTypes)

--- a/src/sources/WizardSource.ts
+++ b/src/sources/WizardSource.ts
@@ -89,10 +89,11 @@ class WizardSource {
 
     payload[type].destination_environment = destEnv
 
+    payload[type].shutdown_instances = Boolean(
+      data.destOptions && data.destOptions.shutdown_instances,
+    )
+
     if (type === 'migration') {
-      payload[type].shutdown_instances = Boolean(
-        data.destOptions && data.destOptions.shutdown_instances,
-      )
       payload[type].replication_count = (
         data.destOptions && data.destOptions.replication_count) || 2
       if (uploadedUserScripts.length) {


### PR DESCRIPTION
Execute now options were set incorrectly when creating a replica or
migration: they were set to "destination_environment" property, instead
of the "migration" or "replica" root object.