### PR TITLE
Support default value as item label in options

### DIFF
--- a/src/components/ui/FieldInput/FieldInput.tsx
+++ b/src/components/ui/FieldInput/FieldInput.tsx
@@ -313,7 +313,10 @@ class FieldInput extends React.Component<Props> {
     }
 
     const selectedItem = items.find(
-      i => !isEnumSeparator(i) && i.value === this.props.value
+      i =>
+        !isEnumSeparator(i) &&
+        // The default value might be set to an item's label instead of its value
+        (i.value === this.props.value || i.label === this.props.value)
     );
     const commonProps = {
       width: this.props.width,


### PR DESCRIPTION
This commit updates the FieldInput component to handle cases where the default value is set to an item's name instead of its ID. This ensures that the correct item is selected when the component is initialized with a default value.