### PR TITLE
Fix provider `options` reload

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -134,13 +134,13 @@ const conf: Config = {
     {
       name: "olvm",
       types: ["destination"],
-      requiredFields: ["cluster"]
+      requiredFields: ["cluster"],
     },
     {
       name: "rhev",
       types: ["destination"],
-      requiredFields: ["cluster"]
-    }
+      requiredFields: ["cluster"],
+    },
   ],
 
   /*
@@ -202,7 +202,13 @@ const conf: Config = {
   hiddenUsers: ["barbican", "coriolis"],
 
   // The list of user roles to hide in the UI
-  hiddenUserRoles: ["audit", "creator", "observer", "service", "key-manager:service-admin"],
+  hiddenUserRoles: [
+    "audit",
+    "creator",
+    "observer",
+    "service",
+    "key-manager:service-admin",
+  ],
 
   // By default, if a field name contains `password` in it (ex.: `user_password`),
   // it will be rendered as a password input

--- a/src/components/modules/TransferModule/TransferItemModal/TransferItemModal.tsx
+++ b/src/components/modules/TransferModule/TransferItemModal/TransferItemModal.tsx
@@ -483,9 +483,10 @@ class TransferItemModal extends React.Component<Props, State> {
     try {
       await providerStore.loadOptionsSchema({
         providerName: endpoint.type,
-        requiresWindowsImage: this.requiresWindowsImage,
         optionsType,
         useCache,
+        forceRefresh: !useCache,
+        requiresWindowsImage: this.requiresWindowsImage,
       });
     } catch (err) {
       if (optionsType === "destination") {
@@ -500,6 +501,7 @@ class TransferItemModal extends React.Component<Props, State> {
       endpointId: endpoint.id,
       providerName: endpoint.type,
       useCache,
+      forceRefresh: !useCache,
       requiresWindowsImage: this.requiresWindowsImage,
     });
   }

--- a/src/components/smart/WizardPage/WizardPage.tsx
+++ b/src/components/smart/WizardPage/WizardPage.tsx
@@ -491,18 +491,25 @@ class WizardPage extends React.Component<Props, State> {
     await providerStore.loadOptionsSchema({
       providerName: endpoint.type,
       optionsType,
+      forceRefresh: true,
       requiresWindowsImage: this.requiresWindowsImage,
     });
     const getSchema = () =>
       optionsType === "source"
         ? providerStore.sourceSchema
         : providerStore.destinationSchema;
+    wizardStore.updateData(
+      optionsType === "source"
+        ? { sourceOptions: undefined }
+        : { destOptions: undefined },
+    );
     wizardStore.fillWithDefaultValues(optionsType, getSchema());
 
     await providerStore.getOptionsValues({
       optionsType,
       endpointId: endpoint.id,
       providerName: endpoint.type,
+      forceRefresh: true,
       requiresWindowsImage: this.requiresWindowsImage,
     });
     wizardStore.fillWithDefaultValues(optionsType, getSchema());

--- a/src/sources/ProviderSource.ts
+++ b/src/sources/ProviderSource.ts
@@ -42,6 +42,7 @@ class ProviderSource {
     providerName: ProviderTypes;
     optionsType: "source" | "destination";
     useCache?: boolean | null;
+    forceRefresh?: boolean;
     quietError?: boolean | null;
     requiresWindowsImage?: boolean;
   }): Promise<Field[]> {
@@ -49,6 +50,7 @@ class ProviderSource {
       providerName,
       optionsType,
       useCache,
+      forceRefresh,
       quietError,
       requiresWindowsImage,
     } = opts;
@@ -57,9 +59,15 @@ class ProviderSource {
         ? providerTypes.SOURCE_TRANSFER
         : providerTypes.TARGET_TRANSFER;
 
+    const url = `${configLoader.config.servicesUrls.coriolis}/${Api.projectId}/providers/${providerName}/schemas/${schemaTypeInt}`;
+
+    if (forceRefresh) {
+      Api.removeFromCache(url);
+    }
+
     try {
       const response = await Api.send({
-        url: `${configLoader.config.servicesUrls.coriolis}/${Api.projectId}/providers/${providerName}/schemas/${schemaTypeInt}`,
+        url,
         cache: useCache,
         quietError,
       });
@@ -88,9 +96,17 @@ class ProviderSource {
     endpointId: string;
     envData: { [prop: string]: any } | null | undefined;
     cache?: boolean | null;
+    forceRefresh?: boolean;
     quietError?: boolean;
   }): Promise<OptionValues[]> {
-    const { optionsType, endpointId, envData, cache, quietError } = opts;
+    const {
+      optionsType,
+      endpointId,
+      envData,
+      cache,
+      forceRefresh,
+      quietError,
+    } = opts;
     let envString = "";
     if (envData) {
       envString = `?env=${DomUtils.encodeToBase64Url(envData)}`;
@@ -100,8 +116,14 @@ class ProviderSource {
     const fieldName =
       optionsType === "source" ? "source_options" : "destination_options";
 
+    const url = `${configLoader.config.servicesUrls.coriolis}/${Api.projectId}/endpoints/${endpointId}/${callName}${envString}`;
+
+    if (forceRefresh) {
+      Api.removeFromCache(url);
+    }
+
     const response = await Api.send({
-      url: `${configLoader.config.servicesUrls.coriolis}/${Api.projectId}/endpoints/${endpointId}/${callName}${envString}`,
+      url,
       cache,
       cancelId: endpointId,
       quietError,

--- a/src/stores/ProviderStore.ts
+++ b/src/stores/ProviderStore.ts
@@ -236,6 +236,7 @@ class ProviderStore {
     providerName: ProviderTypes;
     optionsType: "source" | "destination";
     useCache?: boolean;
+    forceRefresh?: boolean;
     quietError?: boolean;
     requiresWindowsImage?: boolean;
   }): Promise<Field[]> {
@@ -243,6 +244,7 @@ class ProviderStore {
       providerName,
       optionsType,
       useCache,
+      forceRefresh,
       quietError,
       requiresWindowsImage,
     } = options;
@@ -272,6 +274,7 @@ class ProviderStore {
         providerName,
         optionsType,
         useCache,
+        forceRefresh,
         quietError,
         requiresWindowsImage,
       });
@@ -330,6 +333,7 @@ class ProviderStore {
     requiresWindowsImage?: boolean;
     envData?: { [prop: string]: any } | null;
     useCache?: boolean;
+    forceRefresh?: boolean;
     quietError?: boolean;
     allowMultiple?: boolean;
   }): Promise<OptionValues[]> {
@@ -339,6 +343,7 @@ class ProviderStore {
       endpointId,
       envData,
       useCache,
+      forceRefresh,
       quietError,
       allowMultiple,
       requiresWindowsImage,
@@ -386,6 +391,7 @@ class ProviderStore {
         endpointId,
         envData,
         cache: useCache,
+        forceRefresh,
         quietError,
       });
       this.getOptionsValuesSuccess({

--- a/src/utils/LabelDictionary.ts
+++ b/src/utils/LabelDictionary.ts
@@ -178,16 +178,22 @@ class LabelDictionary {
   }
 
   static pushToCache(field: Field, dictionaryKey: string) {
-    if (
-      (field.title || field.description) &&
-      !cache.find(i => i.key === dictionaryKey && i.name === field.name)
-    ) {
-      cache.push({
-        label: field.title,
-        description: field.description,
-        name: field.name,
-        key: dictionaryKey,
-      });
+    if (!(field.title || field.description)) {
+      return;
+    }
+    const existingIndex = cache.findIndex(
+      i => i.key === dictionaryKey && i.name === field.name,
+    );
+    const entry = {
+      label: field.title,
+      description: field.description,
+      name: field.name,
+      key: dictionaryKey,
+    };
+    if (existingIndex >= 0) {
+      cache[existingIndex] = entry;
+    } else {
+      cache.push(entry);
     }
   }
 }


### PR DESCRIPTION
- Fix `LabelDictionary` overwriting stale in-memory cached field labels 
- Add `forceRefresh` to schema and options cache to fix `Reload Options` button
