### PR TITLE
Use correct instance details source in transfer edit modal

### DIFF
--- a/src/components/smart/TransferDetailsPage/TransferDetailsPage.tsx
+++ b/src/components/smart/TransferDetailsPage/TransferDetailsPage.tsx
@@ -694,7 +694,9 @@ class TransferDetailsPage extends React.Component<Props, State> {
         }}
         transfer={transfer}
         destinationEndpoint={destinationEndpoint}
-        instancesDetails={instanceStore.instancesDetails}
+        instancesDetails={
+          this.state.dbInstancesDetails || instanceStore.instancesDetails
+        }
         instancesDetailsLoading={instanceStore.loadingInstancesDetails}
         networks={networkStore.networks}
         networksLoading={networkStore.loading}
@@ -912,7 +914,9 @@ class TransferDetailsPage extends React.Component<Props, State> {
                   m.platform === "destination",
               )}
               loadingInstances={instanceStore.loadingInstancesDetails}
-              instances={instanceStore.instancesDetails}
+              instances={
+                this.state.dbInstancesDetails || instanceStore.instancesDetails
+              }
               onCancelClick={() => {
                 this.handleCloseDeploymentModal();
               }}


### PR DESCRIPTION
* The edit modal was not showing options like `OSMorphing Minion Pool` for previously executed transfers because it only checked `instanceStore.instancesDetails` instead of also checking `dbInstancesDetails` populated from `transfer.info`.