### PR TITLE
Fix unable to edit network map if missing target

### DIFF
--- a/src/@types/Network.ts
+++ b/src/@types/Network.ts
@@ -27,6 +27,6 @@ export type Network = {
 
 export type NetworkMap = {
   sourceNic: Nic,
-  targetNetwork: Network,
+  targetNetwork: Network | null,
   targetSecurityGroups?: SecurityGroup[] | null,
 }

--- a/src/components/organisms/AssessmentDetailsContent/AssessmentDetailsContent.tsx
+++ b/src/components/organisms/AssessmentDetailsContent/AssessmentDetailsContent.tsx
@@ -437,7 +437,7 @@ class AssessmentDetailsContent extends React.Component<Props> {
       const selectedNetwork = this.props.selectedNetworks
         && this.props.selectedNetworks.find(n => n.sourceNic.network_name === nic.network_name)
       if (selectedNetwork) {
-        selectedNetworkName = selectedNetwork.targetNetwork.name
+        selectedNetworkName = selectedNetwork.targetNetwork?.name
       }
 
       return (

--- a/src/components/organisms/EditReplica/EditReplica.tsx
+++ b/src/components/organisms/EditReplica/EditReplica.tsx
@@ -180,10 +180,7 @@ class EditReplica extends React.Component<Props, State> {
         const destNetId = String(typeof destNetObj === 'string' || !destNetObj
           || !destNetObj.id ? destNetObj : destNetObj.id)
 
-        const network = this.props.networks.find(n => n.name === destNetId || n.id === destNetId)
-        if (!network) {
-          return
-        }
+        const network = this.props.networks.find(n => n.name === destNetId || n.id === destNetId) || null
         const mapping: NetworkMap = {
           sourceNic: {
             id: '', network_name: sourceNetworkName, mac_address: '', network_id: '',

--- a/src/components/organisms/WizardNetworks/WizardNetworks.tsx
+++ b/src/components/organisms/WizardNetworks/WizardNetworks.tsx
@@ -175,7 +175,9 @@ class WizardNetworks extends React.Component<Props> {
           items={this.props.networks}
           labelField="name"
           valueField="id"
-          onChange={(item: Network) => { this.props.onChange(nic, item) }}
+          onChange={(item: Network) => {
+            this.props.onChange(nic, item)
+          }}
           data-test-id={`wNetworks-dropdown-${nic.id}`}
         />
       )
@@ -215,7 +217,7 @@ class WizardNetworks extends React.Component<Props> {
           if (selectedSecGroups.length > MAX_SELECTED_GROUPS) {
             selectedSecGroups.splice(MAX_SELECTED_GROUPS - 1, 1)
           }
-          this.props.onChange(nic, selectedNetwork.targetNetwork, selectedSecGroups)
+          this.props.onChange(nic, selectedNetwork.targetNetwork!, selectedSecGroups)
         }}
       />
     ) : null

--- a/src/components/organisms/WizardSummary/WizardSummary.tsx
+++ b/src/components/organisms/WizardSummary/WizardSummary.tsx
@@ -543,7 +543,7 @@ class WizardSummary extends React.Component<Props> {
               <SourceNetwork data-test-id="wSummary-networkSource">{mapping.sourceNic.network_name}</SourceNetwork>
               <NetworkArrow />
               <TargetNetwork>
-                <TargetNetworkName data-test-id="wSummary-networkTarget">{mapping.targetNetwork.name}</TargetNetworkName>
+                <TargetNetworkName data-test-id="wSummary-networkTarget">{mapping.targetNetwork!.name}</TargetNetworkName>
                 {mapping.targetSecurityGroups && mapping.targetSecurityGroups.length ? (
                   <TargetNetworkName>Security Groups: {mapping.targetSecurityGroups.map(s => (typeof s === 'string' ? s : s.name)).join(', ')}</TargetNetworkName>
                 ) : null}

--- a/src/plugins/endpoint/default/OptionsSchemaPlugin.ts
+++ b/src/plugins/endpoint/default/OptionsSchemaPlugin.ts
@@ -195,18 +195,18 @@ export default class OptionsSchemaParser {
     const payload: any = {}
     if (networkMappings && networkMappings.length) {
       const hasSecurityGroups = Boolean(networkMappings
-        .find(nm => nm.targetNetwork.security_groups))
+        .find(nm => nm.targetNetwork!.security_groups))
       networkMappings.forEach(mapping => {
         let target
         if (hasSecurityGroups) {
           target = {
-            id: mapping.targetNetwork.id,
+            id: mapping.targetNetwork!.id,
             security_groups: mapping.targetSecurityGroups
               ? mapping.targetSecurityGroups.map(s => (typeof s === 'string' ? s : s.id))
               : [],
           }
         } else {
-          target = mapping.targetNetwork.id
+          target = mapping.targetNetwork!.id
         }
         payload[mapping.sourceNic.network_name] = target
       })

--- a/src/sources/AssessmentSource.ts
+++ b/src/sources/AssessmentSource.ts
@@ -24,7 +24,7 @@ class AssessmentSourceUtils {
     const networkMap: any = {}
     if (data.networks && data.networks.length) {
       data.networks.forEach(mapping => {
-        networkMap[mapping.sourceNic.network_name] = mapping.targetNetwork.name
+        networkMap[mapping.sourceNic.network_name] = mapping.targetNetwork!.name
       })
     }
     return networkMap


### PR DESCRIPTION
Fixes an issue where if the target network of a replica was no longer
found, networking mapping couldn't be updated.

This fixes the issue, allowing editing a replica's network mapping even
if the target network is no longer available.