### PR TITLE
Fix horizontal scroll appearing when zooming out

### DIFF
--- a/src/components/modules/WizardModule/WizardOptions/WizardOptions.tsx
+++ b/src/components/modules/WizardModule/WizardOptions/WizardOptions.tsx
@@ -53,6 +53,7 @@ const Fields = styled.div<any>`
   display: flex;
   flex-direction: column;
   overflow: auto;
+  padding-right: 4px;
 `
 const Group = styled.div<any>`
   display: flex;


### PR DESCRIPTION
Fixes an issue where at certain browser zoom levels, horizontal scroll
might appear in the Wizard Page.