### PR TITLE
Fix a vertical scroll bar appearing in the wizard

### DIFF
--- a/src/components/modules/WizardModule/WizardOptions/WizardOptions.tsx
+++ b/src/components/modules/WizardModule/WizardOptions/WizardOptions.tsx
@@ -48,6 +48,7 @@ const Options = styled.div<any>`
   display: flex;
   flex-direction: column;
   min-height: 0;
+  height: 100%;
 `;
 const Fields = styled.div<any>`
   ${props => (props.layout === "page" ? "" : "padding: 32px;")}
@@ -55,6 +56,7 @@ const Fields = styled.div<any>`
   flex-direction: column;
   overflow: auto;
   padding-right: ${props => (props.layout === "page" ? 4 : 24)}px;
+  flex-grow: 1;
 `;
 const Group = styled.div<any>`
   display: flex;


### PR DESCRIPTION
An unnecessary vertical scroll bar might have previously appeared in the wizard source \ target options when the last field in the list was required and highlighted with the requirement message.