### PR TITLE
Add license version to appliance ID

### DIFF
--- a/src/@types/Licence.ts
+++ b/src/@types/Licence.ts
@@ -25,3 +25,10 @@ export type Licence = {
   lifetimeAvailableMigrations: number,
   lifetimeAvailableReplicas: number,
 }
+
+export type LicenceServerStatus = {
+  hostname: string,
+  multi_appliance: boolean,
+  supported_licence_versions: string[],
+  server_local_time: string
+}

--- a/src/components/organisms/Licence/Licence.tsx
+++ b/src/components/organisms/Licence/Licence.tsx
@@ -27,7 +27,7 @@ import StyleProps from '../../styleUtils/StyleProps'
 import Palette from '../../styleUtils/Palette'
 import FileUtils from '../../../utils/FileUtils'
 
-import type { Licence } from '../../../@types/Licence'
+import type { Licence, LicenceServerStatus } from '../../../@types/Licence'
 
 import licenceImage from './images/licence'
 
@@ -103,6 +103,7 @@ const FakeFileInput = styled.input`
 
 type Props = {
   licenceInfo: Licence | null,
+  licenceServerStatus: LicenceServerStatus | null,
   licenceError: string | null,
   loadingLicenceInfo: boolean,
   onRequestClose: () => void,
@@ -259,7 +260,7 @@ class LicenceC extends React.Component<Props, State> {
     return <LicenceInfoWrapper>{error}</LicenceInfoWrapper>
   }
 
-  renderLicenceInfo(info: Licence) {
+  renderLicenceInfo(info: Licence, status: LicenceServerStatus) {
     return (
       <LicenceInfoWrapper>
         <LicenceRow>
@@ -279,7 +280,7 @@ class LicenceC extends React.Component<Props, State> {
           <LicenceRowContent>
             <LicenceRowLabel>Appliance ID</LicenceRowLabel>
             <LicenceRowDescription>
-              <CopyValue value={info.applianceId} />
+              <CopyValue value={`${info.applianceId}-licence${status.supported_licence_versions[0]}`} />
             </LicenceRowDescription>
           </LicenceRowContent>
         </LicenceRow>
@@ -374,7 +375,9 @@ class LicenceC extends React.Component<Props, State> {
 
     return (
       <Wrapper>
-        {showInfo && this.props.licenceInfo ? this.renderLicenceInfo(this.props.licenceInfo) : null}
+        {showInfo && this.props.licenceInfo
+          && this.props.licenceServerStatus
+          ? this.renderLicenceInfo(this.props.licenceInfo, this.props.licenceServerStatus) : null}
         {showError && this.props.licenceError
           ? this.renderLicenceError(this.props.licenceError) : null}
         {this.props.addMode ? this.renderLicenceAdd() : null}

--- a/src/components/pages/AboutModal/AboutModal.tsx
+++ b/src/components/pages/AboutModal/AboutModal.tsx
@@ -93,8 +93,7 @@ class AboutModal extends React.Component<Props, State> {
   }
 
   UNSAFE_componentWillMount() {
-    licenceStore.loadVersion()
-    if (userStore.loggedUser && userStore.loggedUser.isAdmin) {
+    if (userStore.loggedUser?.isAdmin) {
       licenceStore.loadLicenceInfo({ showLoading: true })
     }
   }
@@ -130,6 +129,7 @@ class AboutModal extends React.Component<Props, State> {
             ) : null}
             <LicenceComponent
               licenceInfo={licenceStore.licenceInfo}
+              licenceServerStatus={licenceStore.licenceServerStatus}
               licenceError={licenceStore.licenceInfoError}
               loadingLicenceInfo={licenceStore.loadingLicenceInfo}
               onRequestClose={this.props.onRequestClose}

--- a/src/sources/LincenceSource.ts
+++ b/src/sources/LincenceSource.ts
@@ -15,13 +15,21 @@ import Api from '../utils/ApiCaller'
 
 import configLoader from '../utils/Config'
 
-import type { Licence } from '../@types/Licence'
+import type { Licence, LicenceServerStatus } from '../@types/Licence'
 
 class LicenceSource {
   async loadAppliancesIds(skipLog?: boolean | null): Promise<string[]> {
     const url = `${configLoader.config.servicesUrls.coriolisLicensing}/appliances`
     const response = await Api.send({ url, quietError: true, skipLog })
     return response.data.appliances.map((a: any) => a.id)
+  }
+
+  async loadLicenceServerStatus(skipLog?: boolean | null): Promise<LicenceServerStatus> {
+    const url = `${configLoader.config.servicesUrls.coriolisLicensing}/status`
+    const response = await Api.send({ url, quietError: true, skipLog })
+    const status: LicenceServerStatus = response.data.status
+    status.supported_licence_versions.sort((a, b) => b.localeCompare(a))
+    return response.data.status
   }
 
   async loadLicenceInfo(applianceId: string, skipLog?: boolean | null): Promise<Licence> {

--- a/src/utils/ApiLogger.ts
+++ b/src/utils/ApiLogger.ts
@@ -12,8 +12,6 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import licenceStore from '../stores/LicenceStore'
-
 import DomUtils from './DomUtils'
 
 type LogType = 'REQUEST' | 'RESPONSE'
@@ -37,7 +35,6 @@ type Log = {
   requests: RequestLog[],
   userAgent: string,
   platform: string,
-  version: string,
 }
 
 const MAX_LOGS = 1000
@@ -112,7 +109,6 @@ class ApiLogger {
       requests,
       userAgent: window.navigator.userAgent,
       platform: window.navigator.platform,
-      version: licenceStore.version || '-',
     }
 
     DomUtils.download(JSON.stringify(log), 'coriolis-log.json')


### PR DESCRIPTION
This should facilitate an easier way to copy and paste the installation
ID and the licencing server version when issuing a new licence.