### PR TITLE
Support optional properties in BM server object

### DIFF
--- a/src/@types/MetalHub.ts
+++ b/src/@types/MetalHub.ts
@@ -1,16 +1,16 @@
 export type MetalHubDisk = {
-  id: string;
+  id?: string;
   path: string;
-  name: string;
-  size: number;
-  physical_sector_size: number;
-  partitions: {
+  name?: string;
+  size?: number;
+  physical_sector_size?: number;
+  partitions?: {
     name: string;
-    path: string;
-    partition_uuid: string;
+    path?: string;
+    partition_uuid?: string;
     sectors: number;
     start_sector: number;
-    end_sector: number;
+    end_sector?: number;
   }[];
 };
 

--- a/src/components/modules/MetalHubModule/MetalHubServerDetailsContent/MetalHubServerDetailsContent.tsx
+++ b/src/components/modules/MetalHubModule/MetalHubServerDetailsContent/MetalHubServerDetailsContent.tsx
@@ -319,21 +319,29 @@ class MetalHubServerDetailsContent extends React.Component<Props, State> {
     });
   }
 
-  renderPartitions(partitions: MetalHubDisk["partitions"], sectorSize: number) {
+  renderPartitions(
+    partitions: MetalHubDisk["partitions"] = [],
+    sectorSize = 0
+  ) {
     return partitions.map(partition => {
+      if (!partition.partition_uuid) {
+        return null;
+      }
+
       const isOpened = Boolean(
         this.state.openedRows.find(i => i === partition.partition_uuid)
       );
       const size = partition.sectors * sectorSize;
-      const sizeString =
-        size < 1024 * 1024 * 1024
+      const sizeString = sectorSize
+        ? size < 1024 * 1024 * 1024
           ? `${(size / 1024 / 1024).toFixed(2)} MB`
-          : `${(size / 1024 / 1024 / 1024).toFixed(2)} GB`;
+          : `${(size / 1024 / 1024 / 1024).toFixed(2)} GB`
+        : "Size unavailable";
       return (
         <Row
           key={partition.partition_uuid}
           onClick={() => {
-            this.handleRowClick(partition.partition_uuid);
+            this.handleRowClick(partition.partition_uuid!);
           }}
         >
           <ArrowStyled
@@ -402,9 +410,11 @@ class MetalHubServerDetailsContent extends React.Component<Props, State> {
             <TableHeader key={disk.id}>
               <TableHeaderInfo>
                 {disk.name}{" "}
-                <HeaderSubtitle>
-                  {(disk.size / 1024 / 1024 / 1024).toFixed(2)} GB
-                </HeaderSubtitle>
+                {disk.size ? (
+                  <HeaderSubtitle>
+                    {(disk.size / 1024 / 1024 / 1024).toFixed(2)} GB
+                  </HeaderSubtitle>
+                ) : null}
               </TableHeaderInfo>
               <TableBodyContent>
                 {this.renderPartitions(


### PR DESCRIPTION
Previously, the UI could crash when accessing the Bare Metal server details page if it encountered a missing property in the Bare Metal object. This issue has been resolved by marking the relevant properties as optional.