### PR TITLE
Fix default user domain for Keystone UI login

### DIFF
--- a/src/sources/UserSource.ts
+++ b/src/sources/UserSource.ts
@@ -38,11 +38,11 @@ class UserSource {
     localStorage.setItem("userDomainName", domainName);
   }
 
-  getDomainName(): string {
-    return (
-      localStorage.getItem("userDomainName") ||
-      configLoader.config.defaultUserDomain
-    );
+  get domainName(): string {
+    return configLoader.config.showUserDomainInput
+      ? localStorage.getItem("userDomainName") ||
+          configLoader.config.defaultUserDomain
+      : configLoader.config.defaultUserDomain;
   }
 
   async login(userData: Credentials): Promise<any> {

--- a/src/stores/UserStore.ts
+++ b/src/stores/UserStore.ts
@@ -52,7 +52,7 @@ class UserStore {
   @observable allUsersLoading = false;
 
   get domainName(): string {
-    return UserSource.getDomainName();
+    return UserSource.domainName;
   }
 
   saveDomainName(domainName: string) {


### PR DESCRIPTION
The `defaultUserDomain` option from the config file was previously ignored if a successful login was already done with a different user domain in the same browser.

This is fixed by always using the `defaultUserDomain` option when logging in, if `showUserDomainInput` is false. If `showUserDomainInput` is true, then the user domain input is shown when logging in and the behaviour is kept as it was previously, where the last successful user domain is pre-filled in the user domain input.