### PR TITLE
Fix licensing status fixture

### DIFF
--- a/cypress/fixtures/licences/appliance-status.json
+++ b/cypress/fixtures/licences/appliance-status.json
@@ -1,8 +1,8 @@
 {
   "appliance_licence_status": {
     "appliance_id": "29b06e8f-2ae3-4267-a1ec-c587e732391e",
-    "earliest_licence_expiry_time": "2024-09-09T11:58:40Z",
-    "latest_licence_expiry_time": "2024-09-09T11:58:40Z",
+    "earliest_licence_expiry_time": "2034-09-09T11:58:40Z",
+    "latest_licence_expiry_time": "2034-09-09T11:58:40Z",
     "current_performed_migrations": 5,
     "current_performed_replicas": 1,
     "lifetime_performed_migrations": 8,


### PR DESCRIPTION
Fixes the licence status fixture in integration testing. This change will fix the failing dashboard test due to expired licence fixture.