### PR TITLE
Fix loading issues in repl. / migr. details pages

### DIFF
--- a/src/components/organisms/MigrationDetailsContent/MigrationDetailsContent.tsx
+++ b/src/components/organisms/MigrationDetailsContent/MigrationDetailsContent.tsx
@@ -55,6 +55,7 @@ const NavigationItems = [
 
 type Props = {
   item: MigrationItemDetails | null,
+  itemId: string
   minionPools: MinionPool[]
   detailsLoading: boolean,
   instancesDetails: Instance[],
@@ -124,7 +125,7 @@ class MigrationDetailsContent extends React.Component<Props> {
         <DetailsNavigation
           items={NavigationItems}
           selectedValue={this.props.page}
-          itemId={this.props.item ? this.props.item.id : ''}
+          itemId={this.props.itemId}
           itemType="migration"
         />
         <DetailsBody>

--- a/src/components/organisms/ReplicaDetailsContent/ReplicaDetailsContent.tsx
+++ b/src/components/organisms/ReplicaDetailsContent/ReplicaDetailsContent.tsx
@@ -72,6 +72,7 @@ const NavigationItems = [
 type TimezoneValue = 'utc' | 'local'
 type Props = {
   item?: ReplicaItemDetails | null,
+  itemId: string
   endpoints: Endpoint[],
   sourceSchema: Field[],
   sourceSchemaLoading: boolean,

--- a/src/components/pages/MigrationDetailsPage/MigrationDetailsPage.tsx
+++ b/src/components/pages/MigrationDetailsPage/MigrationDetailsPage.tsx
@@ -375,6 +375,7 @@ class MigrationDetailsPage extends React.Component<Props, State> {
           contentComponent={(
             <MigrationDetailsContent
               item={migrationStore.migrationDetails}
+              itemId={this.props.match.params.id}
               instancesDetails={instanceStore.instancesDetails}
               instancesDetailsLoading={instanceStore.loadingInstancesDetails}
               sourceSchema={providerStore.sourceSchema}

--- a/src/components/pages/ReplicaDetailsPage/ReplicaDetailsPage.tsx
+++ b/src/components/pages/ReplicaDetailsPage/ReplicaDetailsPage.tsx
@@ -148,6 +148,7 @@ class ReplicaDetailsPage extends React.Component<Props, State> {
   }
 
   componentWillUnmount() {
+    replicaStore.clearDetails()
     scheduleStore.clearUnsavedSchedules()
     this.stopPolling = true
   }
@@ -580,6 +581,7 @@ class ReplicaDetailsPage extends React.Component<Props, State> {
           contentComponent={(
             <ReplicaDetailsContent
               item={replica}
+              itemId={this.replicaId}
               instancesDetails={instanceStore.instancesDetails}
               instancesDetailsLoading={instanceStore.loadingInstancesDetails}
               endpoints={endpointStore.endpoints}

--- a/src/stores/ReplicaStore.ts
+++ b/src/stores/ReplicaStore.ts
@@ -107,6 +107,10 @@ class ReplicaStore {
     }
   }
 
+  @action clearDetails() {
+    this.replicaDetails = null
+  }
+
   @action getReplicasSuccess(replicas: ReplicaItem[]) {
     this.replicasLoaded = true
     this.replicas = replicas


### PR DESCRIPTION
Fixes an issue where when going from a loaded replica details page back
to the replica list and then to another replica details page, the header
from the previous details page would briefly bee shown. The same applies
to migrations.

Fixes an issue where, while the details page is being loaded, clicking
on 'Executions' / 'Tasks' link would lead to an invalid page.