### PR TITLE
Show loading message in recreate migration modal

### DIFF
--- a/src/components/modules/TransferModule/ReplicaMigrationOptions/ReplicaMigrationOptions.tsx
+++ b/src/components/modules/TransferModule/ReplicaMigrationOptions/ReplicaMigrationOptions.tsx
@@ -32,6 +32,7 @@ import { INSTANCE_OSMORPHING_MINION_POOL_MAPPINGS } from "@src/components/module
 import { ThemeProps } from "@src/components/Theme";
 import replicaMigrationFields from "./replicaMigrationFields";
 import replicaMigrationImage from "./images/replica-migration.svg";
+import LoadingButton from "@src/components/ui/LoadingButton";
 
 const Wrapper = styled.div<any>`
   display: flex;
@@ -82,6 +83,7 @@ type Props = {
   minionPools: MinionPool[];
   loadingInstances: boolean;
   defaultSkipOsMorphing?: boolean | null;
+  migrating?: boolean;
   onCancelClick: () => void;
   onMigrateClick: (opts: {
     fields: Field[];
@@ -322,13 +324,17 @@ class ReplicaMigrationOptions extends React.Component<Props, State> {
           <Button secondary onClick={this.props.onCancelClick}>
             Cancel
           </Button>
-          <Button
-            onClick={() => {
-              this.migrate();
-            }}
-          >
-            Migrate
-          </Button>
+          {this.props.migrating ? (
+            <LoadingButton>Migrating ...</LoadingButton>
+          ) : (
+            <Button
+              onClick={() => {
+                this.migrate();
+              }}
+            >
+              Migrate
+            </Button>
+          )}
         </Buttons>
       </Wrapper>
     );


### PR DESCRIPTION
This commit updates the behavior of the recreate migration modal to show a loading message while the migration is being created. Previously, the modal was instantly dismissed and a notification was shown that the migration was created, requiring the user to click a redirect button for redirection.
With this change, the modal will remain open and display a loading message until the migration has finished being created, at which point it will automatically redirect to the migration status page.
This improves the user experience by providing more information and reducing the number of steps required to view the migration status.