### PR TITLE
Use stored VM info for completed `transfers/deployments` when source VMs are removed

### DIFF
--- a/cypress/e2e/transfers/transfers-list.cy.ts
+++ b/cypress/e2e/transfers/transfers-list.cy.ts
@@ -147,7 +147,7 @@ describe("Replicas list", () => {
     cy.get("div[class^='ActionDropdown__Wrapper']").click();
     cy.loadFixtures(["transfers/replicas"], (results: any[]) => {
       const transfers = results[0].transfers;
-      cy.intercept(`**/coriolis/**/transfers/${transfers[0].id}`, {
+      cy.intercept(`**/coriolis/**/transfers/${transfers[0].id}*`, {
         fixture: "transfers/replica-unexecuted",
       }).as("transfer");
 

--- a/src/components/smart/DeploymentDetailsPage/DeploymentDetailsPage.tsx
+++ b/src/components/smart/DeploymentDetailsPage/DeploymentDetailsPage.tsx
@@ -220,6 +220,7 @@ class DeploymentDetailsPage extends React.Component<Props, State> {
   }) {
     await deploymentStore.getDeployment(options.deploymentId, {
       showLoading: true,
+      includeTaskInfo: true,
     });
     const details = deploymentStore.deploymentDetails;
     if (!details) {
@@ -437,6 +438,7 @@ class DeploymentDetailsPage extends React.Component<Props, State> {
     await deploymentStore.getDeployment(this.props.match.params.id, {
       showLoading: false,
       skipLog: true,
+      includeTaskInfo: true,
     });
     this.timeoutRef = setTimeout(() => {
       this.pollData();

--- a/src/components/smart/TransferDetailsPage/TransferDetailsPage.tsx
+++ b/src/components/smart/TransferDetailsPage/TransferDetailsPage.tsx
@@ -286,6 +286,7 @@ class TransferDetailsPage extends React.Component<Props, State> {
     await transferStore.getTransferDetails({
       transferId: options.transferId || this.transferId,
       showLoading: options.showLoading,
+      includeTaskInfo: true,
     });
     const transfer = this.transfer;
     if (!transfer) {
@@ -621,6 +622,7 @@ class TransferDetailsPage extends React.Component<Props, State> {
       transferStore.getTransferDetails({
         transferId: this.transferId,
         polling: true,
+        includeTaskInfo: true,
       }),
       (async () => {
         if (window.location.pathname.indexOf("executions") > -1) {

--- a/src/sources/DeploymentSource.ts
+++ b/src/sources/DeploymentSource.ts
@@ -72,9 +72,14 @@ class DeploymentSource {
   async getDeployment(
     deploymentId: string,
     skipLog?: boolean,
+    includeTaskInfo?: boolean,
   ): Promise<DeploymentItemDetails> {
+    let url = `${configLoader.config.servicesUrls.coriolis}/${Api.projectId}/deployments/${deploymentId}`;
+    if (includeTaskInfo) {
+      url += "?include_task_info=true";
+    }
     const response = await Api.send({
-      url: `${configLoader.config.servicesUrls.coriolis}/${Api.projectId}/deployments/${deploymentId}`,
+      url,
       skipLog,
       cancelId: deploymentId,
     });

--- a/src/sources/TransferSource.ts
+++ b/src/sources/TransferSource.ts
@@ -121,11 +121,18 @@ class TransferSource {
   async getTransferDetails(options: {
     transferId: string;
     polling?: boolean;
+    includeTaskInfo?: boolean;
   }): Promise<TransferItemDetails> {
-    const { transferId: transferId, polling } = options;
+    const { transferId: transferId, polling, includeTaskInfo } = options;
+
+    let url = `${configLoader.config.servicesUrls.coriolis}/${Api.projectId}/transfers/${transferId}`;
+
+    if (includeTaskInfo) {
+      url += "?include_task_info=true";
+    }
 
     const response = await Api.send({
-      url: `${configLoader.config.servicesUrls.coriolis}/${Api.projectId}/transfers/${transferId}`,
+      url,
       skipLog: polling,
       cancelId: transferId,
     });

--- a/src/stores/DeploymentStore.ts
+++ b/src/stores/DeploymentStore.ts
@@ -120,7 +120,11 @@ class DeploymentStore {
 
   @action async getDeployment(
     deploymentId: string,
-    options?: { showLoading?: boolean; skipLog?: boolean },
+    options?: {
+      showLoading?: boolean;
+      skipLog?: boolean;
+      includeTaskInfo?: boolean;
+    },
   ) {
     if (options && options.showLoading) {
       this.detailsLoading = true;
@@ -130,6 +134,7 @@ class DeploymentStore {
       const deployment = await DeploymentSource.getDeployment(
         deploymentId,
         options && options.skipLog,
+        options && options.includeTaskInfo,
       );
       runInAction(() => {
         this.deploymentDetails = deployment;

--- a/src/stores/TransferStore.ts
+++ b/src/stores/TransferStore.ts
@@ -106,8 +106,14 @@ class TransferStore {
     transferId: string;
     showLoading?: boolean;
     polling?: boolean;
+    includeTaskInfo?: boolean;
   }) {
-    const { transferId: transferId, showLoading, polling } = options;
+    const {
+      transferId: transferId,
+      showLoading,
+      polling,
+      includeTaskInfo,
+    } = options;
 
     if (showLoading) {
       this.transferDetailsLoading = true;
@@ -117,6 +123,7 @@ class TransferStore {
       const transfer = await TransferSource.getTransferDetails({
         transferId: transferId,
         polling,
+        includeTaskInfo,
       });
 
       runInAction(() => {
@@ -307,7 +314,10 @@ class TransferStore {
     try {
       const transferDetails = await Promise.all(
         transfers.map(transfer =>
-          TransferSource.getTransferDetails({ transferId: transfer.id }),
+          TransferSource.getTransferDetails({
+            transferId: transfer.id,
+            includeTaskInfo: true,
+          }),
         ),
       );
 


### PR DESCRIPTION
* When `transfers` or `deployments` complete successfully and `source VMs` are subsequently removed, it fails to load VM details and `mappings` due to API errors when trying to fetch from the `source endpoint`.
* Enable `include_task_info` optional parameter in `API URL` to allow fetching task details even when source VMs are missing.

