### PR TITLE
Enable VMWare target 'clone_disk' option

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -86,15 +86,6 @@ const conf: Config = {
     },
   ],
 
-  providerMigrationOptions: {
-    vmware_vsphere: {
-      cloneDiskDisabledOptions: {
-        defaultValue: false,
-        description: 'Replica Deployments on VMware do not currently support Replica disk cloning',
-      },
-    },
-  },
-
   /*
   Lower number means that the provider will appear sooner in the list.
   Equal number means alphabetical order within the same group number.

--- a/src/@types/Config.ts
+++ b/src/@types/Config.ts
@@ -1,5 +1,3 @@
-import { ProviderTypes } from './Providers'
-
 type Type = 'source' | 'destination'
 
 type ExtraOption = {
@@ -22,17 +20,6 @@ export type Services = {
   coriolisLicensing: string,
 }
 
-export type ProviderMigrationCloneDiskDisabledOption = {
-  defaultValue: boolean
-  description: string
-}
-
-export type ProviderMigrationOptions = {
-  [provider in ProviderTypes]?: {
-    cloneDiskDisabledOptions: ProviderMigrationCloneDiskDisabledOption
-  }
-}
-
 export type Config = {
   disabledPages: string[],
   showUserDomainInput: boolean,
@@ -49,5 +36,4 @@ export type Config = {
   mainListItemsPerPage: number,
   servicesUrls: Services,
   maxMinionPoolEventsPerPage: number,
-  providerMigrationOptions: ProviderMigrationOptions
 }

--- a/src/components/organisms/ReplicaMigrationOptions/ReplicaMigrationOptions.tsx
+++ b/src/components/organisms/ReplicaMigrationOptions/ReplicaMigrationOptions.tsx
@@ -33,7 +33,6 @@ import type { Instance, InstanceScript } from '../../../@types/Instance'
 import { TransferItemDetails } from '../../../@types/MainItem'
 import { MinionPool } from '../../../@types/MinionPool'
 import { INSTANCE_OSMORPHING_MINION_POOL_MAPPINGS } from '../WizardOptions/WizardOptions'
-import { ProviderMigrationCloneDiskDisabledOption } from '../../../@types/Config'
 
 const Wrapper = styled.div<any>`
   display: flex;
@@ -84,7 +83,6 @@ type Props = {
   minionPools: MinionPool[]
   loadingInstances: boolean,
   defaultSkipOsMorphing?: boolean | null,
-  disabledCloneDisk?: ProviderMigrationCloneDiskDisabledOption | null,
   onCancelClick: () => void,
   onMigrateClick: (
     fields: Field[],
@@ -118,20 +116,9 @@ class ReplicaMigrationOptions extends React.Component<Props, State> {
     const mappings = this.props.transferItem?.instance_osmorphing_minion_pool_mappings || {}
 
     this.setState({
-      fields: replicaMigrationFields.map(f => {
-        if (f.name === 'skip_os_morphing') {
-          return { ...f, value: this.props.defaultSkipOsMorphing || null }
-        }
-        if (f.name === 'clone_disks' && this.props.disabledCloneDisk) {
-          return {
-            ...f,
-            disabled: true,
-            value: this.props.disabledCloneDisk.defaultValue,
-            description: this.props.disabledCloneDisk.description,
-          }
-        }
-        return f
-      }),
+      fields: replicaMigrationFields.map(f => (f.name === 'skip_os_morphing' ? (
+        { ...f, value: this.props.defaultSkipOsMorphing || null }
+      ) : f)),
       minionPoolMappings: { ...mappings },
     })
   }
@@ -213,8 +200,7 @@ class ReplicaMigrationOptions extends React.Component<Props, State> {
         layout="page"
         label={field.label || LabelDictionary.get(field.name)}
         onChange={value => this.handleValueChange(field, value)}
-        description={field.description || LabelDictionary.getDescription(field.name)}
-        disabled={field.disabled}
+        description={LabelDictionary.getDescription(field.name)}
       />
     )
   }

--- a/src/components/pages/MigrationDetailsPage/MigrationDetailsPage.tsx
+++ b/src/components/pages/MigrationDetailsPage/MigrationDetailsPage.tsx
@@ -443,8 +443,6 @@ Note that this may lead to scheduled cleanup tasks being forcibly skipped, and t
               loadingInstances={instanceStore.loadingInstancesDetails}
               defaultSkipOsMorphing={migrationStore
                 .getDefaultSkipOsMorphing(migrationStore.migrationDetails)}
-              disabledCloneDisk={migrationStore.getDisabledCloneDiskOptions(endpointStore.endpoints
-                .find(e => e.id === migrationStore.migrationDetails?.destination_endpoint_id)?.type)}
             />
           </Modal>
         ) : null}

--- a/src/components/pages/ReplicaDetailsPage/ReplicaDetailsPage.tsx
+++ b/src/components/pages/ReplicaDetailsPage/ReplicaDetailsPage.tsx
@@ -650,8 +650,6 @@ class ReplicaDetailsPage extends React.Component<Props, State> {
               instances={instanceStore.instancesDetails}
               onCancelClick={() => { this.handleCloseMigrationModal() }}
               onMigrateClick={(o, s, r, m) => { this.migrateReplica(o, s, r, m) }}
-              disabledCloneDisk={migrationStore.getDisabledCloneDiskOptions(endpointStore.endpoints
-                .find(e => e.id === replicaStore.replicaDetails?.destination_endpoint_id)?.type)}
             />
           </Modal>
         ) : null}

--- a/src/components/pages/ReplicasPage/ReplicasPage.tsx
+++ b/src/components/pages/ReplicasPage/ReplicasPage.tsx
@@ -46,7 +46,6 @@ import Palette from '../../styleUtils/Palette'
 import configLoader from '../../../utils/Config'
 import { ReplicaItem } from '../../../@types/MainItem'
 import userStore from '../../../stores/UserStore'
-import { ProviderMigrationCloneDiskDisabledOption } from '../../../@types/Config'
 
 const Wrapper = styled.div<any>``
 
@@ -331,14 +330,6 @@ class ReplicasPage extends React.Component<{ history: any }, State> {
       action: () => { this.handleShowDeleteReplicas() },
     }]
 
-    let disabledDiskOptions: ProviderMigrationCloneDiskDisabledOption | null = null
-    this.state.selectedReplicas.forEach(r => {
-      const options = migrationStore.getDisabledCloneDiskOptions(this.getEndpoint(r.destination_endpoint_id)?.type)
-      if (options) {
-        disabledDiskOptions = options
-      }
-    })
-
     return (
       <Wrapper>
         <MainTemplate
@@ -440,7 +431,6 @@ class ReplicasPage extends React.Component<{ history: any }, State> {
                 this.setState({ showCreateMigrationsModal: false, modalIsOpen: false })
               }}
               onMigrateClick={(options, s) => { this.migrateSelectedReplicas(options, s) }}
-              disabledCloneDisk={disabledDiskOptions}
             />
           </Modal>
         ) : null}

--- a/src/stores/MigrationStore.ts
+++ b/src/stores/MigrationStore.ts
@@ -21,8 +21,6 @@ import type { Field } from '../@types/Field'
 import type { Endpoint } from '../@types/Endpoint'
 import type { InstanceScript } from '../@types/Instance'
 import MigrationSource from '../sources/MigrationSource'
-import configLoader from '../utils/Config'
-import { ProviderTypes } from '../@types/Providers'
 
 class MigrationStore {
   @observable migrations: MigrationItem[] = []
@@ -59,13 +57,6 @@ class MigrationStore {
       return true
     }
     return null
-  }
-
-  getDisabledCloneDiskOptions(provider: ProviderTypes | undefined) {
-    if (!provider) {
-      return null
-    }
-    return configLoader.config.providerMigrationOptions[provider]?.cloneDiskDisabledOptions || null
   }
 
   @action async recreateFullCopy(migration: MigrationItemOptions) {


### PR DESCRIPTION
It is now possible to set the 'clone_disk' option for VMWare target. The
API will send the user an error if necessary.