### PR TITLE
Reduce the number of replica GET /schedules reqs.

### DIFF
--- a/src/components/organisms/FilterList/FilterList.tsx
+++ b/src/components/organisms/FilterList/FilterList.tsx
@@ -42,6 +42,7 @@ type Props = {
   renderItemComponent: (componentProps: ItemComponentProps) => React.ReactNode,
   itemFilterFunction: (item: any, filterStatus?: string | null, filterState?: string) => boolean,
   onSelectedItemsChange?: (items: any[]) => void,
+  onPaginatedItemsChange?: (items: any[]) => void
   filterItems: DictItem[],
   emptyListImage?: string | null,
   emptyListMessage?: string,
@@ -71,7 +72,11 @@ class FilterList extends React.Component<Props, State> {
   }
 
   UNSAFE_componentWillMount() {
-    this.setState({ items: this.props.items })
+    this.setState({ items: this.props.items }, () => {
+      if (this.props.onPaginatedItemsChange) {
+        this.props.onPaginatedItemsChange(this.paginatedItems)
+      }
+    })
   }
 
   UNSAFE_componentWillReceiveProps(props: Props) {
@@ -82,6 +87,10 @@ class FilterList extends React.Component<Props, State> {
         filterText: '',
         selectedItems: [],
         currentPage: 1,
+      }, () => {
+        if (this.props.onPaginatedItemsChange) {
+          this.props.onPaginatedItemsChange(this.paginatedItems)
+        }
       })
       if (this.props.onSelectedItemsChange) this.props.onSelectedItemsChange([])
       return
@@ -89,6 +98,10 @@ class FilterList extends React.Component<Props, State> {
 
     this.setState({
       items: this.filterItems(props.items),
+    }, () => {
+      if (this.props.onPaginatedItemsChange) {
+        this.props.onPaginatedItemsChange(this.paginatedItems)
+      }
     })
   }
 
@@ -121,7 +134,12 @@ class FilterList extends React.Component<Props, State> {
         items,
         currentPage: 1,
       }, () => {
-        if (this.props.onSelectedItemsChange) this.props.onSelectedItemsChange(selectedItems)
+        if (this.props.onSelectedItemsChange) {
+          this.props.onSelectedItemsChange(selectedItems)
+        }
+        if (this.props.onPaginatedItemsChange) {
+          this.props.onPaginatedItemsChange(this.paginatedItems)
+        }
       })
     })
   }
@@ -131,6 +149,10 @@ class FilterList extends React.Component<Props, State> {
       filterText: text,
       items: this.filterItems(this.props.items, null, text),
       currentPage: 1,
+    }, () => {
+      if (this.props.onPaginatedItemsChange) {
+        this.props.onPaginatedItemsChange(this.paginatedItems)
+      }
     })
   }
 
@@ -168,7 +190,11 @@ class FilterList extends React.Component<Props, State> {
   }
 
   handlePageClick(page: number) {
-    this.setState({ currentPage: page })
+    this.setState({ currentPage: page }, () => {
+      if (this.props.onPaginatedItemsChange) {
+        this.props.onPaginatedItemsChange(this.paginatedItems)
+      }
+    })
   }
 
   renderPagination() {

--- a/src/components/pages/ReplicasPage/ReplicasPage.tsx
+++ b/src/components/pages/ReplicasPage/ReplicasPage.tsx
@@ -80,6 +80,8 @@ class ReplicasPage extends React.Component<{ history: any }, State> {
 
   schedulePollTimeout: number = 0
 
+  paginatedReplicaIds: string[] = []
+
   componentDidMount() {
     document.title = 'Coriolis Replicas'
 
@@ -135,6 +137,10 @@ class ReplicasPage extends React.Component<{ history: any }, State> {
     } else {
       this.props.history.push(`/replicas/${item.id}`)
     }
+  }
+
+  handlePaginatedItemsChange(paginatedReplicas: ReplicaItem[]) {
+    this.paginatedReplicaIds = paginatedReplicas.map(r => r.id)
   }
 
   executeSelectedReplicas(fields: Field[]) {
@@ -257,7 +263,7 @@ class ReplicasPage extends React.Component<{ history: any }, State> {
       return
     }
     this.schedulePolling = true
-    await scheduleStore.getSchedulesBulk(replicaStore.replicas.map(r => r.id))
+    await scheduleStore.getSchedulesBulk(this.paginatedReplicaIds)
     this.schedulePollTimeout = setTimeout(() => {
       this.pollSchedule()
     }, SCHEDULE_POLL_TIMEOUT)
@@ -345,6 +351,7 @@ class ReplicasPage extends React.Component<{ history: any }, State> {
               onReloadButtonClick={() => { this.handleReloadButtonClick() }}
               itemFilterFunction={(...args) => this.itemFilterFunction(...args)}
               onSelectedItemsChange={selectedReplicas => { this.setState({ selectedReplicas }) }}
+              onPaginatedItemsChange={paginatedReplicas => { this.handlePaginatedItemsChange(paginatedReplicas) }}
               renderItemComponent={options => (
                 <MainListItem
                   {...options}


### PR DESCRIPTION
Previously, a GET /schedules request was made for every replica, every
few seconds. Now, the requests are made only for the visible replicas
(replicas that are visible in the list through filtering and / or
pagination).