### PR TITLE
Fix missing images in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# ![Coriolis Web](/src/components/atoms/Logo/images/coriolis-small-black.svg)
+# ![Coriolis Web](/src/components/ui/Logo/images/coriolis-small-black.svg)
 
 Web  GUI for [coriolis](https://github.com/cloudbase/coriolis)
 
-![CI Badge](https://github.com/cloudbase/coriolis-web/workflows/Master/badge.svg) [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
+[![Build and Test](https://github.com/cloudbase/coriolis-web/actions/workflows/build.yml/badge.svg)](https://github.com/cloudbase/coriolis-web/actions/workflows/build.yml) [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
 ## Install instructions
 


### PR DESCRIPTION
Resolved issue with missing images for the Coriolis logo and GitHub action status badge in the readme file. The images are now correctly displayed in the readme.