### PR TITLE
Fix transfer executions timeline

### DIFF
--- a/cypress/e2e/transfers/transfers-list.cy.ts
+++ b/cypress/e2e/transfers/transfers-list.cy.ts
@@ -147,8 +147,8 @@ describe("Replicas list", () => {
     cy.get("div[class^='ActionDropdown__Wrapper']").click();
     cy.loadFixtures(["transfers/replicas"], (results: any[]) => {
       const transfers = results[0].transfers;
-      cy.intercept(`**/coriolis/**/transfers/${transfers[0].id}*`, {
-        fixture: "transfers/replica-unexecuted",
+      cy.intercept(`**/coriolis/**/transfers/${transfers[0].id}/executions*`, {
+        body: { executions: [] },
       }).as("transfer");
 
       cy.get("div[class^='ActionDropdown__ListItem']")

--- a/src/components/modules/TransferModule/TransferDetailsContent/TransferDetailsContent.tsx
+++ b/src/components/modules/TransferModule/TransferDetailsContent/TransferDetailsContent.tsx
@@ -124,13 +124,15 @@ class TransferDetailsContent extends React.Component<Props, State> {
   };
 
   getLastExecution() {
-    return this.props.item?.executions?.length
-      ? this.props.item.executions[this.props.item.executions.length - 1]
+    return this.props.executions?.length
+      ? this.props.executions[this.props.executions.length - 1]
       : null;
   }
 
   getStatus() {
-    return this.getLastExecution()?.status;
+    return (
+      this.props.item?.last_execution_status || this.getLastExecution()?.status
+    );
   }
 
   isEndpointMissing() {

--- a/src/components/smart/TransferDetailsPage/TransferDetailsPage.tsx
+++ b/src/components/smart/TransferDetailsPage/TransferDetailsPage.tsx
@@ -221,14 +221,17 @@ class TransferDetailsPage extends React.Component<Props, State> {
   }
 
   getLastExecution() {
-    if (this.transfer?.executions?.length) {
-      return this.transfer.executions[this.transfer.executions.length - 1];
+    const executions = transferStore.executionsList;
+    if (executions.length) {
+      return executions[executions.length - 1];
     }
     return null;
   }
 
   getStatus() {
-    return this.getLastExecution()?.status;
+    return (
+      this.transfer?.last_execution_status || this.getLastExecution()?.status
+    );
   }
 
   getTransferItemType(): string {
@@ -978,7 +981,9 @@ class TransferDetailsPage extends React.Component<Props, State> {
         />
         {this.state.showDeleteTransferConfirmation ? (
           <DeleteTransferModal
-            hasDisks={transferStore.testTransferHasDisks(this.transfer)}
+            hasDisks={transferStore.testTransferHasDisks(
+              transferStore.executionsList,
+            )}
             onRequestClose={() => this.handleCloseDeleteTransferConfirmation()}
             onDeleteTransfer={() => {
               this.handleDeleteTransferConfirmation();

--- a/src/sources/TransferSource.ts
+++ b/src/sources/TransferSource.ts
@@ -151,6 +151,8 @@ class TransferSource {
       limit?: number;
       marker?: string | null;
       quietError?: boolean;
+      sortKeys?: string[];
+      sortDirs?: string[];
     },
   ): Promise<Execution[]> {
     const params: string[] = [];
@@ -160,6 +162,12 @@ class TransferSource {
     if (options?.limit !== undefined) {
       params.push(`limit=${options.limit}`);
     }
+    options?.sortKeys?.forEach(key => {
+      params.push(`sort_keys=${encodeURIComponent(key)}`);
+    });
+    options?.sortDirs?.forEach(dir => {
+      params.push(`sort_dirs=${encodeURIComponent(dir)}`);
+    });
     const queryString = params.length > 0 ? `?${params.join("&")}` : "";
     const response = await Api.send({
       url: `${configLoader.config.servicesUrls.coriolis}/${Api.projectId}/transfers/${transferId}/executions${queryString}`,

--- a/src/sources/TransferSource.ts
+++ b/src/sources/TransferSource.ts
@@ -218,12 +218,11 @@ class TransferSource {
     let lastExecutionId = options.executionId;
 
     if (!lastExecutionId) {
-      const transferDetails = await this.getTransferDetails({
-        transferId: options.transferId,
+      const executions = await this.getExecutions(options.transferId, {
+        limit: 1,
       });
-      const lastExecution =
-        transferDetails.executions[transferDetails.executions.length - 1];
-      if (lastExecution.status !== "RUNNING") {
+      const lastExecution = executions[0];
+      if (!lastExecution || lastExecution.status !== "RUNNING") {
         return options.transferId;
       }
       lastExecutionId = lastExecution.id;

--- a/src/stores/TransferStore.ts
+++ b/src/stores/TransferStore.ts
@@ -14,10 +14,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import { observable, action, runInAction } from "mobx";
 
-import TransferSource, {
-  TransferSourceUtils,
-  sortTasks,
-} from "@src/sources/TransferSource";
+import TransferSource from "@src/sources/TransferSource";
 import type {
   UpdateData,
   TransferItem,
@@ -123,9 +120,11 @@ class TransferStore {
     try {
       const raw = await TransferSource.getExecutions(transferId, {
         limit: this.executionsPageSize,
+        sortKeys: ["number"],
+        sortDirs: ["desc"],
       });
       const hasOlderPage = raw.length === this.executionsPageSize;
-      TransferSourceUtils.sortExecutions(raw);
+      raw.reverse();
       runInAction(() => {
         this.executionsList = raw;
         this.executionsHasOlderPage = hasOlderPage;
@@ -162,9 +161,11 @@ class TransferStore {
         limit: this.executionsPageSize,
         marker,
         quietError: true,
+        sortKeys: ["number"],
+        sortDirs: ["desc"],
       });
       const hasOlderPage = raw.length === this.executionsPageSize;
-      TransferSourceUtils.sortExecutions(raw);
+      raw.reverse();
       runInAction(() => {
         this.executionsList = [...raw, ...this.executionsList];
         this.executionsHasOlderPage = hasOlderPage;
@@ -268,48 +269,67 @@ class TransferStore {
         includeTaskInfo,
       });
 
+      const activeStatuses = [
+        "RUNNING",
+        "PENDING",
+        "CANCELLING",
+        "AWAITING_MINION_ALLOCATIONS",
+      ];
+      const newestExecution =
+        this.executionsList[this.executionsList.length - 1];
+      const hasActiveExecution =
+        activeStatuses.includes(transfer.last_execution_status) ||
+        (newestExecution != null &&
+          activeStatuses.includes(newestExecution.status));
+      const shouldRefreshExecutions =
+        this.executionsList.length > 0 && (!polling || hasActiveExecution);
+      let freshExecutions: Execution[] | null = null;
+      if (shouldRefreshExecutions) {
+        try {
+          freshExecutions = await TransferSource.getExecutions(transferId, {
+            limit: this.executionsPageSize,
+            quietError: polling,
+            sortKeys: ["number"],
+            sortDirs: ["desc"],
+          });
+          freshExecutions.reverse();
+        } catch (err) {
+          console.error(err);
+        }
+      }
+
       runInAction(() => {
         this.transferDetails = transfer;
-        let statusChanged = false;
-        const updatedList = this.executionsList.map(e => {
-          const fresh = transfer.executions?.find(te => te.id === e.id);
-          if (fresh && fresh.status !== e.status) {
-            statusChanged = true;
-            return { ...e, status: fresh.status };
-          }
-          return e;
-        });
-        if (statusChanged) {
-          this.executionsList = updatedList;
-        }
 
-        if (this.executionsList.length > 0 && transfer.executions?.length) {
-          const newestNumber = Math.max(
-            ...this.executionsList.map(e => e.number),
-          );
-          const incoming = transfer.executions.filter(
-            e =>
-              e.number > newestNumber &&
-              !this.deletedExecutionIds.has(e.id) &&
-              !this.executionsList.find(l => l.id === e.id),
-          );
-          if (incoming.length > 0) {
-            TransferSourceUtils.sortExecutions(incoming);
-            this.executionsList = [...this.executionsList, ...incoming];
+        if (freshExecutions) {
+          let statusChanged = false;
+          const updatedList = this.executionsList.map(e => {
+            const fresh = freshExecutions!.find(te => te.id === e.id);
+            if (fresh && fresh.status !== e.status) {
+              statusChanged = true;
+              return { ...e, status: fresh.status };
+            }
+            return e;
+          });
+          if (statusChanged) {
+            this.executionsList = updatedList;
+          }
+
+          if (this.executionsList.length > 0) {
+            const newestNumber = Math.max(
+              ...this.executionsList.map(e => e.number),
+            );
+            const incoming = freshExecutions.filter(
+              e =>
+                e.number > newestNumber &&
+                !this.deletedExecutionIds.has(e.id) &&
+                !this.executionsList.find(l => l.id === e.id),
+            );
+            if (incoming.length > 0) {
+              this.executionsList = [...this.executionsList, ...incoming];
+            }
           }
         }
-
-        transfer.executions?.forEach(exec => {
-          const withTasks = exec as ExecutionTasks;
-          if (
-            Array.isArray(withTasks.tasks) &&
-            !this.deletedExecutionIds.has(exec.id) &&
-            !this.executionsTasks.find(et => et.id === exec.id)
-          ) {
-            sortTasks(withTasks.tasks, TransferSourceUtils.sortTaskUpdates);
-            this.executionsTasks = [...this.executionsTasks, withTasks];
-          }
-        });
       });
     } finally {
       runInAction(() => {
@@ -561,8 +581,10 @@ class TransferStore {
           const executions = await TransferSource.getExecutions(transfer.id, {
             limit: this.executionsPageSize,
             quietError: true,
+            sortKeys: ["number"],
+            sortDirs: ["desc"],
           });
-          TransferSourceUtils.sortExecutions(executions);
+          executions.reverse();
           return { transfer, hasDisks: this.testTransferHasDisks(executions) };
         }),
       );

--- a/src/stores/TransferStore.ts
+++ b/src/stores/TransferStore.ts
@@ -130,6 +130,7 @@ class TransferStore {
         this.executionsHasOlderPage = hasOlderPage;
         this.executionsLoading = false;
       });
+      this.prefetchExecutionsTasks(raw);
     } catch (err) {
       runInAction(() => {
         this.executionsLoading = false;
@@ -171,6 +172,7 @@ class TransferStore {
         this.executionsHasOlderPage = hasOlderPage;
         this.executionsPaginationLoading = false;
       });
+      this.prefetchExecutionsTasks(raw);
     } catch (err) {
       runInAction(() => {
         this.executionsHasOlderPage = false;
@@ -365,55 +367,100 @@ class TransferStore {
 
   currentlyLoadingExecution = "";
 
+  private loadingExecutionTaskIds: Set<string> = new Set();
+
   @action async getExecutionTasks(options: {
     transferId: string;
     executionId?: string;
     polling?: boolean;
   }) {
     const { transferId: transferId, executionId, polling } = options;
-
-    if (!polling && this.currentlyLoadingExecution === executionId) {
-      return;
-    }
-    this.currentlyLoadingExecution = polling
+    const targetId = polling
       ? this.currentlyLoadingExecution
       : executionId || "";
-    if (!this.currentlyLoadingExecution) {
-      return;
-    }
-
-    if (
-      !polling &&
-      this.executionsTasks.find(e => e.id === this.currentlyLoadingExecution)
-    ) {
+    if (!targetId) {
       return;
     }
 
     if (!polling) {
+      this.currentlyLoadingExecution = targetId;
+      if (this.executionsTasks.find(e => e.id === targetId)) {
+        this.executionsTasksLoading = false;
+        return;
+      }
+      if (this.loadingExecutionTaskIds.has(targetId)) {
+        this.executionsTasksLoading = true;
+        return;
+      }
+      this.loadingExecutionTaskIds.add(targetId);
       this.executionsTasksLoading = true;
     }
 
     try {
       const executionTasks = await TransferSource.getExecutionTasks({
         transferId: transferId,
-        executionId: this.currentlyLoadingExecution,
+        executionId: targetId,
         polling,
       });
       runInAction(() => {
         this.executionsTasks = [
-          ...this.executionsTasks.filter(
-            e => e.id !== this.currentlyLoadingExecution,
-          ),
+          ...this.executionsTasks.filter(e => e.id !== targetId),
           executionTasks,
         ];
       });
     } catch (err) {
       console.error(err);
     } finally {
-      runInAction(() => {
-        this.executionsTasksLoading = false;
-      });
+      if (!polling) {
+        runInAction(() => {
+          this.loadingExecutionTaskIds.delete(targetId);
+          if (this.currentlyLoadingExecution === targetId) {
+            this.executionsTasksLoading = false;
+          }
+        });
+      }
     }
+  }
+
+  @action async prefetchExecutionsTasks(
+    executions: Execution[],
+  ): Promise<void> {
+    const transferId = this.transferDetails?.id;
+    if (!transferId) {
+      return;
+    }
+    await Promise.all(
+      executions.map(async execution => {
+        if (
+          this.executionsTasks.find(e => e.id === execution.id) ||
+          this.loadingExecutionTaskIds.has(execution.id)
+        ) {
+          return;
+        }
+        this.loadingExecutionTaskIds.add(execution.id);
+        try {
+          const executionTasks = await TransferSource.getExecutionTasks({
+            transferId,
+            executionId: execution.id,
+            polling: true,
+          });
+          runInAction(() => {
+            if (!this.executionsTasks.find(e => e.id === execution.id)) {
+              this.executionsTasks = [...this.executionsTasks, executionTasks];
+            }
+            if (this.currentlyLoadingExecution === execution.id) {
+              this.executionsTasksLoading = false;
+            }
+          });
+        } catch (err) {
+          console.error(err);
+        } finally {
+          runInAction(() => {
+            this.loadingExecutionTaskIds.delete(execution.id);
+          });
+        }
+      }),
+    );
   }
 
   @action async execute(transferId: string, fields?: Field[]): Promise<void> {

--- a/src/stores/TransferStore.ts
+++ b/src/stores/TransferStore.ts
@@ -68,7 +68,7 @@ class TransferStore {
 
   @observable startingExecution = false;
 
-  @observable transfersWithDisks: TransferItemDetails[] = [];
+  @observable transfersWithDisks: TransferItem[] = [];
 
   @observable transfersWithDisksLoading = false;
 
@@ -534,14 +534,14 @@ class TransferStore {
     await TransferSource.update(options);
   }
 
-  testTransferHasDisks(transfer: TransferItemDetails | null) {
-    if (!transfer || !transfer.executions || transfer.executions.length === 0) {
+  testTransferHasDisks(executions: Execution[]) {
+    if (!executions || executions.length === 0) {
       return false;
     }
-    if (!transfer.executions.find(e => e.type === "transfer_execution")) {
+    if (!executions.find(e => e.type === "transfer_execution")) {
       return false;
     }
-    const lastExecution = transfer.executions[transfer.executions.length - 1];
+    const lastExecution = executions[executions.length - 1];
     if (
       lastExecution.type === "transfer_disks_delete" &&
       lastExecution.status === "COMPLETED"
@@ -556,19 +556,21 @@ class TransferStore {
     this.transfersWithDisksLoading = true;
 
     try {
-      const transferDetails = await Promise.all(
-        transfers.map(transfer =>
-          TransferSource.getTransferDetails({
-            transferId: transfer.id,
-            includeTaskInfo: true,
-          }),
-        ),
+      const results = await Promise.all(
+        transfers.map(async transfer => {
+          const executions = await TransferSource.getExecutions(transfer.id, {
+            limit: this.executionsPageSize,
+            quietError: true,
+          });
+          TransferSourceUtils.sortExecutions(executions);
+          return { transfer, hasDisks: this.testTransferHasDisks(executions) };
+        }),
       );
 
       runInAction(() => {
-        this.transfersWithDisks = transferDetails.filter(r =>
-          this.testTransferHasDisks(r),
-        );
+        this.transfersWithDisks = results
+          .filter(r => r.hasDisks)
+          .map(r => r.transfer);
       });
     } finally {
       runInAction(() => {


### PR DESCRIPTION
This PR implement the following:
* Fix empty executions after `get_transfer` optimization:
  * The transfer details endpoint no longer returns the execution history (executions is now an empty list), so the UI can no longer read execution data off the transfer payload.
  
* Refresh execution timeline statuses while active:
  * Timeline statuses used to be merged from the executions embedded in the transfer details response. Since those are no longer returned, refresh the current page from the executions endpoint during polling instead.

* Prefetch timeline tasks and harden concurrent task loading:
  * Execution tasks were previously seeded from the executions embedded in the transfer details payload. That payload no longer carries them, so tasks are now fetched from the dedicated per-execution endpoint instead.