### PR TITLE
Fix UI crash when selecting `null` value

### DIFF
--- a/src/components/modules/TransferModule/TransferItemModal/TransferItemModal.tsx
+++ b/src/components/modules/TransferModule/TransferItemModal/TransferItemModal.tsx
@@ -473,10 +473,11 @@ class TransferItemModal extends React.Component<Props, State> {
       type === "source"
         ? this.props.sourceEndpoint
         : this.props.destinationEndpoint;
-    const env =
+    const env = ObjectUtils.clone(
       type === "source"
         ? this.props.replica.source_environment
-        : this.props.replica.destination_environment;
+        : this.props.replica.destination_environment
+    );
     const stateEnv =
       type === "source" ? this.state.sourceData : this.state.destinationData;
 
@@ -560,10 +561,12 @@ class TransferItemModal extends React.Component<Props, State> {
   }
 
   validateOptions(type: "source" | "destination") {
-    const env =
+    const env = ObjectUtils.clone(
       type === "source"
         ? this.props.replica.source_environment
-        : this.props.replica.destination_environment;
+        : this.props.replica.destination_environment
+    );
+
     const data =
       type === "source" ? this.state.sourceData : this.state.destinationData;
     const schema =

--- a/src/utils/ObjectUtils.ts
+++ b/src/utils/ObjectUtils.ts
@@ -163,6 +163,10 @@ class ObjectUtils {
 
     return this.mergeDeep(target, ...sources);
   }
+
+  static clone(obj: any) {
+    return JSON.parse(JSON.stringify(obj));
+  }
 }
 
 export default ObjectUtils;


### PR DESCRIPTION
The UI might previously crash when selecting a null value from a dropdown list in Edit Replica modal. This was caused by updating the global state of the replica when editing instead of the local state (the local state here is the changed replica from the Edit Replica modal).

This was fixed by cloning the global state into the local state before any changes are made.