### PR TITLE
Update WizardStorage style format and path display

### DIFF
--- a/src/components/modules/WizardModule/WizardStorage/WizardStorage.tsx
+++ b/src/components/modules/WizardModule/WizardStorage/WizardStorage.tsx
@@ -75,8 +75,9 @@ const StorageItem = styled.div<any>`
 `;
 const StorageImage = styled.div<any>`
   ${ThemeProps.exactSize("48px")}
-  background: url('${props =>
-    props.backend ? backendImage : diskImage}') center no-repeat;
+  background: url('
+    ${props => (props.backend ? backendImage : diskImage)}
+  ') center no-repeat;
   margin-right: 16px;
 `;
 const StorageTitle = styled.div<any>`
@@ -289,7 +290,7 @@ class WizardStorage extends React.Component<Props> {
           true,
         ];
       }
-      return [`${dashPaths[0]}-...-${dashPaths[1]}`, true];
+      return [`${dashPaths[0]}-...-${dashPaths[dashPaths.length - 1]}`, true];
     };
 
     return (


### PR DESCRIPTION
The path display logic can be tested with Openstack as a source. Previously, the path would be erroneously truncated to the first and second elements of the disk name array. With this change, the path is correctly displayed as the first and last elements of the disk name array.