### PR TITLE
Fix reset to null in Edit Replica modal

### DIFF
--- a/src/plugins/default/OptionsSchemaPlugin.ts
+++ b/src/plugins/default/OptionsSchemaPlugin.ts
@@ -153,7 +153,7 @@ export const defaultGetDestinationEnv = (
     }
     if (Array.isArray(value)) {
       env[optionName] = value;
-    } else if (typeof value === "object") {
+    } else if (typeof value === "object" && value != null) {
       const oldValue = oldOptions?.[optionName] || {};
       const mergedValue: any = { ...oldValue, ...value };
       const newValue: any = {};


### PR DESCRIPTION
Fixes an issue in the 'Edit Replica' modal where setting a field's value to 'null' could cause the client to send an invalid value to the API.