### PR TITLE
Docker file upgrade Node version from 16 to 18

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ node_modules
 *.log
 *.md
 .env
+dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,10 @@
-FROM ubuntu:20.04
-
-WORKDIR /root
-
-RUN apt-get update && apt-get install -y curl gnupg
-RUN curl --silent --location https://deb.nodesource.com/setup_16.x | bash -
-RUN apt-get update && apt-get install -y nodejs
-
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN apt-get update && apt-get install -y yarn
+FROM node:18
 
 WORKDIR /root/coriolis-web
 
-ADD ./ .
+COPY ./ .
+
+ENV NODE_OPTIONS=--openssl-legacy-provider
 
 RUN yarn install --production --no-progress
 RUN yarn build


### PR DESCRIPTION
- A new base image (Node) was adopted, replacing the previous one (Ubuntu).
- This new base image eliminates the need for installing Node and Yarn.
- The latest Node LTS version, which is now 18, has been implemented.
- The new Node version defaults to using OpenSSL 3. However, due to incompatibility issues with some dependencies (`webpack`), the legacy version (1.1.1) is retained instead.