### PR TITLE
Fix fields to payload method

### DIFF
--- a/src/plugins/default/ConnectionSchemaPlugin.ts
+++ b/src/plugins/default/ConnectionSchemaPlugin.ts
@@ -138,7 +138,7 @@ export const fieldsToPayload = (
   Object.keys(usableSchema.properties).forEach(fieldName => {
     if (data[fieldName] !== undefined && typeof data[fieldName] !== "object") {
       info[fieldName] = Utils.trim(fieldName, data[fieldName]);
-    } else if (typeof usableSchema.properties[fieldName] === "object") {
+    } else if (usableSchema.properties[fieldName].type === "object") {
       const properties =
         usableSchema.properties[fieldName] &&
         usableSchema.properties[fieldName].properties;
@@ -154,10 +154,8 @@ export const fieldsToPayload = (
         });
       }
     } else if (
-      !data[fieldName] &&
-      usableSchema.required &&
-      usableSchema.required.find((f: string) => f === fieldName) &&
-      usableSchema.properties[fieldName].default
+      data[fieldName] === undefined &&
+      usableSchema.properties[fieldName].default !== undefined
     ) {
       info[fieldName] = usableSchema.properties[fieldName].default;
     }


### PR DESCRIPTION
Formerly, the schema defaults would only apply if the property was also required. This patch makes sure that the defaults always apply, as required fields were meant for the frontend to force the user to provide a value, therefore required properties do not need a default value either way.
This patch also fixes how object-type properties get identified.