### PR TITLE
Fix migrations appearing twice when recreating

### DIFF
--- a/src/stores/MigrationStore.ts
+++ b/src/stores/MigrationStore.ts
@@ -179,9 +179,6 @@ class MigrationStore {
       userScriptData,
       minionPoolMappings,
     });
-    runInAction(() => {
-      this.migrations = [migration, ...this.migrations];
-    });
     return migration;
   }
 


### PR DESCRIPTION
When recreating multiple migrations simultaneously from the migrations list page, duplicated migrations might appear temporarily.