### PR TITLE
Fix updating field to empty value in edit replica

### DIFF
--- a/src/plugins/default/OptionsSchemaPlugin.ts
+++ b/src/plugins/default/OptionsSchemaPlugin.ts
@@ -145,11 +145,10 @@ export const defaultGetDestinationEnv = (
 
   Object.keys(options).forEach(optionName => {
     const value = options[optionName];
-    if (
-      specialOptions.find(o => o === optionName) ||
-      value == null ||
-      value === ""
-    ) {
+    const oldValue = oldOptions?.[optionName];
+    const noValue =
+      (value == null || value === "") && (oldValue == null || oldValue === "");
+    if (specialOptions.find(o => o === optionName) || noValue) {
       return;
     }
     if (Array.isArray(value)) {


### PR DESCRIPTION
Previously, when editing a replica by completely removing the value from a field, the empty field was ignored when building the request body with the updated data.

This is now fixed by using the current state of the replica to determine whether the updated field value should be sent even if it is empty.