### PR TITLE
Improve UX for wizard options required fields

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,20 +4,13 @@
   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
-    // Launch Chrome like this: "C:\Program Files (x86)\Google\Chrome\Application\chrome.exe" --remote-debugging-port=9222
     {
-      "type": "chrome",
+      "type": "pwa-msedge",
       "request": "attach",
-      "name": "Attach to Chrome",
+      "runtimeExecutable": "stable",
+      "name": "Attach to Edge",
       "port": 9222,
       "urlFilter": "http://localhost:3001/*",
-      "webRoot": "${workspaceFolder}"
-    },
-    {
-      "type": "chrome",
-      "request": "launch",
-      "name": "Launch Chrome against localhost",
-      "url": "http://localhost:3001",
       "webRoot": "${workspaceFolder}"
     },
   ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,6 @@
   },
   "files.eol": "\n",
   "typescript.tsdk": "node_modules/typescript/lib",
-  "typescript.preferences.importModuleSpecifier": "non-relative"
+  "typescript.preferences.importModuleSpecifier": "non-relative",
+  "debug.javascript.autoAttachFilter": "always"
 }

--- a/src/@types/Field.ts
+++ b/src/@types/Field.ts
@@ -52,6 +52,7 @@ export type Field = {
   readOnly?: boolean,
   title?: string,
   description?: string,
+  warning?: string,
   subFields?: Field[],
   groupName?: string
 }

--- a/src/components/modules/TransferModule/TransferItemModal/TransferItemModal.tsx
+++ b/src/components/modules/TransferModule/TransferItemModal/TransferItemModal.tsx
@@ -26,9 +26,8 @@ import Button from '@src/components/ui/Button'
 import StatusImage from '@src/components/ui/StatusComponents/StatusImage'
 import Modal from '@src/components/ui/Modal'
 import Panel from '@src/components/ui/Panel'
-import { isOptionsPageValid } from '@src/components/modules/WizardModule/WizardPageContent'
 import WizardNetworks, { WizardNetworksChangeObject } from '@src/components/modules/WizardModule/WizardNetworks'
-import WizardOptions, { INSTANCE_OSMORPHING_MINION_POOL_MAPPINGS } from '@src/components/modules/WizardModule/WizardOptions'
+import WizardOptions, { findInvalidFields, INSTANCE_OSMORPHING_MINION_POOL_MAPPINGS } from '@src/components/modules/WizardModule/WizardOptions'
 import WizardStorage from '@src/components/modules/WizardModule/WizardStorage'
 
 import type {
@@ -440,12 +439,12 @@ class TransferItemModal extends React.Component<Props, State> {
     const env = type === 'source' ? this.props.replica.source_environment : this.props.replica.destination_environment
     const data = type === 'source' ? this.state.sourceData : this.state.destinationData
     const schema = type === 'source' ? providerStore.sourceSchema : providerStore.destinationSchema
-    const isValid = isOptionsPageValid({
+    const invalidFields = findInvalidFields({
       ...env,
       ...data,
     }, schema)
 
-    this.setState({ updateDisabled: !isValid })
+    this.setState({ updateDisabled: invalidFields.length > 0 })
   }
 
   handlePanelChange(panel: string) {

--- a/src/components/modules/WizardModule/WizardOptions/WizardOptions.tsx
+++ b/src/components/modules/WizardModule/WizardOptions/WizardOptions.tsx
@@ -388,11 +388,13 @@ class WizardOptions extends React.Component<Props> {
 
     let fieldsSchema: Field[] = this.getDefaultSimpleFieldsSchema()
 
-    fieldsSchema = fieldsSchema.concat(this.props.fields.filter(f => f.required))
+    const isRequired = (f: Field) => f.required || f.properties?.some(p => p.required)
+
+    fieldsSchema = fieldsSchema.concat(this.props.fields.filter(isRequired))
 
     if (this.props.useAdvancedOptions) {
       fieldsSchema = fieldsSchema.concat(this.getDefaultAdvancedFieldsSchema())
-      fieldsSchema = fieldsSchema.concat(this.props.fields.filter(f => !f.required))
+      fieldsSchema = fieldsSchema.concat(this.props.fields.filter(f => !isRequired(f)))
     }
 
     const nonNullableBooleans: string[] = fieldsSchema.filter(f => f.type === 'boolean' && f.nullableBoolean === false).map(f => f.name)

--- a/src/components/modules/WizardModule/WizardOptions/WizardOptions.tsx
+++ b/src/components/modules/WizardModule/WizardOptions/WizardOptions.tsx
@@ -352,6 +352,7 @@ class WizardOptions extends React.Component<Props> {
         minimum={field.minimum}
         maximum={field.maximum}
         label={field.label || LabelDictionary.get(field.name, this.props.dictionaryKey)}
+        warning={field.warning}
         description={field.description
           || LabelDictionary.getDescription(field.name, this.props.dictionaryKey)}
         password={this.isPassword(field.name)}

--- a/src/components/smart/WizardPage/WizardPage.tsx
+++ b/src/components/smart/WizardPage/WizardPage.tsx
@@ -129,6 +129,10 @@ class WizardPage extends React.Component<Props, State> {
       .filter(p => p.id !== 'storage' || hasStorageMapping())
   }
 
+  get requiresWindowsImage() {
+    return Boolean(wizardStore.data.selectedInstances?.find(i => i.os_type === 'windows'))
+  }
+
   setTransferItemTitle() {
     const selectedInstance = wizardStore.data?.selectedInstances?.[0]
     let title = selectedInstance?.name || selectedInstance?.instance_name || selectedInstance?.id
@@ -278,6 +282,7 @@ class WizardPage extends React.Component<Props, State> {
       providerName: target.type,
       optionsType: 'destination',
       useCache: true,
+      requiresWindowsImage: this.requiresWindowsImage,
     })
     wizardStore.fillWithDefaultValues('destination', providerStore.destinationSchema)
     // Preload destination options values
@@ -286,6 +291,7 @@ class WizardPage extends React.Component<Props, State> {
       endpointId: target.id,
       providerName: target.type,
       useCache: true,
+      requiresWindowsImage: this.requiresWindowsImage,
     })
     wizardStore.fillWithDefaultValues('destination', providerStore.destinationSchema)
     await this.loadExtraOptions(null, 'destination')
@@ -358,6 +364,9 @@ class WizardPage extends React.Component<Props, State> {
   handleSourceOptionsChange(field: Field, value: any, parentFieldName?: string) {
     wizardStore.updateData({ selectedInstances: [] })
     wizardStore.updateSourceOptions({ field, value, parentFieldName })
+    if (field.subFields) {
+      wizardStore.fillWithDefaultValues('source', providerStore.sourceSchema)
+    }
     if (field.type !== 'string' || field.enum) {
       this.loadExtraOptions(field, 'source')
     }
@@ -409,6 +418,7 @@ class WizardPage extends React.Component<Props, State> {
     await providerStore.loadOptionsSchema({
       providerName: endpoint.type,
       optionsType,
+      requiresWindowsImage: this.requiresWindowsImage,
     })
     const getSchema = () => (optionsType === 'source' ? providerStore.sourceSchema : providerStore.destinationSchema)
     wizardStore.fillWithDefaultValues(optionsType, getSchema())
@@ -417,6 +427,7 @@ class WizardPage extends React.Component<Props, State> {
       optionsType,
       endpointId: endpoint.id,
       providerName: endpoint.type,
+      requiresWindowsImage: this.requiresWindowsImage,
     })
     wizardStore.fillWithDefaultValues(optionsType, getSchema())
 
@@ -454,6 +465,7 @@ class WizardPage extends React.Component<Props, State> {
       providerName: endpoint.type,
       envData,
       useCache,
+      requiresWindowsImage: this.requiresWindowsImage,
     })
     wizardStore.fillWithDefaultValues(type, getSchema())
   }
@@ -464,6 +476,7 @@ class WizardPage extends React.Component<Props, State> {
         providerName: endpoint.type,
         optionsType,
         useCache: true,
+        requiresWindowsImage: this.requiresWindowsImage,
       })
       const getSchema = () => (optionsType === 'source' ? providerStore.sourceSchema : providerStore.destinationSchema)
       wizardStore.fillWithDefaultValues(optionsType, getSchema())
@@ -472,6 +485,7 @@ class WizardPage extends React.Component<Props, State> {
         optionsType,
         endpointId: endpoint.id,
         providerName: endpoint.type,
+        requiresWindowsImage: this.requiresWindowsImage,
         useCache: true,
       })
       wizardStore.fillWithDefaultValues(optionsType, getSchema())
@@ -581,6 +595,7 @@ class WizardPage extends React.Component<Props, State> {
       }
       this.handleCreationSuccess([item])
     } catch (err) {
+      console.error(err)
       this.setState({ nextButtonDisabled: false })
     }
   }

--- a/src/components/smart/WizardPage/WizardPage.tsx
+++ b/src/components/smart/WizardPage/WizardPage.tsx
@@ -154,8 +154,8 @@ class WizardPage extends React.Component<Props, State> {
   }
 
   handleEnterKey() {
-    if (this.contentRef && !this.contentRef.isNextButtonDisabled()) {
-      this.handleNextClick()
+    if (this.contentRef && !this.contentRef.nextButtonDisabled) {
+      this.contentRef.handleNextClick()
     }
   }
 

--- a/src/components/ui/Dropdowns/AutocompleteDropdown/AutocompleteDropdown.tsx
+++ b/src/components/ui/Dropdowns/AutocompleteDropdown/AutocompleteDropdown.tsx
@@ -100,6 +100,20 @@ const ListItem = styled.div<any>`
     background: ${ThemePalette.primary};
     color: white;
   }
+
+  ${props => (props.disabled ? css`
+    cursor: default;
+    color: ${ThemePalette.grayscale[3]};
+    &:hover {
+      background: white;
+      color: ${ThemePalette.grayscale[3]};
+    }
+  ` : '')}
+
+`
+const SubtitleLabel = styled.div`
+  display: flex;
+  font-size: 11px;
 `
 const DuplicatedLabel = styled.div<any>`
   display: flex;
@@ -257,6 +271,10 @@ class AutocompleteDropdown extends React.Component<Props, State> {
   }
 
   handleItemClick(item: any) {
+    if (item.disabled) {
+      return
+    }
+
     this.setState({
       showDropdownList: false,
       firstItemHover: false,
@@ -405,8 +423,12 @@ class AutocompleteDropdown extends React.Component<Props, State> {
               selected={value !== null && value === selectedValue}
               dim={this.props.dimNullValue && value == null}
               arrowSelected={i === this.state.arrowSelection}
+              disabled={item.disabled}
             >
               {label}
+              {item.subtitleLabel ? (
+                <SubtitleLabel>{item.subtitleLabel}</SubtitleLabel>
+              ) : null}
               {duplicatedLabel ? <DuplicatedLabel> (<span>{value || ''}</span>)</DuplicatedLabel> : ''}
             </ListItem>
           )

--- a/src/components/ui/Dropdowns/Dropdown/Dropdown.tsx
+++ b/src/components/ui/Dropdowns/Dropdown/Dropdown.tsx
@@ -140,7 +140,6 @@ const ListItem = styled.div<any>`
   transition: all ${ThemeProps.animations.swift};
   padding-left: ${(props: any) => props.paddingLeft}px;
   word-break: break-word;
-  ${props => (props.disabled ? css`cursor: default;` : '')}
 
   &:first-child {
     border-top-left-radius: ${ThemeProps.borderRadius};
@@ -159,6 +158,14 @@ const ListItem = styled.div<any>`
       stroke: white;
     }
   }
+
+  ${props => (props.disabled ? css`
+    cursor: default;
+    &:hover {
+      background: white;
+      color: ${ThemePalette.grayscale[3]};
+    }
+  ` : '')}
 `
 const SubtitleLabel = styled.div`
   display: flex;

--- a/src/components/ui/FieldInput/FieldInput.tsx
+++ b/src/components/ui/FieldInput/FieldInput.tsx
@@ -63,6 +63,13 @@ const Label = styled.div<any>`
     opacity: 0.5;
   ` : '')}
 `
+const WarningLabel = styled.div<{ fontSize: number }>`
+  font-weight: 300;
+  font-size: ${props => props.fontSize}px;
+  color: ${ThemePalette.grayscale[3]};
+  display: inline-block;
+  margin-left: 4px;
+`
 const LabelText = styled.span``
 const Asterisk = styled.div<any>`
   ${ThemeProps.exactSize('16px')}
@@ -99,6 +106,7 @@ type Props = {
   width?: number,
   label?: string,
   description?: string,
+  warning?: string,
   addNullValue?: boolean,
   nullableBoolean?: boolean,
   labelRenderer?: ((prop: string) => string) | null,
@@ -392,6 +400,7 @@ class FieldInput extends React.Component<Props> {
     }
 
     const description = this.props.description
+    const warning = this.props.warning
     const marginRight = this.props.layout === 'modal' || description || this.props.required ? '24px' : 0
 
     return (
@@ -405,7 +414,12 @@ class FieldInput extends React.Component<Props> {
           {this.props.label}
         </LabelText>
         {description ? <InfoIcon text={description} marginLeft={-20} marginBottom={this.props.layout === 'page' ? null : 0} /> : null}
+        {/*
+        {warning ? <InfoIcon warning filled text={warning}
+         marginLeft={3} marginBottom={this.props.layout === 'page' ? null : 0} style={{ transform: 'scale(0.8)' }} /> : null}
+        */}
         {this.props.layout === 'page' && Boolean(this.props.required) ? <Asterisk marginLeft={description ? '4px' : '-16px'} /> : null}
+        {warning ? <WarningLabel fontSize={this.props.layout === 'page' ? 10 : 6}>{warning}</WarningLabel> : null}
       </Label>
     )
   }

--- a/src/components/ui/FieldInput/FieldInput.tsx
+++ b/src/components/ui/FieldInput/FieldInput.tsx
@@ -37,6 +37,7 @@ import FileInput from '@src/components/ui/FileInput'
 import asteriskImage from './images/asterisk.svg'
 
 const Wrapper = styled.div<any>`
+  position: relative;
   ${props => (props.layout === 'page' ? css`
     display: flex;
     flex-direction: ${props.inline ? 'row' : 'column'};
@@ -77,6 +78,13 @@ const Asterisk = styled.div<any>`
   background: url('${asteriskImage}') center no-repeat;
   margin-bottom: -3px;
   margin-left: ${props => props.marginLeft || '0px'};
+`
+const HighlightLabel = styled.div<{ rightMargin: number }>`
+  position: absolute;
+  bottom: -13px;
+  font-size: 10px;
+  right: ${props => `${props.rightMargin}px`};
+  color: ${ThemePalette.alert};
 `
 
 type Props = {
@@ -194,6 +202,7 @@ class FieldInput extends React.Component<Props> {
 
     return (
       <PropertiesTable
+        highlight={this.props.highlight}
         width={this.props.width}
         properties={this.props.properties}
         valueCallback={field => this.props.valueCallback && this.props.valueCallback(field)}
@@ -414,10 +423,6 @@ class FieldInput extends React.Component<Props> {
           {this.props.label}
         </LabelText>
         {description ? <InfoIcon text={description} marginLeft={-20} marginBottom={this.props.layout === 'page' ? null : 0} /> : null}
-        {/*
-        {warning ? <InfoIcon warning filled text={warning}
-         marginLeft={3} marginBottom={this.props.layout === 'page' ? null : 0} style={{ transform: 'scale(0.8)' }} /> : null}
-        */}
         {this.props.layout === 'page' && Boolean(this.props.required) ? <Asterisk marginLeft={description ? '4px' : '-16px'} /> : null}
         {warning ? <WarningLabel fontSize={this.props.layout === 'page' ? 10 : 6}>{warning}</WarningLabel> : null}
       </Label>
@@ -434,6 +439,7 @@ class FieldInput extends React.Component<Props> {
       >
         {this.renderLabel()}
         {this.renderInput()}
+        {this.props.highlight ? <HighlightLabel rightMargin={this.props.type === 'object' ? 21 : 0}>Required field</HighlightLabel> : null}
       </Wrapper>
     )
   }

--- a/src/components/ui/FieldInput/FieldInput.tsx
+++ b/src/components/ui/FieldInput/FieldInput.tsx
@@ -195,7 +195,7 @@ class FieldInput extends React.Component<Props> {
           }
         }}
         labelRenderer={this.props.labelRenderer}
-        hideRequiredSymbol={this.props.layout === 'page'}
+        // hideRequiredSymbol={this.props.layout === 'page'}
         disabledLoading={this.props.disabledLoading}
         disabled={this.props.disabled}
       />

--- a/src/components/ui/InfoIcon/InfoIcon.tsx
+++ b/src/components/ui/InfoIcon/InfoIcon.tsx
@@ -32,7 +32,7 @@ type Props = {
   marginLeft?: number | null,
   marginBottom?: number | null,
   className?: string,
-  style?: any,
+  style?: React.CSSProperties,
   warning?: boolean,
   filled?: boolean,
 }

--- a/src/components/ui/PropertiesTable/PropertiesTable.tsx
+++ b/src/components/ui/PropertiesTable/PropertiesTable.tsx
@@ -25,11 +25,16 @@ import Dropdown from '@src/components/ui/Dropdowns/Dropdown'
 import AutocompleteDropdown from '@src/components/ui/Dropdowns/AutocompleteDropdown'
 import { Field, EnumItem, isEnumSeparator } from '@src/@types/Field'
 
-const Wrapper = styled.div<any>`
+const Wrapper = styled.div<{
+  width?: number,
+  highlight?: boolean,
+  disabled?: boolean,
+  disabledLoading?: boolean
+}>`
   display: flex;
   ${props => (props.width ? `width: ${props.width - 2}px;` : '')}
   flex-direction: column;
-  border: 1px solid ${ThemePalette.grayscale[2]};
+  border: 1px solid ${props => (props.highlight ? ThemePalette.alert : ThemePalette.grayscale[2])};
   border-radius: ${ThemeProps.borderRadius};
   ${props => (props.disabled ? css`
     opacity: 0.5;
@@ -70,6 +75,7 @@ const Row = styled.div<any>`
 `
 type Props = {
   properties: Field[],
+  highlight?: boolean,
   onChange: (property: Field, value: any) => void,
   valueCallback: (property: Field) => any,
   hideRequiredSymbol?: boolean,
@@ -200,6 +206,7 @@ class PropertiesTable extends React.Component<Props> {
         disabled={this.props.disabled}
         disabledLoading={this.props.disabledLoading}
         width={width}
+        highlight={this.props.highlight}
       >
         {this.props.properties.map(prop => (
           <Row key={prop.name}>

--- a/src/components/ui/PropertiesTable/PropertiesTable.tsx
+++ b/src/components/ui/PropertiesTable/PropertiesTable.tsx
@@ -193,11 +193,13 @@ class PropertiesTable extends React.Component<Props> {
   }
 
   render() {
+    const hasRequiredInputs = this.props.properties.some(prop => prop.required && prop.type === 'string')
+    const width = this.props.width && hasRequiredInputs ? this.props.width - 20 : this.props.width
     return (
       <Wrapper
         disabled={this.props.disabled}
         disabledLoading={this.props.disabledLoading}
-        width={this.props.width}
+        width={width}
       >
         {this.props.properties.map(prop => (
           <Row key={prop.name}>

--- a/src/plugins/aws/OptionsSchemaPlugin.ts
+++ b/src/plugins/aws/OptionsSchemaPlugin.ts
@@ -13,7 +13,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 import type { InstanceScript } from '@src/@types/Instance'
-import { Field, isEnumSeparator } from '@src/@types/Field'
+import { Field } from '@src/@types/Field'
 import type { OptionValues, StorageMap } from '@src/@types/Endpoint'
 import type { SchemaProperties, SchemaDefinitions } from '@src/@types/Schema'
 import type { NetworkMap } from '@src/@types/Network'
@@ -23,6 +23,7 @@ import DefaultOptionsSchemaPlugin, {
   defaultGetMigrationImageMap,
   defaultFillFieldValues,
   defaultFillMigrationImageMapValues,
+  removeExportImageFieldValues,
 } from '../default/OptionsSchemaPlugin'
 
 export default class OptionsSchemaParser {
@@ -69,20 +70,7 @@ export default class OptionsSchemaParser {
       requiresWindowsImage,
     })) {
       defaultFillFieldValues(field, option)
-
-      if (field.name === 'export_image') {
-        field.enum?.forEach(exportImageValue => {
-          if (typeof exportImageValue === 'string' || isEnumSeparator(exportImageValue)) {
-            return
-          }
-          // @ts-ignore
-          const osType = exportImageValue.os_type
-          if (osType !== 'unknown' && osType !== 'linux') {
-            exportImageValue.disabled = true
-            exportImageValue.subtitleLabel = `Source plugins rely on a Linux-based temporary virtual machine to perform data exports, but the platform reports this image to be of OS type '${osType}'.`
-          }
-        })
-      }
+      removeExportImageFieldValues(field)
     }
   }
 

--- a/src/plugins/aws/OptionsSchemaPlugin.ts
+++ b/src/plugins/aws/OptionsSchemaPlugin.ts
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2021  Cloudbase Solutions SRL
+Copyright (C) 2022  Cloudbase Solutions SRL
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as
 published by the Free Software Foundation, either version 3 of the
@@ -13,20 +13,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 import type { InstanceScript } from '@src/@types/Instance'
-import type { Field } from '@src/@types/Field'
+import { Field, isEnumSeparator } from '@src/@types/Field'
 import type { OptionValues, StorageMap } from '@src/@types/Endpoint'
 import type { SchemaProperties, SchemaDefinitions } from '@src/@types/Schema'
 import type { NetworkMap } from '@src/@types/Network'
 import { UserScriptData } from '@src/@types/MainItem'
 import DefaultOptionsSchemaPlugin, {
-  defaultFillMigrationImageMapValues,
-  defaultFillFieldValues,
   defaultGetDestinationEnv,
   defaultGetMigrationImageMap,
+  defaultFillFieldValues,
+  defaultFillMigrationImageMapValues,
 } from '../default/OptionsSchemaPlugin'
 
 export default class OptionsSchemaParser {
-  static migrationImageMapFieldName = 'migr_template_map'
+  static migrationImageMapFieldName = DefaultOptionsSchemaPlugin.migrationImageMapFieldName
 
   static parseSchemaToFields(opts: {
     schema: SchemaProperties,
@@ -34,43 +34,30 @@ export default class OptionsSchemaParser {
     dictionaryKey?: string,
     requiresWindowsImage?: boolean,
   }) {
-    const fields = DefaultOptionsSchemaPlugin.parseSchemaToFields(opts)
-    fields.forEach(f => {
-      if (
-        f.name !== 'migr_template_username_map'
-        && f.name !== 'migr_template_password_map'
-        && f.name !== 'migr_template_map'
-      ) {
-        return
-      }
-
-      const password = f.name === 'migr_template_password_map'
-      f.properties = [
-        {
-          type: 'string',
-          name: 'windows',
-          required: opts.requiresWindowsImage,
-          password,
-        },
-        {
-          type: 'string',
-          name: 'linux',
-          required: true,
-          password,
-        },
-      ]
-    })
-
+    const fields: Field[] = DefaultOptionsSchemaPlugin.parseSchemaToFields(opts)
+    const exportImage = fields.find(f => f.name === 'export_image')
+    if (exportImage) {
+      exportImage.required = true
+    }
     return fields
   }
 
   static sortFields(fields: Field[]) {
     DefaultOptionsSchemaPlugin.sortFields(fields)
+    fields.sort((f1, f2) => {
+      // sort region first
+      if (f1.name === 'region') {
+        return -1
+      }
+      if (f2.name === 'region') {
+        return 1
+      }
+      return 0
+    })
   }
 
   static fillFieldValues(opts: { field: Field, options: OptionValues[], requiresWindowsImage: boolean }) {
     const { field, options, requiresWindowsImage } = opts
-
     const option = options.find(f => f.name === field.name)
     if (!option) {
       return
@@ -82,10 +69,24 @@ export default class OptionsSchemaParser {
       requiresWindowsImage,
     })) {
       defaultFillFieldValues(field, option)
+
+      if (field.name === 'export_image') {
+        field.enum?.forEach(exportImageValue => {
+          if (typeof exportImageValue === 'string' || isEnumSeparator(exportImageValue)) {
+            return
+          }
+          // @ts-ignore
+          const osType = exportImageValue.os_type
+          if (osType !== 'unknown' && osType !== 'linux') {
+            exportImageValue.disabled = true
+            exportImageValue.subtitleLabel = `Source plugins rely on a Linux-based temporary virtual machine to perform data exports, but the platform reports this image to be of OS type '${osType}'.`
+          }
+        })
+      }
     }
   }
 
-  static getDestinationEnv(options?: { [prop: string]: any } | null, oldOptions?: any) {
+  static getDestinationEnv(options: { [prop: string]: any } | null, oldOptions?: any) {
     const env = {
       ...defaultGetDestinationEnv(options, oldOptions),
       ...defaultGetMigrationImageMap(
@@ -97,13 +98,13 @@ export default class OptionsSchemaParser {
     return env
   }
 
-  static getNetworkMap(networkMappings: NetworkMap[] | null | undefined) {
+  static getNetworkMap(networkMappings: NetworkMap[] | null) {
     return DefaultOptionsSchemaPlugin.getNetworkMap(networkMappings)
   }
 
   static getStorageMap(
-    defaultStorage?: { value: string | null, busType?: string | null },
-    storageMap?: StorageMap[] | null,
+    defaultStorage: { value: string | null, busType?: string | null },
+    storageMap: StorageMap[] | null,
     configDefault?: string | null,
   ) {
     return DefaultOptionsSchemaPlugin.getStorageMap(defaultStorage, storageMap, configDefault)

--- a/src/plugins/default/OptionsSchemaPlugin.ts
+++ b/src/plugins/default/OptionsSchemaPlugin.ts
@@ -16,7 +16,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import Utils from '@src/utils/ObjectUtils'
 
-import type { Field } from '@src/@types/Field'
+import { Field, isEnumSeparator } from '@src/@types/Field'
 import type { OptionValues, StorageMap } from '@src/@types/Endpoint'
 import type { SchemaProperties, SchemaDefinitions } from '@src/@types/Schema'
 import type { NetworkMap } from '@src/@types/Network'
@@ -39,6 +39,22 @@ export const defaultFillFieldValues = (field: Field, option: OptionValues) => {
   }
   if (field.type === 'boolean' && option.config_default != null) {
     field.default = typeof option.config_default === 'boolean' ? option.config_default : option.config_default === 'true'
+  }
+}
+
+export const removeExportImageFieldValues = (field: Field) => {
+  if (field.name === 'export_image') {
+    field.enum = field.enum?.filter(exportImageValue => {
+      if (typeof exportImageValue === 'string' || isEnumSeparator(exportImageValue)) {
+        return true
+      }
+      // @ts-ignore
+      const isLinux = exportImageValue.os_type === 'linux' || exportImageValue.os_type === 'unknown'
+      if (!isLinux) {
+        field.warning = 'Only Linux images are listed.'
+      }
+      return isLinux
+    })
   }
 }
 

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -24,10 +24,12 @@ import AzureContentPlugin from './azure/ContentPlugin'
 import OpenstackContentPlugin from './openstack/ContentPlugin'
 
 import DefaultOptionsSchemaPlugin from './default/OptionsSchemaPlugin'
+import AwsOptionsSchemaPlugin from './aws/OptionsSchemaPlugin'
 import OvmOptionsSchemaPlugin from './ovm/OptionsSchemaPlugin'
 import VmwareOptionsSchemaPlugin from './vmware_vsphere/OptionsSchemaPlugin'
 import OpenstackOptionsSchemaPlugin from './openstack/OptionsSchemaPlugin'
 import OvirtOptionsSchemaPlugin from './ovirt/OptionsSchemaPlugin'
+import AzureOptionsSchemaPlugin from './azure/OptionsSchemaPlugin'
 
 import DefaultInstanceInfoPlugin from './default/InstanceInfoPlugin'
 import OciInstanceInfoPlugin from './oci/InstanceInfoPlugin'
@@ -57,10 +59,12 @@ export const OptionsSchemaPlugin = {
   for: (provider: ProviderTypes) => {
     const map = {
       default: DefaultOptionsSchemaPlugin,
+      aws: AwsOptionsSchemaPlugin,
       oracle_vm: OvmOptionsSchemaPlugin,
       openstack: OpenstackOptionsSchemaPlugin,
       vmware_vsphere: VmwareOptionsSchemaPlugin,
       ovirt: OvirtOptionsSchemaPlugin,
+      azure: AzureOptionsSchemaPlugin,
     }
     if (hasKey(map, provider)) {
       return map[provider]

--- a/src/plugins/openstack/OptionsSchemaPlugin.ts
+++ b/src/plugins/openstack/OptionsSchemaPlugin.ts
@@ -13,7 +13,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 import type { InstanceScript } from '@src/@types/Instance'
-import { Field, isEnumSeparator } from '@src/@types/Field'
+import { Field } from '@src/@types/Field'
 import type { OptionValues, StorageMap } from '@src/@types/Endpoint'
 import type { SchemaProperties, SchemaDefinitions } from '@src/@types/Schema'
 import type { NetworkMap } from '@src/@types/Network'
@@ -23,6 +23,7 @@ import DefaultOptionsSchemaPlugin, {
   defaultGetMigrationImageMap,
   defaultFillFieldValues,
   defaultFillMigrationImageMapValues,
+  removeExportImageFieldValues,
 } from '../default/OptionsSchemaPlugin'
 
 export default class OptionsSchemaParser {
@@ -73,19 +74,7 @@ export default class OptionsSchemaParser {
             DefaultOptionsSchemaPlugin.fillFieldValues({
               field: f, options, customFieldName: f.name.split('/')[1], requiresWindowsImage,
             })
-            if (f.name === 'export_image') {
-              f.enum?.forEach(exportImageValue => {
-                if (typeof exportImageValue === 'string' || isEnumSeparator(exportImageValue)) {
-                  return
-                }
-                // @ts-ignore
-                const osType = exportImageValue.os_type
-                if (osType !== 'unknown' && osType !== 'linux') {
-                  exportImageValue.disabled = true
-                  exportImageValue.subtitleLabel = `Source plugins rely on a Linux-based temporary virtual machine to perform data exports, but the platform reports this image to be of OS type '${osType}'.`
-                }
-              })
-            }
+            removeExportImageFieldValues(f)
           })
         }
       })

--- a/src/plugins/ovirt/OptionsSchemaPlugin.ts
+++ b/src/plugins/ovirt/OptionsSchemaPlugin.ts
@@ -28,12 +28,13 @@ import DefaultOptionsSchemaPlugin, {
 export default class OptionsSchemaParser {
   static migrationImageMapFieldName = 'migr_template_map'
 
-  static parseSchemaToFields(
+  static parseSchemaToFields(opts: {
     schema: SchemaProperties,
-    schemaDefinitions: SchemaDefinitions | null | undefined,
-    dictionaryKey: string,
-  ) {
-    const fields: Field[] = DefaultOptionsSchemaPlugin.parseSchemaToFields(schema, schemaDefinitions, dictionaryKey)
+    schemaDefinitions?: SchemaDefinitions | null | undefined,
+    dictionaryKey?: string,
+    requiresWindowsImage?: boolean,
+  }) {
+    const fields: Field[] = DefaultOptionsSchemaPlugin.parseSchemaToFields(opts)
     fields.forEach(f => {
       if (
         f.name !== 'migr_template_username_map'
@@ -64,16 +65,19 @@ export default class OptionsSchemaParser {
     DefaultOptionsSchemaPlugin.sortFields(fields)
   }
 
-  static fillFieldValues(field: Field, options: OptionValues[]) {
+  static fillFieldValues(opts: { field: Field, options: OptionValues[], requiresWindowsImage: boolean }) {
+    const { field, options, requiresWindowsImage } = opts
+
     const option = options.find(f => f.name === field.name)
     if (!option) {
       return
     }
-    if (!defaultFillMigrationImageMapValues(
+    if (!defaultFillMigrationImageMapValues({
       field,
       option,
-      this.migrationImageMapFieldName,
-    )) {
+      migrationImageMapFieldName: this.migrationImageMapFieldName,
+      requiresWindowsImage,
+    })) {
       defaultFillFieldValues(field, option)
     }
   }

--- a/src/sources/MigrationSource.ts
+++ b/src/sources/MigrationSource.ts
@@ -180,9 +180,7 @@ class MigrationSource {
       || (opts.updatedStorageMappings && opts.updatedStorageMappings.length)) {
       payload.migration.storage_mappings = {
         ...opts.storageMappings,
-        ...destParser
-          .getStorageMap(opts.updatedDefaultStorage
-            || opts.defaultStorage, opts.updatedStorageMappings),
+        ...destParser.getStorageMap(opts.updatedDefaultStorage || opts.defaultStorage, opts.updatedStorageMappings),
       }
     }
     const { migration } = opts

--- a/src/sources/ProviderSource.ts
+++ b/src/sources/ProviderSource.ts
@@ -34,9 +34,15 @@ class ProviderSource {
     return response.data.providers
   }
 
-  async loadOptionsSchema(opts: { providerName: ProviderTypes, optionsType: 'source' | 'destination', useCache?: boolean | null, quietError?: boolean | null }): Promise<Field[]> {
+  async loadOptionsSchema(opts: {
+    providerName: ProviderTypes,
+    optionsType: 'source' | 'destination',
+    useCache?: boolean | null,
+    quietError?: boolean | null,
+    requiresWindowsImage?: boolean,
+  }): Promise<Field[]> {
     const {
-      providerName, optionsType, useCache, quietError,
+      providerName, optionsType, useCache, quietError, requiresWindowsImage,
     } = opts
     const schemaTypeInt = optionsType === 'source' ? providerTypes.SOURCE_REPLICA : providerTypes.TARGET_REPLICA
 
@@ -49,7 +55,9 @@ class ProviderSource {
       const schema = optionsType === 'source' ? response?.data?.schemas?.source_environment_schema : response?.data?.schemas?.destination_environment_schema
       let fields = []
       if (schema) {
-        fields = SchemaParser.optionsSchemaToFields(providerName, schema, `${providerName}-${optionsType}`)
+        fields = SchemaParser.optionsSchemaToFields({
+          provider: providerName, schema, dictionaryKey: `${providerName}-${optionsType}`, requiresWindowsImage,
+        })
       }
       return fields
     } catch (err) {

--- a/src/sources/Schemas.ts
+++ b/src/sources/Schemas.ts
@@ -32,10 +32,15 @@ class SchemaParser {
     return fields
   }
 
-  static optionsSchemaToFields(provider: ProviderTypes, schema: any, dictionaryKey: string) {
+  static optionsSchemaToFields(opts: { provider: ProviderTypes, schema: any, dictionaryKey: string, requiresWindowsImage?: boolean }) {
+    const {
+      provider, schema, dictionaryKey, requiresWindowsImage,
+    } = opts
     const parser = OptionsSchemaPlugin.for(provider)
     const schemaRoot = schema.oneOf ? schema.oneOf[0] : schema
-    const fields = parser.parseSchemaToFields(schemaRoot, schema.definitions, dictionaryKey)
+    const fields = parser.parseSchemaToFields({
+      schema: schemaRoot, schemaDefinitions: schema.definitions, dictionaryKey, requiresWindowsImage,
+    })
     parser.sortFields(fields)
     return fields
   }
@@ -59,7 +64,7 @@ class SchemaParser {
   }
 
   static minionPoolOptionsSchemaToFields(provider: ProviderTypes, schema: any, dictionaryKey: string) {
-    let fields = this.optionsSchemaToFields(provider, schema, dictionaryKey)
+    let fields = this.optionsSchemaToFields({ provider, schema, dictionaryKey })
     const parsers = MinionPoolSchemaPlugin.for(provider)
     fields = parsers.minionPoolTransformOptionsFields(fields)
     return fields

--- a/src/stores/MinionPoolStore.ts
+++ b/src/stores/MinionPoolStore.ts
@@ -185,7 +185,7 @@ class MinionPoolStore {
     }
     this.minionPoolEnvSchema.forEach(field => {
       const parser = OptionsSchemaPlugin.for(provider)
-      parser.fillFieldValues(field, options)
+      parser.fillFieldValues({ field, options, requiresWindowsImage: false })
     })
     this.minionPoolEnvSchema = [...this.minionPoolEnvSchema]
   }

--- a/src/stores/ProviderStore.ts
+++ b/src/stores/ProviderStore.ts
@@ -25,6 +25,7 @@ import { OptionsSchemaPlugin } from '@src/plugins'
 import type { OptionValues } from '@src/@types/Endpoint'
 import type { Field } from '@src/@types/Field'
 import type { Providers, ProviderTypes } from '@src/@types/Providers'
+import ObjectUtils from '@src/utils/ObjectUtils'
 import regionStore from './RegionStore'
 
 export const getFieldChangeOptions = (config: {
@@ -304,6 +305,7 @@ class ProviderStore {
     const providerType = optionsType === 'source' ? providerTypes.SOURCE_OPTIONS : providerTypes.DESTINATION_OPTIONS
 
     await this.loadProviders()
+    await ObjectUtils.waitFor(() => !this.providersLoading)
     if (!this.providers) {
       return []
     }


### PR DESCRIPTION
The following changes are now applied:
- The Next button is no longer disabled in wizard source and destination
options when required field values are missing.
- When clicking the Next button, the required fields with missing values
are *highlighted* and the wizard doesn't go to the next page.
- As part of *highlighting* a field, a small label is displayed besides
that field saying that the field is required. This label is also shown
everywhere there are required fields: new endpoint, new user etc.