### PR TITLE
Fix `Invalid DateTime` for `UNEXECUTED` tasks

### DIFF
--- a/src/components/modules/TransferModule/MainDetails/MainDetails.tsx
+++ b/src/components/modules/TransferModule/MainDetails/MainDetails.tsx
@@ -167,11 +167,7 @@ class MainDetails extends React.Component<Props, State> {
 
   renderLastExecutionTime() {
     return this.props.item
-      ? this.renderValue(
-          DateUtils.getLocalDate(this.props.item.updated_at).toFormat(
-            "yyyy-LL-dd HH:mm:ss",
-          ),
-        )
+      ? this.renderValue(DateUtils.formatSafeDate(this.props.item.updated_at))
       : "-";
   }
 

--- a/src/components/modules/TransferModule/TaskItem/TaskItem.tsx
+++ b/src/components/modules/TransferModule/TaskItem/TaskItem.tsx
@@ -245,9 +245,8 @@ class TaskItem extends React.Component<Props> {
   }
 
   renderHeader(status: string) {
-    const date = this.props.item.updated_at
-      ? this.props.item.updated_at
-      : this.props.item.created_at;
+    const date =
+      this.props.item.updated_at || this.props.item.created_at || null;
 
     const instance = this.props.instancesDetails.find(
       i => i.id === this.props.item.instance,
@@ -276,9 +275,7 @@ class TaskItem extends React.Component<Props> {
           {this.getLastMessage()}
         </HeaderData>
         <HeaderData width={this.props.columnWidths[3]}>
-          {date
-            ? DateUtils.getLocalDate(date).toFormat("yyyy-LL-dd HH:mm:ss")
-            : "-"}
+          {DateUtils.formatSafeDate(date)}
         </HeaderData>
         <ArrowStyled
           primary
@@ -346,11 +343,7 @@ class TaskItem extends React.Component<Props> {
               }
             >
               <ProgressUpdateDate width={this.props.columnWidths[0]}>
-                <span>
-                  {DateUtils.getLocalDate(update.created_at).toFormat(
-                    "yyyy-LL-dd HH:mm:ss",
-                  )}
-                </span>
+                <span>{DateUtils.formatSafeDate(update.created_at)}</span>
               </ProgressUpdateDate>
               <ProgressUpdateValue>
                 {update.message}

--- a/src/utils/DateUtils.ts
+++ b/src/utils/DateUtils.ts
@@ -55,6 +55,20 @@ class DateUtils {
     }
   }
 
+  static formatSafeDate(
+    value: string | Date | null | undefined,
+    fallback = "—",
+  ): string {
+    if (value == null) {
+      return fallback;
+    }
+    const dt = this.getLocalDate(value);
+    if (!dt.isValid) {
+      return fallback;
+    }
+    return dt.toFormat("yyyy-LL-dd HH:mm:ss");
+  }
+
   static toUnix(date: Date): number {
     return parseInt((date.getTime() / 1000).toFixed(0), 10);
   }


### PR DESCRIPTION
Add `DateUtils.formatSafeDate()` that guards against `null/undefined/invalid` dates and returns "—" as fallback.