### PR TITLE
Fix endpoint `false` valued properties

### DIFF
--- a/src/plugins/default/ConnectionSchemaPlugin.ts
+++ b/src/plugins/default/ConnectionSchemaPlugin.ts
@@ -136,7 +136,7 @@ export const fieldsToPayload = (
   const info: any = {};
   const usableSchema: any = schema;
   Object.keys(usableSchema.properties).forEach(fieldName => {
-    if (data[fieldName] && typeof data[fieldName] !== "object") {
+    if (data[fieldName] !== undefined && typeof data[fieldName] !== "object") {
       info[fieldName] = Utils.trim(fieldName, data[fieldName]);
     } else if (typeof usableSchema.properties[fieldName] === "object") {
       const properties =


### PR DESCRIPTION
When setting endpoint properties to `false`, the endpoint store module would not save the value in the request body. This patch makes sure that even `false` values get into the request body.