### PR TITLE
Fix and refactor data validation for Edit Replica

### DIFF
--- a/src/components/modules/WizardModule/WizardOptions/WizardOptions.tsx
+++ b/src/components/modules/WizardModule/WizardOptions/WizardOptions.tsx
@@ -133,19 +133,13 @@ export const shouldRenderField = (field: Field) =>
 
 export const findInvalidFields = (data: any, schema: Field[]): Field[] => {
   const isInvalid = (field: Field): boolean => {
-    if (data) {
-      const fieldValue = field.groupName
-        ? data[field.groupName]?.[field.name]
-        : data[field.name];
-      if (fieldValue === null) {
-        return true;
-      }
-      if (fieldValue === undefined) {
-        return field.default == null;
-      }
-      return !fieldValue;
+    if (field.groupName && data[field.groupName]?.[field.name] !== undefined) {
+      return !data[field.groupName][field.name];
+    } else if (data[field.name] !== undefined) {
+      return !data[field.name];
+    } else {
+      return !field.default;
     }
-    return field.default == null;
   };
 
   if (!schema || schema.length === 0) {


### PR DESCRIPTION
Fixed an issue where the validation was not working (shown as invalid) when a required field was part of a UI group, like "Generic Exporter Options".
In this case the UI expected to find the data inside that group, but the value was actually at the top level of the data object as it came from the source or destination env.
The value gets added to the group when the user updates the field, but otherwise the validation was failing.

Also refactored the validation code to make it more simple, readable and maintainable.