### PR TITLE
Fix loading execution of wrong replica

### DIFF
--- a/src/stores/ReplicaStore.ts
+++ b/src/stores/ReplicaStore.ts
@@ -131,6 +131,7 @@ class ReplicaStore {
 
   @action clearDetails() {
     this.replicaDetails = null;
+    this.currentlyLoadingExecution = "";
   }
 
   @action getReplicasSuccess(replicas: ReplicaItem[]) {


### PR DESCRIPTION
Fixes an issue where the execution ID of the previously visited replica was used to load the execution of the current replica.

This commit makes sure that old execution ID is cleared before leaving the replica details page.