### PR TITLE
Remove duplicated URL in error notification

### DIFF
--- a/src/utils/ApiCallerHandlers.ts
+++ b/src/utils/ApiCallerHandlers.ts
@@ -9,9 +9,8 @@ const isOnLoginPage = (): boolean =>
 const truncateUrl = (url: string): string => {
   const MAX_LENGTH = 100;
   let relativePath = url.replace(/http(s)?:\/\/.*?\//, "/");
-  relativePath += relativePath;
   if (relativePath.length > MAX_LENGTH) {
-    relativePath = `${relativePath.substr(0, MAX_LENGTH)}...`;
+    relativePath = `${relativePath.substring(0, MAX_LENGTH)}...`;
   }
   return relativePath;
 };


### PR DESCRIPTION
Fixes an issue where the relative path of an URL may appear duplicated when a request gives an error.

Replaces the deprecated `substr` with `substring`.