### PR TITLE
Rename NODE_MODE env. variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Your server will be running at `http://localhost:3000/` (the port is configurabl
 
 ## Development mode
 
-- set env. variable `NODE_MODE='development'`
+- set env. variable `NODE_ENV='development'`
 - run `yarn client-dev` to start local development server (starts on port 3001)
 - run `yarn server-dev` to start the express server in development mode
 
@@ -55,7 +55,7 @@ All environment variables can be set in a `.env` file created in the root direct
 The following is the list of environment variables and their default values:
 
 ```(bash)
-NODE_MODE='production'
+NODE_ENV='production'
 CORIOLIS_URL='<your-coriolis-url>'
 MOD_JSON='<path-to-json>'
 ```

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,5 @@
 module.exports = api => {
-  api.cache.using(() => process.env.NODE_MODE)
+  api.cache.using(() => process.env.NODE_ENV)
 
   const common = {
     presets: [
@@ -20,7 +20,7 @@ module.exports = api => {
       '@babel/plugin-proposal-optional-chaining',
     ],
   }
-  if (process.env.NODE_MODE === 'development' || process.env.NODE_ENV === 'test') {
+  if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
     common.plugins.push(['babel-plugin-styled-components', { displayName: true, minify: false }])
   } else {
     common.plugins.push(['babel-plugin-styled-components', { displayName: false, minify: true }])

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -55,12 +55,6 @@ export const loginButtons = [
   // },
 ]
 
-export const env = {
-  name: process.env.NODE_ENV || 'development',
-  isDev: process.env.NODE_ENV !== 'production',
-  isBrowser: typeof window !== 'undefined',
-}
-
 export const executionOptions = [
   {
     name: 'shutdown_instances',

--- a/src/plugins/default/OptionsSchemaPlugin.ts
+++ b/src/plugins/default/OptionsSchemaPlugin.ts
@@ -12,8 +12,6 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/* eslint-disable no-param-reassign */
-
 import Utils from '@src/utils/ObjectUtils'
 
 import type { Field } from '@src/@types/Field'


### PR DESCRIPTION
Use NODE_ENV instead to set the node environment.
NODE_MODE was used back when there was a naming conflict between the
two.