### PR TITLE
Send 'user_scripts' when recreating migration CORWEB-248

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "node ./server",
     "build": "webpack --config webpack.prod.js",
-    "ui-dev": "webpack-dev-server --config webpack.dev.js",
+    "client-dev": "webpack-dev-server --config webpack.dev.js",
     "server-dev": "nodemon -e ts,js -w server/**/",
     "server-debug": "node --inspect server",
     "tsc": "npx tsc --skipLibCheck",

--- a/src/@types/Instance.ts
+++ b/src/@types/Instance.ts
@@ -52,7 +52,7 @@ export type InstanceBase = {
 } & Partial<Instance>
 
 export type InstanceScript = {
-  global?: string | null,
+  global?: 'windows' | 'linux' | null,
   instanceId?: string | null,
   scriptContent: string,
   fileName: string,

--- a/src/@types/MainItem.ts
+++ b/src/@types/MainItem.ts
@@ -13,7 +13,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 import type { Execution } from './Execution'
-import type { Instance } from './Instance'
+import type { Instance, InstanceScript } from './Instance'
 import type { NetworkMap } from './Network'
 import type { StorageMap } from './Endpoint'
 import { Task } from './Task'
@@ -33,6 +33,7 @@ export type UpdateData = {
   source: any,
   network: NetworkMap[],
   storage: StorageMap[],
+  uploadedScripts: InstanceScript[],
 }
 type NetworkMapSecurityGroups = { id: string, security_groups?: string[] }
 type NetworkMapSourceDest = {
@@ -77,17 +78,27 @@ type BaseItem = {
   network_map?: TransferNetworkMap,
   last_execution_status: string
   user_id: string
-  instance_osmorphing_minion_pool_mappings?: {[instanceName: string]: string}
+  instance_osmorphing_minion_pool_mappings?: { [instanceName: string]: string }
+  user_scripts?: UserScriptData
 }
 
 export type ReplicaItem = BaseItem & {
   type: 'replica',
 }
 
+export type UserScriptData = {
+  global?: {
+    linux?: string | null
+    windows?: string | null
+  }
+  instances?: {
+    [instanceName: string]: string | null
+  }
+}
+
 export type MigrationItem = BaseItem & {
   type: 'migration',
   replica_id?: string,
-  user_scripts?: any
 }
 
 export type MigrationItemOptions = MigrationItem & {

--- a/src/@types/MainItem.ts
+++ b/src/@types/MainItem.ts
@@ -87,6 +87,7 @@ export type ReplicaItem = BaseItem & {
 export type MigrationItem = BaseItem & {
   type: 'migration',
   replica_id?: string,
+  user_scripts?: any
 }
 
 export type MigrationItemOptions = MigrationItem & {

--- a/src/components/organisms/ReplicaMigrationOptions/ReplicaMigrationOptions.tsx
+++ b/src/components/organisms/ReplicaMigrationOptions/ReplicaMigrationOptions.tsx
@@ -251,6 +251,7 @@ class ReplicaMigrationOptions extends React.Component<Props, State> {
         onScriptUpload={s => { this.handleScriptUpload(s) }}
         onCancelScript={(g, i) => { this.handleCanceScript(g, i) }}
         uploadedScripts={this.state.uploadedScripts}
+        userScriptData={this.props.transferItem?.user_scripts}
         scrollableRef={(r: HTMLElement) => { this.scrollableRef = r }}
         layout="modal"
       />

--- a/src/components/organisms/WizardPageContent/WizardPageContent.tsx
+++ b/src/components/organisms/WizardPageContent/WizardPageContent.tsx
@@ -508,6 +508,7 @@ class WizardPageContent extends React.Component<Props, State> {
             onScriptUpload={this.props.onUserScriptUpload}
             onCancelScript={this.props.onCancelUploadedScript}
             uploadedScripts={this.props.uploadedUserScripts}
+            userScriptData={null}
           />
         )
         break

--- a/src/components/pages/MigrationDetailsPage/MigrationDetailsPage.tsx
+++ b/src/components/pages/MigrationDetailsPage/MigrationDetailsPage.tsx
@@ -254,6 +254,7 @@ class MigrationDetailsPage extends React.Component<Props, State> {
       replicaId,
       options,
       userScripts,
+      migrationStore.migrationDetails?.user_scripts,
       minionPoolMappings,
     )
     this.props.history.push(`/migrations/${migration.id}/tasks`)

--- a/src/components/pages/MigrationsPage/MigrationsPage.tsx
+++ b/src/components/pages/MigrationsPage/MigrationsPage.tsx
@@ -145,6 +145,7 @@ class MigrationsPage extends React.Component<{ history: any }, State> {
           migration.replica_id,
           replicaMigrationFields,
           [],
+          migration.user_scripts,
           migration.instance_osmorphing_minion_pool_mappings || {},
         )
       } else {

--- a/src/components/pages/ReplicaDetailsPage/ReplicaDetailsPage.tsx
+++ b/src/components/pages/ReplicaDetailsPage/ReplicaDetailsPage.tsx
@@ -409,6 +409,7 @@ class ReplicaDetailsPage extends React.Component<Props, State> {
       replica.id,
       options,
       uploadedScripts,
+      replica.user_scripts,
       minionPoolMappings,
     )
     notificationStore.alert('Migration successfully created from replica.', 'success', {

--- a/src/components/pages/ReplicasPage/ReplicasPage.tsx
+++ b/src/components/pages/ReplicasPage/ReplicasPage.tsx
@@ -161,6 +161,7 @@ class ReplicasPage extends React.Component<{ history: any }, State> {
         fields,
         uploadedScripts.filter(s => !s.instanceId
           || replica.instances.find(i => i === s.instanceId)),
+        replica.user_scripts,
         replica.instance_osmorphing_minion_pool_mappings || {},
       )))
     notificationStore.alert('Migrations successfully created from replicas.', 'success')

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -96,7 +96,7 @@ export const wizardPages: WizardPage[] = [
   { id: 'networks', title: 'Networks', breadcrumb: 'Networks' },
   { id: 'storage', title: 'Storage Mapping', breadcrumb: 'Storage' },
   {
-    id: 'scripts', title: 'User Scripts', breadcrumb: 'Scripts', excludeFrom: 'replica',
+    id: 'scripts', title: 'User Scripts', breadcrumb: 'Scripts',
   },
   {
     id: 'schedule', title: 'Schedule', breadcrumb: 'Schedule', excludeFrom: 'migration',

--- a/src/plugins/endpoint/default/OptionsSchemaPlugin.ts
+++ b/src/plugins/endpoint/default/OptionsSchemaPlugin.ts
@@ -24,6 +24,7 @@ import type { SchemaProperties, SchemaDefinitions } from '../../../@types/Schema
 import type { NetworkMap } from '../../../@types/Network'
 import type { InstanceScript } from '../../../@types/Instance'
 import { executionOptions, migrationFields } from '../../../constants'
+import { UserScriptData } from '../../../@types/MainItem'
 
 const migrationImageOsTypes = ['windows', 'linux']
 
@@ -257,18 +258,21 @@ export default class OptionsSchemaParser {
     return payload
   }
 
-  static getUserScripts(uploadedUserScripts: InstanceScript[]) {
-    const payload: any = {}
+  static getUserScripts(
+    uploadedUserScripts: InstanceScript[],
+    userScriptData: UserScriptData | null | undefined,
+  ) {
+    const payload: any = userScriptData || {}
     const globalScripts = uploadedUserScripts.filter(s => s.global)
     if (globalScripts.length) {
-      payload.global = {}
+      payload.global = payload.global || {}
       globalScripts.forEach(script => {
         payload.global[script.global || ''] = script.scriptContent
       })
     }
     const instanceScripts = uploadedUserScripts.filter(s => s.instanceId)
     if (instanceScripts.length) {
-      payload.instances = {}
+      payload.instances = payload.instances || {}
       instanceScripts.forEach(script => {
         payload.instances[script.instanceId || ''] = script.scriptContent
       })

--- a/src/plugins/endpoint/openstack/OptionsSchemaPlugin.ts
+++ b/src/plugins/endpoint/openstack/OptionsSchemaPlugin.ts
@@ -24,6 +24,7 @@ import type { Field } from '../../../@types/Field'
 import type { OptionValues, StorageMap } from '../../../@types/Endpoint'
 import type { SchemaProperties, SchemaDefinitions } from '../../../@types/Schema'
 import type { NetworkMap } from '../../../@types/Network'
+import { UserScriptData } from '../../../@types/MainItem'
 
 export default class OptionsSchemaParser {
   static migrationImageMapFieldName = DefaultOptionsSchemaPlugin.migrationImageMapFieldName
@@ -102,7 +103,10 @@ export default class OptionsSchemaParser {
     return DefaultOptionsSchemaPlugin.getStorageMap(defaultStorage, storageMap, configDefault)
   }
 
-  static getUserScripts(uploadedUserScripts: InstanceScript[]) {
-    return DefaultOptionsSchemaPlugin.getUserScripts(uploadedUserScripts)
+  static getUserScripts(
+    uploadedUserScripts: InstanceScript[],
+    userScriptData: UserScriptData | null | undefined,
+  ) {
+    return DefaultOptionsSchemaPlugin.getUserScripts(uploadedUserScripts, userScriptData)
   }
 }

--- a/src/plugins/endpoint/ovm/OptionsSchemaPlugin.ts
+++ b/src/plugins/endpoint/ovm/OptionsSchemaPlugin.ts
@@ -24,6 +24,7 @@ import type { Field } from '../../../@types/Field'
 import type { OptionValues, StorageMap } from '../../../@types/Endpoint'
 import type { SchemaProperties, SchemaDefinitions } from '../../../@types/Schema'
 import type { NetworkMap } from '../../../@types/Network'
+import { UserScriptData } from '../../../@types/MainItem'
 
 export default class OptionsSchemaParser {
   static migrationImageMapFieldName = 'migr_template_map'
@@ -100,7 +101,10 @@ export default class OptionsSchemaParser {
     return DefaultOptionsSchemaPlugin.getStorageMap(defaultStorage, storageMap, configDefault)
   }
 
-  static getUserScripts(uploadedUserScripts: InstanceScript[]) {
-    return DefaultOptionsSchemaPlugin.getUserScripts(uploadedUserScripts)
+  static getUserScripts(
+    uploadedUserScripts: InstanceScript[],
+    userScriptData: UserScriptData | null | undefined,
+  ) {
+    return DefaultOptionsSchemaPlugin.getUserScripts(uploadedUserScripts, userScriptData)
   }
 }

--- a/src/sources/MigrationSource.ts
+++ b/src/sources/MigrationSource.ts
@@ -26,7 +26,9 @@ import type { Endpoint, StorageMap } from '../@types/Endpoint'
 
 import configLoader from '../utils/Config'
 import { Task } from '../@types/Task'
-import { MigrationItem, MigrationItemOptions, MigrationItemDetails } from '../@types/MainItem'
+import {
+  MigrationItem, MigrationItemOptions, MigrationItemDetails, UserScriptData,
+} from '../@types/MainItem'
 import { INSTANCE_OSMORPHING_MINION_POOL_MAPPINGS } from '../components/organisms/WizardOptions/WizardOptions'
 
 class MigrationSourceUtils {
@@ -130,7 +132,8 @@ class MigrationSource {
     updatedNetworkMappings: NetworkMap[] | null,
     defaultSkipOsMorphing: boolean | null,
     replicationCount?: number | null,
-    migration: MigrationItemDetails
+    migration: MigrationItemDetails,
+    uploadedScripts: InstanceScript[]
   }): Promise<MigrationItemDetails> {
     const getValue = (fieldName: string): string | null => {
       const updatedDestEnv = opts.updatedDestEnv && opts.updatedDestEnv[fieldName]
@@ -223,8 +226,9 @@ class MigrationSource {
       ...updatedDestEnv,
     }
 
-    if (migration.user_scripts) {
-      payload.migration.user_scripts = migration.user_scripts
+    if (opts.uploadedScripts?.length || migration.user_scripts) {
+      payload.migration.user_scripts = DefaultOptionsSchemaPlugin
+        .getUserScripts(opts.uploadedScripts, migration.user_scripts)
     }
 
     const response = await Api.send({
@@ -260,6 +264,7 @@ class MigrationSource {
     replicaId: string,
     options: Field[],
     userScripts: InstanceScript[],
+    userScriptData: UserScriptData | null | undefined,
     minionPoolMappings: { [instance: string]: string },
   ): Promise<MigrationItem> {
     const payload: any = {
@@ -271,8 +276,9 @@ class MigrationSource {
       payload.migration[o.name] = o.value || o.default || false
     })
 
-    if (userScripts.length) {
-      payload.migration.user_scripts = DefaultOptionsSchemaPlugin.getUserScripts(userScripts)
+    if (userScripts.length || userScriptData) {
+      payload.migration.user_scripts = DefaultOptionsSchemaPlugin
+        .getUserScripts(userScripts, userScriptData)
     }
 
     if (Object.keys(minionPoolMappings).length) {

--- a/src/sources/MigrationSource.ts
+++ b/src/sources/MigrationSource.ts
@@ -223,6 +223,10 @@ class MigrationSource {
       ...updatedDestEnv,
     }
 
+    if (migration.user_scripts) {
+      payload.migration.user_scripts = migration.user_scripts
+    }
+
     const response = await Api.send({
       url: `${configLoader.config.servicesUrls.coriolis}/${Api.projectId}/migrations`,
       method: 'POST',

--- a/src/sources/ReplicaSource.ts
+++ b/src/sources/ReplicaSource.ts
@@ -16,6 +16,7 @@ import moment from 'moment'
 
 import Api from '../utils/ApiCaller'
 import { OptionsSchemaPlugin } from '../plugins/endpoint'
+import DefaultOptionsSchemaPlugin from '../plugins/endpoint/default/OptionsSchemaPlugin'
 
 import configLoader from '../utils/Config'
 import type { UpdateData, ReplicaItem, ReplicaItemDetails } from '../@types/MainItem'
@@ -265,6 +266,11 @@ class ReplicaSource {
     if (defaultStorage || updateData.storage.length > 0) {
       payload.replica.storage_mappings = parser
         .getStorageMap(defaultStorage, updateData.storage, storageConfigDefault)
+    }
+
+    if (updateData.uploadedScripts?.length) {
+      payload.replica.user_scripts = DefaultOptionsSchemaPlugin
+        .getUserScripts(updateData.uploadedScripts, replica.user_scripts)
     }
 
     const response = await Api.send({

--- a/src/sources/WizardSource.ts
+++ b/src/sources/WizardSource.ts
@@ -93,12 +93,12 @@ class WizardSource {
       data.destOptions && data.destOptions.shutdown_instances,
     )
 
+    if (uploadedUserScripts.length) {
+      payload[type].user_scripts = destParser.getUserScripts(uploadedUserScripts, {})
+    }
+
     if (type === 'migration') {
-      payload[type].replication_count = (
-        data.destOptions && data.destOptions.replication_count) || 2
-      if (uploadedUserScripts.length) {
-        payload[type].user_scripts = destParser.getUserScripts(uploadedUserScripts)
-      }
+      payload[type].replication_count = data.destOptions?.replication_count || 2
     }
 
     const response = await Api.send({

--- a/src/stores/MigrationStore.ts
+++ b/src/stores/MigrationStore.ts
@@ -15,7 +15,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import { observable, action, runInAction } from 'mobx'
 
 import type {
-  UpdateData, MigrationItem, MigrationItemDetails, MigrationItemOptions,
+  UpdateData, MigrationItem, MigrationItemDetails, MigrationItemOptions, UserScriptData,
 } from '../@types/MainItem'
 import type { Field } from '../@types/Field'
 import type { Endpoint } from '../@types/Endpoint'
@@ -89,6 +89,7 @@ class MigrationStore {
       updatedNetworkMappings: updateData.network,
       defaultSkipOsMorphing: this.getDefaultSkipOsMorphing(migration),
       replicationCount,
+      uploadedScripts: updateData.uploadedScripts,
     })
     return migrationResult
   }
@@ -124,12 +125,14 @@ class MigrationStore {
     replicaId: string,
     options: Field[],
     userScripts: InstanceScript[],
+    userScriptData: UserScriptData | null | undefined,
     minionPoolMappings: { [instance: string]: string },
   ) {
     const migration = await MigrationSource.migrateReplica(
       replicaId,
       options,
       userScripts,
+      userScriptData,
       minionPoolMappings,
     )
     runInAction(() => {


### PR DESCRIPTION
User scripts are now stored in migration body, so the UI must send them
when recreating it.