### PR TITLE
Fix zipped files not being compressed

### DIFF
--- a/src/stores/EndpointStore.ts
+++ b/src/stores/EndpointStore.ts
@@ -223,7 +223,10 @@ class EndpointStore {
       })
     );
 
-    const content = await zip.generateAsync({ type: "blob" });
+    const content = await zip.generateAsync({
+      type: "blob",
+      compression: "DEFLATE",
+    });
     saveAs(content, "coriolis-endpoints.zip");
   }
 

--- a/src/stores/LogStore.ts
+++ b/src/stores/LogStore.ts
@@ -104,7 +104,10 @@ class LogStore {
       zip.file(`${response.name}.log`, response.content.data);
     });
     await downloadDiagnosticsIntoZip(zip);
-    const zipContent = await zip.generateAsync({ type: "blob" });
+    const zipContent = await zip.generateAsync({
+      type: "blob",
+      compression: "DEFLATE",
+    });
     saveAs(zipContent, "logs.zip");
     runInAction(() => {
       this.downloadingAllLogs = false;
@@ -125,7 +128,10 @@ class LogStore {
     this.generatingDiagnostics = true;
     const zip = new JSZip();
     await downloadDiagnosticsIntoZip(zip);
-    const zipContent = await zip.generateAsync({ type: "blob" });
+    const zipContent = await zip.generateAsync({
+      type: "blob",
+      compression: "DEFLATE",
+    });
     saveAs(zipContent, "diagnostics.zip");
     runInAction(() => {
       this.generatingDiagnostics = false;


### PR DESCRIPTION
When zipping files using the JSZip library, by default, files are not compressed when they are zipped (`store` compression level is used). The JSZip options have now been updated to actually compress the files.

The affected processes are the logs and endpoints downloads.