### PR TITLE
Fix networks not loading properly in Edit Replica

### DIFF
--- a/src/components/modules/TransferModule/TransferItemModal/TransferItemModal.tsx
+++ b/src/components/modules/TransferModule/TransferItemModal/TransferItemModal.tsx
@@ -480,19 +480,20 @@ class TransferItemModal extends React.Component<Props, State> {
     const stateEnv =
       type === "source" ? this.state.sourceData : this.state.destinationData;
 
-    const envData = getFieldChangeOptions({
+    const envData = ObjectUtils.mergeDeep(env, stateEnv);
+    const changedEnvData = getFieldChangeOptions({
       providerName: endpoint.type,
       schema:
         type === "source"
           ? providerStore.sourceSchema
           : providerStore.destinationSchema,
-      data: ObjectUtils.mergeDeep(env, stateEnv),
+      data: envData,
       field: field || null,
       type,
       parentFieldName,
     });
 
-    if (!envData) {
+    if (!changedEnvData) {
       return;
     }
     providerStore.getOptionsValues({
@@ -879,7 +880,9 @@ class TransferItemModal extends React.Component<Props, State> {
           ...migrationFields.map(f => f.name),
         ]}
         dictionaryKey={dictionaryKey}
-        executeNowOptionsDisabled={!providerStore.hasExecuteNowOptions(this.props.sourceEndpoint.type)}
+        executeNowOptionsDisabled={
+          !providerStore.hasExecuteNowOptions(this.props.sourceEndpoint.type)
+        }
       />
     );
   }


### PR DESCRIPTION
Fixes an issue where sometimes not all environment data was sent to the API when requesting the list of networks, thus the network might return an incomplete or incorrect list.