### PR TITLE
Fix occasional UI 'Error setting up request' alert

### DIFF
--- a/src/utils/ApiCaller.ts
+++ b/src/utils/ApiCaller.ts
@@ -200,7 +200,7 @@ class ApiCaller {
           })
           reject({})
         } else {
-          const canceled = error.constructor.name === 'Cancel'
+          const canceled = error.__CANCEL__
           reject({ canceled })
           if (canceled) {
             logger.log({


### PR DESCRIPTION
When cancelling an API request, the app's production build would
interpret the cancellation as an error, due to the fact that the
production build minimizes the class' names.

Solved by using a different method to find out if the error was an
actual error or just a canceled request.