### PR TITLE
Fix endpoint details loading animation

### DIFF
--- a/src/components/organisms/EndpointDetailsContent/EndpointDetailsContent.tsx
+++ b/src/components/organisms/EndpointDetailsContent/EndpointDetailsContent.tsx
@@ -257,7 +257,7 @@ class EndpointDetailsContent extends React.Component<Props> {
             <Label>Used in replicas/migrations ({usage.length})</Label>
             {usage.length > 0 ? this.renderUsage(usage) : <Value>-</Value>}
           </Field>
-          {this.renderConnectionInfoLoading()}
+          {!this.props.connectionInfo ? this.renderConnectionInfoLoading() : null}
           {this.renderConnectionInfo(this.props.connectionInfo)}
         </Info>
         {this.renderButtons()}

--- a/src/sources/EndpointSource.ts
+++ b/src/sources/EndpointSource.ts
@@ -87,7 +87,7 @@ class EndpointSource {
   }
 
   async getSecretPayload(uuid: string, count: number = 0) {
-    const delay = () => new Promise(r => { setTimeout(() => { r() }, 2000) })
+    const delay = () => new Promise<void>(r => { setTimeout(() => { r() }, 2000) })
 
     if (count >= 10) {
       return Promise.reject({ secretCustomError: `The secret '${uuid}' is not active after ${count} retries.` })


### PR DESCRIPTION
Sometimes, when visiting the endpoint details page, the loading
animation would be shown, even though the connection info was already
loaded.