### PR TITLE
Fix endpoint fields reverting to previous values

### DIFF
--- a/src/stores/ProviderStore.ts
+++ b/src/stores/ProviderStore.ts
@@ -176,8 +176,15 @@ class ProviderStore {
     regionsField.enum = [...regionStore.regions]
   }
 
+  loadingForProvider: ProviderTypes | null = null
+
   @action async getConnectionInfoSchema(providerName: ProviderTypes): Promise<void> {
+    if (this.connectionSchemaLoading && this.loadingForProvider === providerName) {
+      return
+    }
+
     this.connectionSchemaLoading = true
+    this.loadingForProvider = providerName
 
     try {
       const fields: Field[] = await ProviderSource.getConnectionInfoSchema(providerName)

--- a/src/stores/ProviderStore.ts
+++ b/src/stores/ProviderStore.ts
@@ -330,7 +330,8 @@ class ProviderStore {
         isValid(),
       )
       return options
-    } catch (err) {
+    } catch (e) {
+      const err: any = e
       console.error(err)
       canceled = err ? err.canceled : false
       if (canceled) {

--- a/src/utils/ApiCaller.ts
+++ b/src/utils/ApiCaller.ts
@@ -116,7 +116,8 @@ class ApiCaller {
         cacher.save({ key: options.url, data: response.data })
       }
       return response
-    } catch (error) {
+    } catch (err) {
+      const error: any = err
       if (error.response) {
         throw apiCallerHandlers.handleErrorResponse(error)
       } else if (error.request) {

--- a/src/utils/ObjectUtils.ts
+++ b/src/utils/ObjectUtils.ts
@@ -72,7 +72,7 @@ class ObjectUtils {
   }
 
   static async wait(ms: number) {
-    return new Promise(r => setTimeout(() => r(), ms))
+    return new Promise<void>(r => setTimeout(() => r(), ms))
   }
 
   static async waitFor(


### PR DESCRIPTION
Sometimes when opening the edit endpoint modal and immediately starting
to edit a field, the field would revert to its initial value. This
doesn’t happen if the user waits a few seconds before starting to edit a
field.

This was caused by a concurrency issue between requests and fixed by no
longer making the requests if they are already in progress.