### PR TITLE
Reload mappings if destination options are changed CORWEB-255

### DIFF
--- a/src/components/organisms/EditReplica/EditReplica.tsx
+++ b/src/components/organisms/EditReplica/EditReplica.tsx
@@ -48,6 +48,7 @@ import StyleProps from '../../styleUtils/StyleProps'
 import LoadingButton from '../../molecules/LoadingButton/LoadingButton'
 import minionPoolStore from '../../../stores/MinionPoolStore'
 import WizardScripts from '../WizardScripts/WizardScripts'
+import networkStore from '../../../stores/NetworkStore'
 
 const PanelContent = styled.div<any>`
   display: flex;
@@ -357,12 +358,17 @@ class EditReplica extends React.Component<Props, State> {
       useCache,
       envData,
     })
+    if (type === 'destination') {
+      networkStore.loadNetworks(endpoint.id, envData, { cache: true })
+      if (this.hasStorageMap()) {
+        endpointStore.loadStorage(this.props.destinationEndpoint.id, envData, { cache: true })
+      }
+    }
   }
 
   hasStorageMap(): boolean {
-    return providerStore.providers && providerStore.providers[this.props.destinationEndpoint.type]
-      ? !!providerStore.providers[this.props.destinationEndpoint.type]
-        .types.find(t => t === providerTypes.STORAGE)
+    return providerStore.providers?.[this.props.destinationEndpoint.type]
+      ? !!providerStore.providers[this.props.destinationEndpoint.type].types.find(t => t === providerTypes.STORAGE)
       : false
   }
 

--- a/src/sources/EndpointSource.ts
+++ b/src/sources/EndpointSource.ts
@@ -273,9 +273,12 @@ class EndpointSource {
     return SchemaParser.parseConnectionResponse(response.data.endpoint)
   }
 
-  async loadStorage(endpointId: string, data: any): Promise<Storage> {
+  async loadStorage(endpointId: string, data: any, options?: { cache?: boolean }): Promise<Storage> {
     const env = DomUtils.encodeToBase64Url(data)
-    const response = await Api.get(`${configLoader.config.servicesUrls.coriolis}/${Api.projectId}/endpoints/${endpointId}/storage?env=${env}`)
+    const response = await Api.send({
+      url: `${configLoader.config.servicesUrls.coriolis}/${Api.projectId}/endpoints/${endpointId}/storage?env=${env}`,
+      cache: options?.cache,
+    })
     return response.data.storage
   }
 }

--- a/src/stores/EndpointStore.ts
+++ b/src/stores/EndpointStore.ts
@@ -312,12 +312,12 @@ class EndpointStore {
     this.adding = false
   }
 
-  @action async loadStorage(endpointId: string, data: any): Promise<void> {
+  @action async loadStorage(endpointId: string, data: any, options?: {cache?: boolean}): Promise<void> {
     this.storageBackends = []
     this.storageLoading = true
 
     try {
-      const storage = await EndpointSource.loadStorage(endpointId, data)
+      const storage = await EndpointSource.loadStorage(endpointId, data, options)
       this.loadStorageSuccess(storage)
     } catch (ex) {
       runInAction(() => { this.storageLoading = false })


### PR DESCRIPTION
If some destination options fields are changed (the ones specified in
config.ts as extra-options `requiredFields` or `relistFields`), the
networks and storage will reload when editing a replica or when
recreating a migration.