### PR TITLE
Fix crash in MainDetails component on Replica edit.

### DIFF
--- a/src/components/modules/TransferModule/MainDetails/MainDetails.tsx
+++ b/src/components/modules/TransferModule/MainDetails/MainDetails.tsx
@@ -261,6 +261,9 @@ class MainDetails extends React.Component<Props, State> {
             if (p === "disk_mappings" || p === "backend_mappings") {
               return null;
             }
+            if (value[p] == null || value[p] == undefined) {
+              return null;
+            }
             return {
               label: `${label} - ${LabelDictionary.get(p)}`,
               value: getValue(p, value[p]),


### PR DESCRIPTION
When editing a Replica while looking at its MainDetails screen and changing a value, the MainDetails page in the background automatically re-renders on each value selection, and crashed if the value was edited to be null.