### PR TITLE
Fix endpoints page crash on no provider label

### DIFF
--- a/src/components/smart/EndpointsPage/EndpointsPage.tsx
+++ b/src/components/smart/EndpointsPage/EndpointsPage.tsx
@@ -94,7 +94,8 @@ class EndpointsPage extends React.Component<{ history: any }, State> {
     const providers = endpointStore.endpoints.reduce((p, endpoint) => {
       if (!p.find(p2 => p2.value === endpoint.type)) {
         p.push({
-          label: configLoader.config.providerNames[endpoint.type],
+          label:
+            configLoader.config.providerNames[endpoint.type] || endpoint.type,
           value: endpoint.type,
         });
       }


### PR DESCRIPTION
The endpoints page might crash if the provider label is not set. This can happen depending on the order of the endpoints in the list. This commit fixes the crash by checking for the label before trying to render it.