### PR TITLE
Add high quality source maps to production builds

### DIFF
--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,4 +1,7 @@
 const merge = require('webpack-merge')
 const common = require('./webpack.common')
 
-module.exports = merge(common, { mode: 'production' })
+module.exports = merge(common, {
+  mode: 'production',
+  devtool: 'source-map',
+})


### PR DESCRIPTION
This will give better call stacks when throwing errors, thus making it
easier to identify production build errors.