### PR TITLE
Add `numbered pagination` component with `page navigation` controls

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -198,9 +198,9 @@ const conf: Config = {
     "client_secret",
   ],
 
-  // The number of items per page applicable to main lists:
+  // The number of items per page applicable to default lists:
   // transfers, deployments, endpoints, users etc.
-  mainListItemsPerPage: 20,
+  defaultListItemsPerPage: 25,
 
   maxMinionPoolEventsPerPage: 50,
 

--- a/cypress/e2e/endpoints/endpoints-list.cy.ts
+++ b/cypress/e2e/endpoints/endpoints-list.cy.ts
@@ -39,46 +39,56 @@ describe("Endpoints list", () => {
 
     cy.fixture("endpoints/endpoints").then((endpointsFixture: any) => {
       const endpoints = endpointsFixture.endpoints;
+      const ITEMS_PER_PAGE = 10;
 
       cy.get("div[class^='MainListFilter__FilterItem']")
         .contains("Azure")
         .click();
+      const azureEndpoints = endpoints.filter(r => r.type === "azure");
       cy.get("div[class^='EndpointListItem__Wrapper']").should(
         "have.length",
-        endpoints.filter(r => r.type === "azure").length,
+        Math.min(azureEndpoints.length, ITEMS_PER_PAGE),
       );
 
       cy.get("div[class^='MainListFilter__FilterItem']")
         .contains("VMware")
         .click();
+      const vmwareEndpoints = endpoints.filter(
+        r => r.type === "vmware_vsphere",
+      );
       cy.get("div[class^='EndpointListItem__Wrapper']").should(
         "have.length",
-        endpoints.filter(r => r.type === "vmware_vsphere").length,
+        Math.min(vmwareEndpoints.length, ITEMS_PER_PAGE),
       );
 
       cy.get("div[class^='SearchButton__Wrapper']").click();
       cy.get("input[class*='SearchInput']").type("cor");
+      const vmwareCorEndpoints = endpoints.filter(
+        e => e.type === "vmware_vsphere" && e.name.includes("cor"),
+      );
       cy.get("div[class^='EndpointListItem__Wrapper']").should(
         "have.length",
-        endpoints.filter(
-          e => e.type === "vmware_vsphere" && e.name.includes("cor"),
-        ).length,
+        Math.min(vmwareCorEndpoints.length, ITEMS_PER_PAGE),
       );
+
       cy.get("div[class^='TextInput__Close']").click();
+      cy.get("input[class*='SearchInput']").should("have.value", "");
 
       cy.get("div[class^='MainListFilter__FilterItem']")
         .contains("All")
         .click();
       cy.get("div[class^='EndpointListItem__Wrapper']").should(
         "have.length",
-        endpoints.length,
+        Math.min(endpoints.length, ITEMS_PER_PAGE),
       );
 
       cy.get("div[class^='SearchButton__Wrapper']").click();
       cy.get("input[class*='SearchInput']").type("cor");
+      cy.get("input[class*='SearchInput']").should("have.value", "cor");
+      const corEndpoints = endpoints.filter(e => e.name.includes("cor"));
       cy.get("div[class^='EndpointListItem__Wrapper']").should(
         "have.length",
-        endpoints.filter(e => e.name.includes("cor")).length,
+        Math.min(corEndpoints.length, ITEMS_PER_PAGE),
       );
     });
   });

--- a/src/@types/Config.ts
+++ b/src/@types/Config.ts
@@ -39,7 +39,7 @@ export type Config = {
   providersDisabledExecuteOptions: [ProviderTypes];
   hiddenUsers: string[];
   passwordFields: string[];
-  mainListItemsPerPage: number;
+  defaultListItemsPerPage?: number;
   servicesUrls: Services;
   maxMinionPoolEventsPerPage: number;
   bareMetalEndpointName: string;

--- a/src/components/modules/MinionModule/MinionPoolDetailsContent/MinionPoolEvents.spec.tsx
+++ b/src/components/modules/MinionModule/MinionPoolDetailsContent/MinionPoolEvents.spec.tsx
@@ -81,7 +81,7 @@ describe("MinionPoolEvents", () => {
     expect(filterDropdown).toBeTruthy();
   });
 
-  describe("Pagination", () => {
+  describe("ArrowPagination", () => {
     const showAllEvents = async () => {
       let showAllEvents: HTMLElement | null = null;
       TestUtils.selectAll("DropdownLink__Label").forEach(element => {
@@ -109,12 +109,12 @@ describe("MinionPoolEvents", () => {
       render(<MinionPoolEvents {...defaultProps} />);
 
       // pagination is not visible for 1 event
-      expect(TestUtils.select("Pagination__Wrapper")!).toBeFalsy();
+      expect(TestUtils.select("ArrowPagination__Wrapper")!).toBeFalsy();
 
       await showAllEvents();
 
       // pagination is visible for more than 1 event
-      expect(TestUtils.select("Pagination__Wrapper")!).toBeTruthy();
+      expect(TestUtils.select("ArrowPagination__Wrapper")!).toBeTruthy();
     });
 
     it("goes to next page and back", async () => {
@@ -123,28 +123,31 @@ describe("MinionPoolEvents", () => {
       await showAllEvents();
 
       expect(
-        TestUtils.select("Pagination__PagePrevious")!.hasAttribute("disabled"),
+        TestUtils.select("ArrowPagination__PagePrevious")!.hasAttribute(
+          "disabled",
+        ),
       ).toBeTruthy();
-      expect(TestUtils.select("Pagination__PageNumber")!.textContent).toBe(
+      expect(TestUtils.select("ArrowPagination__PageNumber")!.textContent).toBe(
         "1 of 3",
       );
 
       await act(async () => {
-        TestUtils.select("Pagination__PageNext")!.click();
+        TestUtils.select("ArrowPagination__PageNext")!.click();
       });
 
       expect(
-        TestUtils.select("Pagination__PagePrevious")!.hasAttribute("disabled"),
+        TestUtils.select("ArrowPagination__PagePrevious")!.hasAttribute(
+          "disabled",
+        ),
       ).toBeFalsy();
-      expect(TestUtils.select("Pagination__PageNumber")!.textContent).toBe(
+      expect(TestUtils.select("ArrowPagination__PageNumber")!.textContent).toBe(
         "2 of 3",
       );
 
       await act(async () => {
-        TestUtils.select("Pagination__PagePrevious")!.click();
+        TestUtils.select("ArrowPagination__PagePrevious")!.click();
       });
-
-      expect(TestUtils.select("Pagination__PageNumber")!.textContent).toBe(
+      expect(TestUtils.select("ArrowPagination__PageNumber")!.textContent).toBe(
         "1 of 3",
       );
     });

--- a/src/components/modules/MinionModule/MinionPoolDetailsContent/MinionPoolEvents.tsx
+++ b/src/components/modules/MinionModule/MinionPoolDetailsContent/MinionPoolEvents.tsx
@@ -22,7 +22,7 @@ import {
 import { ThemePalette, ThemeProps } from "@src/components/Theme";
 import DropdownLink from "@src/components/ui/Dropdowns/DropdownLink";
 import InfoIcon from "@src/components/ui/InfoIcon";
-import Pagination from "@src/components/ui/Pagination";
+import ArrowPagination from "@src/components/ui/Pagination/ArrowPagination";
 import StatusIcon from "@src/components/ui/StatusComponents/StatusIcon";
 import configLoader from "@src/utils/Config";
 import DateUtils from "@src/utils/DateUtils";
@@ -255,7 +255,7 @@ class MinionPoolEvents extends React.Component<Props, State> {
         configLoader.config.maxMinionPoolEventsPerPage,
     );
     return (
-      <Pagination
+      <ArrowPagination
         previousDisabled={this.state.currentPage === 1}
         nextDisabled={this.state.currentPage === totalPages}
         onPreviousClick={() => {

--- a/src/components/modules/WizardModule/WizardInstances/WizardInstances.tsx
+++ b/src/components/modules/WizardModule/WizardInstances/WizardInstances.tsx
@@ -20,7 +20,7 @@ import { ThemePalette, ThemeProps } from "@src/components/Theme";
 import Button from "@src/components/ui/Button";
 import Checkbox from "@src/components/ui/Checkbox";
 import InfoIcon from "@src/components/ui/InfoIcon";
-import Pagination from "@src/components/ui/Pagination";
+import ArrowPagination from "@src/components/ui/Pagination/ArrowPagination";
 import ReloadButton from "@src/components/ui/ReloadButton";
 import SearchInput from "@src/components/ui/SearchInput";
 import StatusImage from "@src/components/ui/StatusComponents/StatusImage";
@@ -465,7 +465,7 @@ class WizardInstances extends React.Component<Props, State> {
     const isNextDisabled = !hasNextPage || areAllDisabled;
 
     return (
-      <Pagination
+      <ArrowPagination
         style={{ margin: "32px 0 16px 0" }}
         previousDisabled={isPreviousDisabled}
         onPreviousClick={() => {

--- a/src/components/smart/EndpointsPage/EndpointsPage.tsx
+++ b/src/components/smart/EndpointsPage/EndpointsPage.tsx
@@ -355,6 +355,8 @@ class EndpointsPage extends React.Component<Props, State> {
               onEmptyListButtonClick={() => {
                 this.handleEmptyListButtonClick();
               }}
+              itemsPerPageOptions={[10, 25, 50]}
+              initialItemsPerPage={10}
             />
           }
           headerComponent={

--- a/src/components/smart/ProjectsPage/ProjectsPage.tsx
+++ b/src/components/smart/ProjectsPage/ProjectsPage.tsx
@@ -159,6 +159,8 @@ class ProjectsPage extends React.Component<Props, State> {
                   }
                 />
               )}
+              itemsPerPageOptions={[10, 25, 50]}
+              initialItemsPerPage={10}
             />
           }
           headerComponent={

--- a/src/components/smart/UsersPage/UsersPage.tsx
+++ b/src/components/smart/UsersPage/UsersPage.tsx
@@ -145,6 +145,8 @@ class UsersPage extends React.Component<Props, State> {
                   getProjectName={projectId => this.getProjectName(projectId)}
                 />
               )}
+              itemsPerPageOptions={[10, 25, 50]}
+              initialItemsPerPage={10}
             />
           }
           headerComponent={

--- a/src/components/ui/Lists/FilterList/FilterList.spec.tsx
+++ b/src/components/ui/Lists/FilterList/FilterList.spec.tsx
@@ -14,7 +14,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React, { act } from "react";
 import styled from "styled-components";
-import { render } from "@testing-library/react";
+import { render, fireEvent } from "@testing-library/react";
 import FilterList from "@src/components/ui/Lists/FilterList";
 import TestUtils from "@tests/TestUtils";
 import userEvent from "@testing-library/user-event";
@@ -71,6 +71,7 @@ const ItemComponent = (props: ItemComponentProps) => (
 const FilterListWrap = (options?: {
   onItemClick?: () => void;
   onSelectedItemsChange?: (items: any[]) => void;
+  initialItemsPerPage?: number;
 }) => (
   <FilterList
     items={ITEMS}
@@ -82,6 +83,7 @@ const FilterListWrap = (options?: {
     selectionLabel="test item"
     renderItemComponent={ItemComponent}
     onSelectedItemsChange={options?.onSelectedItemsChange || (() => {})}
+    initialItemsPerPage={options?.initialItemsPerPage || 2}
   />
 );
 
@@ -98,9 +100,9 @@ describe("FilterList", () => {
     const listItems = TestUtils.selectAll("FilterListspec__MainListItem-");
     expect(listItems).toHaveLength(2);
     expect(listItems[1].textContent).toBe(ITEMS[1].label);
-    expect(TestUtils.select("Pagination__PageNumber")?.textContent).toBe(
-      "1 of 2",
-    );
+    expect(
+      TestUtils.select("NumberedPagination__PageNumber")?.textContent,
+    ).toBe("Page 1 of 2");
   });
 
   it("filters items", async () => {
@@ -135,13 +137,16 @@ describe("FilterList", () => {
 
   it("goes to next page", async () => {
     render(FilterListWrap());
-    await act(async () => {
-      TestUtils.select("Pagination__PageNext")?.click();
-    });
 
-    expect(TestUtils.select("Pagination__PageNumber")?.textContent).toBe(
-      "2 of 2",
+    const nextButton = Array.from(document.querySelectorAll("button")).find(
+      btn => btn.textContent === "Next",
     );
+
+    fireEvent.click(nextButton!);
+
+    expect(
+      TestUtils.select("NumberedPagination__PageNumber")?.textContent,
+    ).toBe("Page 2 of 2");
     expect(
       TestUtils.selectAll("FilterListspec__MainListItem-")[1].textContent,
     ).toBe(ITEMS[3].label);
@@ -166,7 +171,7 @@ describe("FilterList", () => {
     });
     expect(checkbox.checked).toBe(true);
     expect(TestUtils.select("MainListFilter__SelectionText")?.textContent).toBe(
-      "1 of 4\u00a0test item(s) selected",
+      "1 of 2\u00a0test item(s) selected",
     );
     expect(onSelectedItemsChange).toHaveBeenCalledWith([ITEMS[1]]);
   });

--- a/src/components/ui/Lists/FilterList/FilterList.spec.tsx
+++ b/src/components/ui/Lists/FilterList/FilterList.spec.tsx
@@ -21,7 +21,7 @@ import userEvent from "@testing-library/user-event";
 import { ItemComponentProps } from "@src/components/ui/Lists/MainList";
 
 jest.mock("@src/utils/Config", () => ({
-  config: { mainListItemsPerPage: 2 },
+  config: { defaultListItemsPerPage: 2 },
 }));
 
 const ITEMS = [

--- a/src/components/ui/Pagination/ArrowPagination/ArrowPagination.spec.tsx
+++ b/src/components/ui/Pagination/ArrowPagination/ArrowPagination.spec.tsx
@@ -14,11 +14,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from "react";
 import { render } from "@testing-library/react";
-import Pagination from "@src/components/ui/Pagination";
+import ArrowPagination from "./ArrowPagination";
 import TestUtils from "@tests/TestUtils";
 
-const PaginationWithDefaultProps = (props: Partial<Pagination["props"]>) => (
-  <Pagination
+const ArrowPaginationWithDefaultProps = (
+  props: Partial<ArrowPagination["props"]>,
+) => (
+  <ArrowPagination
     currentPage={2}
     totalPages={10}
     onPreviousClick={props.onPreviousClick || (() => {})}
@@ -29,10 +31,10 @@ const PaginationWithDefaultProps = (props: Partial<Pagination["props"]>) => (
   />
 );
 
-describe("Pagination", () => {
+describe("ArrowPagination", () => {
   it("renders", () => {
-    render(<PaginationWithDefaultProps />);
-    expect(TestUtils.select("Pagination__PageNumber")?.textContent).toBe(
+    render(<ArrowPaginationWithDefaultProps />);
+    expect(TestUtils.select("ArrowPagination__PageNumber")?.textContent).toBe(
       "2 of 10",
     );
   });
@@ -41,14 +43,14 @@ describe("Pagination", () => {
     const onPreviousClick = jest.fn();
     const onNextClick = jest.fn();
     render(
-      <PaginationWithDefaultProps
+      <ArrowPaginationWithDefaultProps
         onPreviousClick={onPreviousClick}
         onNextClick={onNextClick}
       />,
     );
-    TestUtils.select("Pagination__PagePrevious")!.click();
+    TestUtils.select("ArrowPagination__PagePrevious")!.click();
     expect(onPreviousClick).toHaveBeenCalled();
-    TestUtils.select("Pagination__PageNext")!.click();
+    TestUtils.select("ArrowPagination__PageNext")!.click();
     expect(onNextClick).toHaveBeenCalled();
   });
 
@@ -56,37 +58,37 @@ describe("Pagination", () => {
     let onPreviousClick = jest.fn();
     let onNextClick = jest.fn();
     const { rerender } = render(
-      <PaginationWithDefaultProps
+      <ArrowPaginationWithDefaultProps
         onPreviousClick={onPreviousClick}
         previousDisabled
         onNextClick={onNextClick}
       />,
     );
-    TestUtils.select("Pagination__PagePrevious")!.click();
+    TestUtils.select("ArrowPagination__PagePrevious")!.click();
     expect(onPreviousClick).not.toHaveBeenCalled();
-    TestUtils.select("Pagination__PageNext")!.click();
+    TestUtils.select("ArrowPagination__PageNext")!.click();
     expect(onNextClick).toHaveBeenCalled();
 
     onPreviousClick = jest.fn();
     onNextClick = jest.fn();
     rerender(
-      <PaginationWithDefaultProps
+      <ArrowPaginationWithDefaultProps
         onPreviousClick={onPreviousClick}
         onNextClick={onNextClick}
         nextDisabled
       />,
     );
-    TestUtils.select("Pagination__PagePrevious")!.click();
+    TestUtils.select("ArrowPagination__PagePrevious")!.click();
     expect(onPreviousClick).toHaveBeenCalled();
-    TestUtils.select("Pagination__PageNext")!.click();
+    TestUtils.select("ArrowPagination__PageNext")!.click();
     expect(onNextClick).not.toHaveBeenCalled();
   });
 
   it("shows loading", () => {
-    const { rerender } = render(<PaginationWithDefaultProps />);
+    const { rerender } = render(<ArrowPaginationWithDefaultProps />);
     expect(TestUtils.select("HorizontalLoading__Wrapper")).toBeFalsy();
 
-    rerender(<PaginationWithDefaultProps loading />);
+    rerender(<ArrowPaginationWithDefaultProps loading />);
     expect(TestUtils.select("HorizontalLoading__Wrapper")).toBeTruthy();
   });
 });

--- a/src/components/ui/Pagination/ArrowPagination/ArrowPagination.tsx
+++ b/src/components/ui/Pagination/ArrowPagination/ArrowPagination.tsx
@@ -80,7 +80,7 @@ type Props = {
 };
 
 @observer
-class Pagination extends React.Component<Props> {
+class ArrowPagination extends React.Component<Props> {
   goTo(type: "previous" | "next") {
     if (type === "previous" && !this.props.previousDisabled) {
       this.props.onPreviousClick();
@@ -154,4 +154,4 @@ class Pagination extends React.Component<Props> {
   }
 }
 
-export default Pagination;
+export default ArrowPagination;

--- a/src/components/ui/Pagination/ArrowPagination/package.json
+++ b/src/components/ui/Pagination/ArrowPagination/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "ArrowPagination",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./ArrowPagination.tsx"
+}

--- a/src/components/ui/Pagination/NumberedPagination/NumberedPagination.spec.tsx
+++ b/src/components/ui/Pagination/NumberedPagination/NumberedPagination.spec.tsx
@@ -1,0 +1,120 @@
+/*
+Copyright (C) 2025  Cloudbase Solutions SRL
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import NumberedPagination from "./NumberedPagination";
+import TestUtils from "@tests/TestUtils";
+
+const NumberedPaginationWithDefaultProps = (
+  props: Partial<NumberedPagination["props"]>,
+) => (
+  <NumberedPagination
+    itemsCount={props.itemsCount || 100}
+    currentPage={props.currentPage || 2}
+    itemsPerPage={props.itemsPerPage || 10}
+    itemsPerPageOptions={props.itemsPerPageOptions || [5, 10, 20, 50]}
+    onPageChange={props.onPageChange || (() => {})}
+    onItemsPerPageChange={props.onItemsPerPageChange || (() => {})}
+    style={props.style}
+  />
+);
+
+describe("NumberedPagination", () => {
+  it("renders", () => {
+    render(<NumberedPaginationWithDefaultProps />);
+    expect(
+      TestUtils.select("NumberedPagination__PageNumber")?.textContent,
+    ).toBe("Page 2 of 10");
+  });
+
+  it("handles previous and next click", async () => {
+    const onPageChange = jest.fn();
+
+    render(<NumberedPaginationWithDefaultProps onPageChange={onPageChange} />);
+
+    const previousButton = screen.getByRole("button", { name: "Previous" });
+    const nextButton = screen.getByRole("button", { name: "Next" });
+
+    await userEvent.click(previousButton);
+    expect(onPageChange).toHaveBeenCalled();
+
+    await userEvent.click(nextButton);
+    expect(onPageChange).toHaveBeenCalled();
+  });
+
+  it("handles disabled states", async () => {
+    let onPageChange = jest.fn();
+
+    const { rerender } = render(
+      <NumberedPaginationWithDefaultProps
+        onPageChange={onPageChange}
+        currentPage={1}
+        itemsCount={30}
+        itemsPerPage={10}
+      />,
+    );
+    let previousButton = screen.getByRole("button", { name: "Previous" });
+    let nextButton = screen.getByRole("button", { name: "Next" });
+
+    await userEvent.click(previousButton);
+    expect(onPageChange).not.toHaveBeenCalled();
+
+    await userEvent.click(nextButton);
+    expect(onPageChange).toHaveBeenCalled();
+
+    onPageChange = jest.fn();
+    rerender(
+      <NumberedPaginationWithDefaultProps
+        onPageChange={onPageChange}
+        currentPage={3}
+        itemsCount={30}
+        itemsPerPage={10}
+      />,
+    );
+
+    previousButton = screen.getByRole("button", { name: "Previous" });
+    nextButton = screen.getByRole("button", { name: "Next" });
+
+    await userEvent.click(previousButton);
+    expect(onPageChange).toHaveBeenCalled();
+
+    onPageChange = jest.fn();
+
+    expect(nextButton).toHaveProperty("disabled", true);
+    await userEvent.click(nextButton);
+    expect(onPageChange).not.toHaveBeenCalled();
+  });
+
+  it("renders all items per page options", () => {
+    const itemsPerPageOptions = [5, 10, 20, 50, 100];
+
+    render(
+      <NumberedPaginationWithDefaultProps
+        itemsPerPageOptions={itemsPerPageOptions}
+      />,
+    );
+
+    const options = screen.getAllByRole("option");
+
+    expect(options.length).toBe(itemsPerPageOptions.length);
+    itemsPerPageOptions.forEach((option, index) => {
+      expect((options[index] as HTMLOptionElement).value).toBe(
+        option.toString(),
+      );
+      expect(options[index].textContent).toBe(option.toString());
+    });
+  });
+});

--- a/src/components/ui/Pagination/NumberedPagination/NumberedPagination.tsx
+++ b/src/components/ui/Pagination/NumberedPagination/NumberedPagination.tsx
@@ -1,0 +1,116 @@
+/*
+Copyright (C) 2025  Cloudbase Solutions SRL
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { observer } from "mobx-react";
+import React from "react";
+import styled from "styled-components";
+
+const PaginationWrapper = styled.div<any>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const PaginationButton = styled.button`
+  background-color: #007bff;
+  color: white;
+  border: 1px solid #dee2e6;
+  padding: 5px 20px;
+  margin: 0 5px;
+  cursor: pointer;
+  border-radius: 4px;
+
+  &:disabled {
+    background-color: #e9ecef;
+    color: #6c757d;
+    border-color: #dee2e6;
+    cursor: default;
+  }
+`;
+
+const PageNumber = styled.span``;
+
+const PageNext = styled(PaginationButton)``;
+
+const PagePrevious = styled(PaginationButton)``;
+
+const ItemsPerPageSelect = styled.select`
+  margin-left: 10px;
+  padding: 5px;
+  border-radius: 4px;
+  border: 1px solid #cccccc;
+`;
+
+type Props = {
+  className?: string;
+  style?: any;
+  itemsCount: number;
+  currentPage: number;
+  itemsPerPage: number;
+  itemsPerPageOptions: number[];
+  onPageChange: (newPage: number) => void;
+  onItemsPerPageChange?: (event: React.ChangeEvent<HTMLSelectElement>) => void;
+};
+
+@observer
+class NumberedPagination extends React.Component<Props> {
+  render() {
+    const { itemsCount, currentPage, itemsPerPage } = this.props;
+    const totalPages = Math.max(1, Math.ceil(itemsCount / itemsPerPage));
+    const hasNextPage = currentPage * itemsPerPage < itemsCount;
+
+    return (
+      <PaginationWrapper
+        style={this.props.style}
+        className={this.props.className}
+      >
+        <PagePrevious
+          onClick={() => {
+            if (currentPage > 1) {
+              this.props.onPageChange(currentPage - 1);
+            }
+          }}
+          disabled={currentPage === 1}
+        >
+          Previous
+        </PagePrevious>
+        <PageNumber>
+          Page {currentPage} of {totalPages}
+        </PageNumber>
+        <PageNext
+          onClick={() => {
+            if (currentPage < totalPages) {
+              this.props.onPageChange(currentPage + 1);
+            }
+          }}
+          disabled={!hasNextPage}
+        >
+          Next
+        </PageNext>
+        <ItemsPerPageSelect
+          value={itemsPerPage}
+          onChange={this.props.onItemsPerPageChange}
+        >
+          {this.props.itemsPerPageOptions.map(opt => (
+            <option key={opt} value={opt}>
+              {opt}
+            </option>
+          ))}
+        </ItemsPerPageSelect>
+      </PaginationWrapper>
+    );
+  }
+}
+
+export default NumberedPagination;

--- a/src/components/ui/Pagination/NumberedPagination/package.json
+++ b/src/components/ui/Pagination/NumberedPagination/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "NumberedPagination",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./NumberedPagination.tsx"
+}

--- a/src/components/ui/Pagination/package.json
+++ b/src/components/ui/Pagination/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "Pagination",
-  "version": "0.0.0",
-  "private": true,
-  "main": "./Pagination.tsx"
-}


### PR DESCRIPTION
This PR includes the following changes:

- Rename `Pagination` component to `ArrowPagination`;
- Add new `NumberedPagination` component with `page counts` and `navigation`;
- Fix `e2e/unit` tests;
- Add test cases for `NumberedPagination` component.