### PR TITLE
Fix 'Next' button disabled in Wizard Options

### DIFF
--- a/src/components/smart/WizardPage/WizardPage.tsx
+++ b/src/components/smart/WizardPage/WizardPage.tsx
@@ -542,6 +542,8 @@ class WizardPage extends React.Component<Props, State> {
       return;
     }
     try {
+      this.setState({ nextButtonDisabled: false });
+
       await providerStore.getOptionsValues({
         optionsType: type,
         endpointId: endpoint.id,


### PR DESCRIPTION
The 'Next' button in the Wizard Options interface is disabled after an options API call fails, and does not automatically re-enable even after the API call eventually succeeds.