### PR TITLE
Use text area for OCI’s custom_certificate_bundle

### DIFF
--- a/src/plugins/oci/ConnectionSchemaPlugin.ts
+++ b/src/plugins/oci/ConnectionSchemaPlugin.ts
@@ -17,14 +17,16 @@ import type { Field } from "@src/@types/Field";
 
 import ConnectionSchemaParserBase from "@src/plugins/default/ConnectionSchemaPlugin";
 
+const TEXT_AREA_FIELDS = ["private_key_data", "custom_certificate_bundle"];
+
 export default class ConnectionSchemaParser extends ConnectionSchemaParserBase {
   override parseSchemaToFields(schema: Schema): Field[] {
     const fields = super.parseSchemaToFields(schema);
-    const privateKeyField = fields.find(f => f.name === "private_key_data");
-    if (privateKeyField) {
-      privateKeyField.useTextArea = true;
-    }
-
+    fields.forEach(field => {
+      if (TEXT_AREA_FIELDS.includes(field.name)) {
+        field.useTextArea = true;
+      }
+    });
     return fields;
   }
 }


### PR DESCRIPTION
A text area is used for the field when creating an OCI endpoint.