### PR TITLE
Fix migration title changing on recreation

### DIFF
--- a/src/components/modules/TransferModule/TransferItemModal/TransferItemModal.tsx
+++ b/src/components/modules/TransferModule/TransferItemModal/TransferItemModal.tsx
@@ -378,6 +378,9 @@ class TransferItemModal extends React.Component<Props, State> {
     }
 
     if (fieldName === "title") {
+      if (this.props.replica.notes) {
+        return this.props.replica.notes;
+      }
       let title = this.props.instancesDetails?.[0]?.name;
       if (
         this.props.instancesDetails &&

--- a/src/sources/MigrationSource.ts
+++ b/src/sources/MigrationSource.ts
@@ -183,7 +183,7 @@ class MigrationSource {
         opts.replicationCount ||
         2,
       instances: opts.instanceNames,
-      notes: getValue("title") || getValue("notes") || "",
+      notes: opts.updatedDestEnv?.title || opts.migration.notes || "",
     };
 
     const skipOsMorphingValue = getValue("skip_os_morphing");


### PR DESCRIPTION
- Fixes an issue where recreating a migration that has a title set, and the user doesn't update the title, would revert the title to the default, which uses the instance name.
- Fixes an issue where the default title, which uses the instance name, is displayed when the migration recreation modal is opened, instead of displaying the title set by the user.