### PR TITLE
Reload OCI options on migration image map change

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -45,8 +45,8 @@ const conf: Config = {
   bareMetalEndpointName: 'appliance-metal-hub',
 
   /**
-   * The list of providers for which and extra source or destination options API call will be made,
-   * if the required fields have any value set.
+   * The list of providers for which and extra source or destination options API call will be made.
+   * The API call will be made only if all the required fields have values.
    * If `requiredValues` is provided, the field specified there needs to have a
    * certain value (specified in values)
    * in order to make the options API call.
@@ -83,6 +83,7 @@ const conf: Config = {
       name: 'oci',
       types: ['destination'],
       requiredFields: ['compartment', 'availability_domain', 'vcn_compartment'],
+      relistFields: ['migr_image_map', 'migr_image'],
     },
     {
       name: 'vmware_vsphere',

--- a/src/components/modules/TransferModule/TransferItemModal/TransferItemModal.tsx
+++ b/src/components/modules/TransferModule/TransferItemModal/TransferItemModal.tsx
@@ -334,7 +334,7 @@ class TransferItemModal extends React.Component<Props, State> {
       const endpoint = type === 'source' ? this.props.sourceEndpoint : this.props.destinationEndpoint
       try {
         await this.loadOptions(endpoint, type, useCache)
-        this.loadExtraOptions(null, type, useCache)
+        this.loadExtraOptions({ type, useCache })
       } catch (err) {
         if (type === 'source') {
           this.setState(prevState => {
@@ -376,7 +376,15 @@ class TransferItemModal extends React.Component<Props, State> {
     })
   }
 
-  loadExtraOptions(field: Field | null, type: 'source' | 'destination', useCache?: boolean) {
+  loadExtraOptions(opts: {
+    field?: Field,
+    type: 'source' | 'destination',
+    useCache?: boolean,
+    parentFieldName?: string
+  }) {
+    const {
+      field, type, useCache, parentFieldName,
+    } = opts
     const endpoint = type === 'source' ? this.props.sourceEndpoint : this.props.destinationEndpoint
     const env = type === 'source' ? this.props.replica.source_environment : this.props.replica.destination_environment
     const stateEnv = type === 'source' ? this.state.sourceData : this.state.destinationData
@@ -388,8 +396,9 @@ class TransferItemModal extends React.Component<Props, State> {
         ...env,
         ...stateEnv,
       },
-      field,
+      field: field || null,
       type,
+      parentFieldName,
     })
 
     if (!envData) {
@@ -509,7 +518,7 @@ class TransferItemModal extends React.Component<Props, State> {
 
     const handleStateUpdate = () => {
       if (field.type !== 'string' || field.enum) {
-        this.loadExtraOptions(field, type)
+        this.loadExtraOptions({ field, type, parentFieldName })
       }
       this.validateOptions(type)
     }

--- a/src/stores/ProviderStore.ts
+++ b/src/stores/ProviderStore.ts
@@ -34,13 +34,14 @@ export const getFieldChangeOptions = (config: {
   data: any,
   field: Field | null,
   type: 'source' | 'destination',
+  parentFieldName?: string,
 }) => {
   const {
-    providerName, schema, data, field, type,
+    providerName, schema, data, field, type, parentFieldName,
   } = config
   const providerWithEnvOptions = configLoader.config.extraOptionsApiCalls
     .find(p => p.name === providerName && p.types.find(t => t === type))
-
+  const fieldName = parentFieldName || field?.name || ''
   if (!providerName || !providerWithEnvOptions) {
     return null
   }
@@ -80,12 +81,11 @@ export const getFieldChangeOptions = (config: {
   const requiredValidFields = requiredFields.filter(filterValidField)
   const relistValidFields = relistFields?.filter(filterValidField)
 
-  const relistField = relistFields?.find(fn => fn === field?.name)
+  const relistField = relistFields?.find(fn => fn === fieldName)
 
-  const isCurrentFieldValid = field ? (
-    requiredValidFields.find(fn => fn === field.name)
-    || relistField
-  ) : true
+  const isCurrentFieldValid = field
+    ? requiredValidFields.find(fn => fn === fieldName) || relistField
+    : true
   if (requiredValidFields.length !== requiredFields.length || !isCurrentFieldValid) {
     return null
   }


### PR DESCRIPTION
This applies to the Replica / Migration wizard.

This commit also contains reloading of options when the minion pool
migration image changes when creating a minion pool.