### PR TITLE
Increase eslint code max line length to 150

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -57,6 +57,14 @@
     "max-classes-per-file": "off",
     "prefer-promise-reject-errors": "off",
     "import/prefer-default-export": "off",
-    "no-param-reassign": "off"
+    "no-param-reassign": "off",
+    "max-len": [
+      "error",
+      {
+        "code": 150,
+        "ignoreTemplateLiterals": true,
+        "ignoreStrings": true
+      }
+    ]
   }
 }


### PR DESCRIPTION
Previous default was 100. Since the setting also overrides some other
previous default values, the previous default values are also included
so that nothing else should change.