### PR TITLE
Improve transfer items details page loading flow CORWEB-251

### DIFF
--- a/src/sources/MigrationSource.ts
+++ b/src/sources/MigrationSource.ts
@@ -70,6 +70,7 @@ class MigrationSource {
     const response = await Api.send({
       url: `${configLoader.config.servicesUrls.coriolis}/${Api.projectId}/migrations/${migrationId}`,
       skipLog,
+      cancelId: migrationId,
     })
     const migration = response.data.migration
     sortTasks(migration.tasks, MigrationSourceUtils.sortTaskUpdates)

--- a/src/sources/ReplicaSource.ts
+++ b/src/sources/ReplicaSource.ts
@@ -115,6 +115,7 @@ class ReplicaSource {
     const response = await Api.send({
       url: `${configLoader.config.servicesUrls.coriolis}/${Api.projectId}/replicas/${replicaId}`,
       skipLog: polling,
+      cancelId: replicaId,
     })
     const replica: ReplicaItemDetails = response.data.replica
     replica.executions = ReplicaSourceUtils.filterDeletedExecutions(replica.executions)

--- a/src/stores/EndpointStore.ts
+++ b/src/stores/EndpointStore.ts
@@ -63,7 +63,10 @@ class EndpointStore {
   @observable multiValidation: MultiValidationItem[] = []
 
   @action async getEndpoints(options?: { showLoading?: boolean, skipLog?: boolean }) {
-    if (options && options.showLoading) {
+    if (this.loading) {
+      return
+    }
+    if (options?.showLoading) {
       this.loading = true
     }
     try {

--- a/src/stores/InstanceStore.ts
+++ b/src/stores/InstanceStore.ts
@@ -339,9 +339,7 @@ class InstanceStore {
     this.reqId = !this.reqId ? 1 : this.reqId + 1
     InstanceSource.cancelInstancesDetailsRequests(this.reqId - 1)
 
-    instances
-      .sort((a, b) => (a.instance_name || a.name || a.id)
-        .localeCompare(b.instance_name || b.name || b.id))
+    instances.sort((a, b) => (a.instance_name || a.name || a.id).localeCompare(b.instance_name || b.name || b.id))
 
     const count = instances.length
     if (count === 0) {
@@ -352,7 +350,7 @@ class InstanceStore {
     this.instancesDetailsCount = count
     this.instancesDetailsRemaining = count
 
-    await new Promise(resolve => {
+    await new Promise<void>(resolve => {
       Promise.all(instances.map(async instanceInfo => {
         try {
           const resp = await InstanceSource.loadInstanceDetails({

--- a/src/stores/MigrationStore.ts
+++ b/src/stores/MigrationStore.ts
@@ -21,6 +21,7 @@ import type { Field } from '../@types/Field'
 import type { Endpoint } from '../@types/Endpoint'
 import type { InstanceScript } from '../@types/Instance'
 import MigrationSource from '../sources/MigrationSource'
+import apiCaller from '../utils/ApiCaller'
 
 class MigrationStore {
   @observable migrations: MigrationItem[] = []
@@ -145,6 +146,13 @@ class MigrationStore {
       ]
     })
     return migration
+  }
+
+  @action cancelMigrationDetails() {
+    if (this.migrationDetails) {
+      apiCaller.cancelRequests(this.migrationDetails.id)
+    }
+    this.detailsLoading = false
   }
 
   @action clearDetails() {

--- a/src/stores/ProviderStore.ts
+++ b/src/stores/ProviderStore.ts
@@ -187,7 +187,7 @@ class ProviderStore {
   }
 
   @action async loadProviders(): Promise<void> {
-    if (this.providers) {
+    if (this.providers || this.providersLoading) {
       return
     }
     this.providersLoading = true
@@ -233,8 +233,7 @@ class ProviderStore {
     }
 
     try {
-      const fields: Field[] = await ProviderSource
-        .loadOptionsSchema(providerName, optionsType, useCache, quietError)
+      const fields: Field[] = await ProviderSource.loadOptionsSchema(providerName, optionsType, useCache, quietError)
       this.loadOptionsSchemaSuccess(fields, optionsType, isValid())
       return fields
     } finally {

--- a/src/stores/ReplicaStore.ts
+++ b/src/stores/ReplicaStore.ts
@@ -22,6 +22,7 @@ import type {
 import type { Execution, ExecutionTasks } from '../@types/Execution'
 import type { Endpoint } from '../@types/Endpoint'
 import type { Field } from '../@types/Field'
+import apiCaller from '../utils/ApiCaller'
 
 class ReplicaStoreUtils {
   static getNewReplica(
@@ -83,6 +84,13 @@ class ReplicaStore {
     } finally {
       this.getReplicasDone()
     }
+  }
+
+  @action cancelReplicaDetails() {
+    if (this.replicaDetails?.id) {
+      apiCaller.cancelRequests(this.replicaDetails?.id)
+    }
+    this.replicaDetailsLoading = false
   }
 
   @action async getReplicaDetails(options: {


### PR DESCRIPTION
The replica / migration details page loading flow has been improved so
that, in rare cases, it could no longer show info from a different one.

It also fixes the rare cases where the "Endpoint Missing" placeholder
was erroneously shown.