### PR TITLE
Fix "Projects not found" routing error

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -215,7 +215,7 @@ class App extends React.Component<{}, State> {
             {renderOptionalRoute({ name: 'planning', component: AssessmentDetailsPage, path: '/assessment/:info' })}
             {renderOptionalRoute({ name: 'users', component: UsersPage, exact: true })}
             {renderOptionalRoute({ name: 'users', component: UserDetailsPage, path: '/users/:id' })}
-            {renderOptionalRoute({ name: 'users', component: ProjectsPage, exact: true })}
+            {renderOptionalRoute({ name: 'projects', component: ProjectsPage, exact: true })}
             {renderOptionalRoute({ name: 'projects', component: ProjectDetailsPage, path: '/projects/:id' })}
             {renderOptionalRoute({ name: 'logging', component: LogsPage })}
             {renderRoute('/streamlog', LogStreamPage)}


### PR DESCRIPTION
Fixes a routing typo that raises a not found error when navigating to
the Projects page.