### PR TITLE
Fix search in Replicas and Migrations pages

### DIFF
--- a/src/@types/MainItem.ts
+++ b/src/@types/MainItem.ts
@@ -71,7 +71,7 @@ type BaseItem = {
   id: string;
   name: string;
   description?: string;
-  notes: string;
+  notes: string | null;
   created_at: string;
   updated_at: string;
   origin_endpoint_id: string;

--- a/src/components/smart/MigrationsPage/MigrationsPage.tsx
+++ b/src/components/smart/MigrationsPage/MigrationsPage.tsx
@@ -179,7 +179,7 @@ class MigrationsPage extends React.Component<{ history: any }, State> {
     if (item.instances[0].toLowerCase().indexOf(text) > -1) {
       return true;
     }
-    if (item.notes.toLowerCase().indexOf(text) > -1) {
+    if (item.notes && item.notes.toLowerCase().indexOf(text) > -1) {
       return true;
     }
     if (item.destination_environment) {

--- a/src/components/smart/ReplicasPage/ReplicasPage.tsx
+++ b/src/components/smart/ReplicasPage/ReplicasPage.tsx
@@ -307,7 +307,7 @@ class ReplicasPage extends React.Component<{ history: any }, State> {
     if (item.instances[0].toLowerCase().indexOf(text) > -1) {
       return true;
     }
-    if (item.notes.toLowerCase().indexOf(text) > -1) {
+    if (item.notes && item.notes.toLowerCase().indexOf(text) > -1) {
       return true;
     }
     if (item.destination_environment) {


### PR DESCRIPTION
Fixes an issue where search functionality was not working when replicas or migrations had a notes field with a null value. Previously, it was assumed that the notes field could only contain a string.